### PR TITLE
Unversion chromium on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 dist: xenial
 language: node_js
-env:
-  - CHROMIUM_VERSION="78.0.3904.97-0ubuntu0.16.04.1"
 before_install:
   - sudo apt-get remove --purge -yq google-chrome-stable
-  - sudo apt-get install -yq chromium-browser=${CHROMIUM_VERSION}
+  - sudo apt-get install -yq chromium-browser
 before_script:
   - env > .env
 script:


### PR DESCRIPTION
Let Ubuntu install the latest version it has available. Judging by the recent release timeline, by the time a new major version is released, the NPM package for chromedriver will have had an update too.