### PR TITLE
fix compare image handle position

### DIFF
--- a/components/generic/CompareImageSlider.stories.js
+++ b/components/generic/CompareImageSlider.stories.js
@@ -1,10 +1,19 @@
 import { storiesOf } from '@storybook/vue';
-
 import CompareImageSlider from './CompareImageSlider.vue';
+
+const i18n = {
+  locale: 'en',
+  messages: {
+    en: {
+      'directions.right': 'foo'
+    }
+  }
+};
 
 storiesOf('Generic', module)
   .add('Compare Image Slider', () => ({
     components: { CompareImageSlider },
+    i18n,
     data() {
       return {
         imageLeft: 'img/landscape.jpg',

--- a/components/generic/CompareImageSlider.stories.js
+++ b/components/generic/CompareImageSlider.stories.js
@@ -5,7 +5,7 @@ const i18n = {
   locale: 'en',
   messages: {
     en: {
-      'directions.right': 'foo'
+      directions: { right: 'foo', left: 'foo' }
     }
   }
 };
@@ -16,15 +16,31 @@ storiesOf('Generic', module)
     i18n,
     data() {
       return {
-        imageLeft: 'img/landscape.jpg',
-        imageRight: 'img/landscape-monochrome.jpg'
+        leftImageSrc: 'img/landscape.jpg',
+        rightImageSrc: 'img/landscape-monochrome.jpg',
+        leftImageAttribute: {
+          name: 'Name',
+          creator: 'Creator',
+          provider: 'Provider',
+          rightsStatement: 'Rights statement',
+          url: 'Url path'
+        },
+        rightImageAttribute: {
+          name: 'Name',
+          creator: 'Creator',
+          provider: 'Provider',
+          rightsStatement: 'Rights statement',
+          url: 'Url path'
+        }
       };
     },
     template: `
       <b-container class="mt-3">
         <CompareImageSlider
-          :image-left="imageLeft"
-          :image-right="imageRight"
+          :left-image-src="leftImageSrc"
+          :right-image-src="rightImageSrc"
+          :left-image-attribution="leftImageAttribute"
+          :right-image-attribution="rightImageAttribute"
         />
       </b-container>`
   }));

--- a/components/generic/CompareImageSlider.vue
+++ b/components/generic/CompareImageSlider.vue
@@ -118,8 +118,8 @@
     },
 
     mounted() {
-      this.setImageWidth();
-      this.setSliderWidth();
+      // this.setImageWidth();
+      // this.setSliderWidth();
 
       window.addEventListener('resize', this.setImageWidth);
       window.addEventListener('mousemove', this.drag);

--- a/components/generic/CompareImageSlider.vue
+++ b/components/generic/CompareImageSlider.vue
@@ -1,21 +1,38 @@
 <template>
   <figure
     ref="container"
-    class="compare-image"
     data-qa="compare image"
   >
-    <img
-      ref="leftImage"
-      :src="leftImageSrc"
-      :style="leftImageClip"
-      data-qa="compare image left image"
-    >
-    <img
-      ref="rightImage"
-      :src="rightImageSrc"
-      data-qa="compare image right image"
-    >
+    <div class="compare-image">
+      <img
+        ref="leftImage"
+        :src="leftImageSrc"
+        :style="leftImageClip"
+        data-qa="compare image left image"
+      >
+      <img
+        ref="rightImage"
+        :src="rightImageSrc"
+        data-qa="compare image right image"
+      >
 
+      <div
+        ref="slider"
+        class="slider"
+        :style="sliderBarPosition"
+        data-qa="compare image slider"
+        @mousedown="initDrag"
+      >
+        <span class="slider-bar" />
+        <button
+          :class="{ 'is-active' : dragging }"
+          class="slider-handle"
+          data-qa="compare image slider handler"
+        >
+          <span class="sr-only">Slider Handle</span>
+        </button>
+      </div>
+    </div>
     <figcaption>
       <label data-qa="compare image left attribution">
         {{ $t('directions.left') }}
@@ -39,23 +56,6 @@
         />
       </label>
     </figcaption>
-
-    <div
-      ref="slider"
-      class="slider"
-      :style="sliderBarPosition"
-      data-qa="compare image slider"
-      @mousedown="initDrag"
-    >
-      <span class="slider-bar" />
-      <button
-        :class="{ 'is-active' : dragging }"
-        class="slider-handle"
-        data-qa="compare image slider handler"
-      >
-        <span class="sr-only">Slider Handle</span>
-      </button>
-    </div>
   </figure>
 </template>
 
@@ -118,8 +118,8 @@
     },
 
     mounted() {
-      // this.setImageWidth();
-      // this.setSliderWidth();
+      this.setImageWidth();
+      this.setSliderWidth();
 
       window.addEventListener('resize', this.setImageWidth);
       window.addEventListener('mousemove', this.drag);

--- a/components/generic/CompareImageSlider.vue
+++ b/components/generic/CompareImageSlider.vue
@@ -1,9 +1,9 @@
 <template>
-  <figure
-    ref="container"
-    data-qa="compare image"
-  >
-    <div class="compare-image">
+  <figure ref="container">
+    <div
+      class="compare-image"
+      data-qa="compare image"
+    >
       <img
         ref="leftImage"
         :src="leftImageSrc"


### PR DESCRIPTION
- Created a wrapper which wraps around images and slider, while moving the figcaption element to the bottom of the component. This allows the handle to adjust accordingly when resizing the browser.

- Also fixed broken StoryBook issues