### PR TITLE
Favour Contentful entity page title & description

### DIFF
--- a/components/entity/EntityDetails.vue
+++ b/components/entity/EntityDetails.vue
@@ -72,10 +72,7 @@
     },
     computed: {
       truncatedDescription() {
-        if (!this.description) {
-          return;
-        }
-        return this.description.length > this.limitCharacters ? this.description.slice(0, this.limitCharacters) + '...' : this.description;
+        return this.$options.filters.truncate(this.description, 255, this.$t('formatting.ellipsis'));
       }
     },
     methods: {

--- a/pages/entity/_type/_.vue
+++ b/pages/entity/_type/_.vue
@@ -101,7 +101,15 @@
         return (!this.entity || !this.entity.depiction) ? null : entities.getWikimediaThumbnailUrl(this.entity.depiction.id);
       },
       description() {
-        return entities.getEntityDescription(this.entity);
+        return this.pageDescription ? this.pageDescription : entities.getEntityDescription(this.entity);
+      },
+      // Description from the Contentful entry
+      pageDescription() {
+        return this.page ? this.page.description : null;
+      },
+      // Title from the Contentful entry
+      pageTitle() {
+        return this.page ? this.page.name : null;
       },
       perPage() {
         return PER_PAGE;
@@ -116,7 +124,9 @@
         };
       },
       title() {
-        return !this.entity ? this.$t('entity') : this.entity.prefLabel.en;
+        if (!this.entity) return this.$t('entity');
+        if (this.pageTitle) return this.pageTitle;
+        return this.entity.prefLabel.en;
       }
     },
     asyncData({ env, query, params, res, redirect, app, store }) {
@@ -212,7 +222,13 @@
     },
     head() {
       return {
-        title: this.title
+        title: this.title,
+        meta: [
+          { hid: 'title', name: 'title', content: this.title },
+          { hid: 'description', name: 'description', content: this.description },
+          { hid: 'og:title', property: 'og:title', content: this.title },
+          { hid: 'og:description', property: 'og:description', content: this.description }
+        ]
       };
     },
     beforeRouteLeave(to, from, next) {

--- a/pages/entity/_type/_.vue
+++ b/pages/entity/_type/_.vue
@@ -68,7 +68,7 @@
   import AlertMessage from '../../../components/generic/AlertMessage';
   import BrowseChip from '../../../components/browse/BrowseChip';
   import BrowseSections from '../../../components/browse/BrowseSections';
-  import EntityDetails from '../../../components/browse/EntityDetails';
+  import EntityDetails from '../../../components/entity/EntityDetails';
   import SearchInterface from '../../../components/search/SearchInterface';
 
   import * as entities from '../../../plugins/europeana/entity';

--- a/pages/entity/_type/_.vue
+++ b/pages/entity/_type/_.vue
@@ -165,7 +165,8 @@
         })
       ])
         .then(axios.spread((entity, related, entries) => {
-          const desiredPath = entities.getEntitySlug(entity.entity);
+          const entityPage = entries.total > 0 ? entries.items[0].fields : null;
+          const desiredPath = entities.getEntitySlug(entity.entity, entityPage);
 
           if (params.pathMatch !== desiredPath) {
             const redirectPath = app.localePath({
@@ -175,8 +176,6 @@
             store.commit('entity/setId', null);
             return redirect(302, redirectPath);
           }
-
-          const entityPage = entries.total > 0 ? entries.items[0].fields : null;
 
           store.commit('search/setPill', entity.entity.prefLabel[store.state.i18n.locale]);
 

--- a/pages/entity/_type/_.vue
+++ b/pages/entity/_type/_.vue
@@ -133,7 +133,6 @@
     },
 
     asyncData({ env, query, params, res, redirect, app, store }) {
-      console.log('asyncData');
       const currentPage = pageFromQuery(query.page);
       const entityUri = entities.getEntityUri(params.type, params.pathMatch);
 
@@ -205,7 +204,6 @@
     },
 
     async fetch({ store, query, res }) {
-      console.log('fetch');
       store.commit('search/setActive', true);
 
       const entityUri = store.state.entity.id;
@@ -234,7 +232,6 @@
     },
 
     mounted() {
-      console.log('mounted');
       this.$store.commit('search/setPill', this.title);
     },
 

--- a/plugins/europeana/entity.js
+++ b/plugins/europeana/entity.js
@@ -163,13 +163,39 @@ function normalizeEntityId(id) {
 
 /**
  * Retrieves the path for the entity, based on id and title
+ *
+ * If `entityPage.name` is present, that will be used in the slug. Otherwise
+ * `prefLabel.en` if present.
+ *
  * @param {Object} entity an entity object as retrieved from the entity API
  * @param {string} title the title of the entity
+ * @param {Object} entityPage Contentful entry for the entity page
  * @return {string} path
+ * @example Slug based on `entityPage.name`
+ *    const slug = getEntitySlug({
+ *      id: 'http://data.europeana.eu/concept/base/48',
+ *      prefLabel: { en: 'Photograph' }
+ *    }, {
+ *      name: 'Photography'
+ *    });
+ *    console.log(slug); // expected output: '48-photography'
+ * @example Slug based on `entity.prefLabel.en`
+ *    const slug = getEntitySlug({
+ *      id: 'http://data.europeana.eu/agent/base/59832',
+ *      prefLabel: { en: 'Vincent van Gogh' }
+ *    });
+ *    console.log(slug); // expected output: '59832-vincent-van-gogh'
  */
-export function getEntitySlug(entity) {
+export function getEntitySlug(entity, entityPage) {
+  let name;
+  if (entityPage && entityPage.name) {
+    // FIXME: this needs to always be the English version
+    name = entityPage.name;
+  } else if (entity.prefLabel.en) {
+    name = entity.prefLabel.en;
+  }
   const entityId = entity.id.toString().split('/').pop();
-  const path = entityId + (entity.prefLabel.en ? '-' + entity.prefLabel.en.toLowerCase().replace(/ /g, '-') : '');
+  const path = entityId + (name ? '-' + name.toLowerCase().replace(/ /g, '-') : '');
   return path;
 }
 

--- a/plugins/europeana/entity.js
+++ b/plugins/europeana/entity.js
@@ -169,7 +169,7 @@ function normalizeEntityId(id) {
  *
  * @param {Object} entity an entity object as retrieved from the entity API
  * @param {string} title the title of the entity
- * @param {Object} entityPage Contentful entry for the entity page
+ * @param {Object} entityPage Contentful entry for the entity page, with all locales
  * @return {string} path
  * @example Slug based on `entityPage.name`
  *    const slug = getEntitySlug({
@@ -187,7 +187,7 @@ function normalizeEntityId(id) {
  *    console.log(slug); // expected output: '59832-vincent-van-gogh'
  */
 export function getEntitySlug(entity, entityPage) {
-  const name = (entityPage && entityPage.name) ? entityPage.name : entity.prefLabel.en;
+  const name = (entityPage && entityPage.name) ? entityPage.name['en-GB'] : entity.prefLabel.en;
   const entityId = entity.id.toString().split('/').pop();
   const path = entityId + (name ? '-' + name.toLowerCase().replace(/ /g, '-') : '');
   return path;

--- a/plugins/europeana/entity.js
+++ b/plugins/europeana/entity.js
@@ -300,6 +300,7 @@ function getRelatedEntityTitleLink(entities) {
  * TODO: l10n
  */
 export function getEntityDescription(entity) {
+  if (!entity) return null;
   let description;
   if (entity.type === 'Concept' && entity.note) {
     description = entity.note.en ? entity.note.en[0] : '';

--- a/plugins/europeana/entity.js
+++ b/plugins/europeana/entity.js
@@ -187,13 +187,7 @@ function normalizeEntityId(id) {
  *    console.log(slug); // expected output: '59832-vincent-van-gogh'
  */
 export function getEntitySlug(entity, entityPage) {
-  let name;
-  if (entityPage && entityPage.name) {
-    // FIXME: this needs to always be the English version
-    name = entityPage.name;
-  } else if (entity.prefLabel.en) {
-    name = entity.prefLabel.en;
-  }
+  const name = (entityPage && entityPage.name) ? entityPage.name : entity.prefLabel.en;
   const entityId = entity.id.toString().split('/').pop();
   const path = entityId + (name ? '-' + name.toLowerCase().replace(/ /g, '-') : '');
   return path;
@@ -277,7 +271,7 @@ export function searchEntities(entityUris, params) {
 }
 
 /**
- * Format the the entity data
+ * Format the the entity data for a related entity
  * @param {Object} entities the data returned from the Entity API
  * @return {Object} entity links and titles
  */
@@ -303,6 +297,7 @@ function getRelatedEntityTitleLink(entities) {
  * If type is person, use biographicalInformation
  * @param {Object} entity data
  * @return {String} description when available in English
+ * TODO: l10n
  */
 export function getEntityDescription(entity) {
   let description;

--- a/plugins/europeana/utils.js
+++ b/plugins/europeana/utils.js
@@ -13,6 +13,30 @@ export function apiError(error) {
 }
 
 const locales = require('../i18n/locales.js');
+const undefinedLocaleCodes = ['def', 'und'];
+
+const isoAlpha3Map = locales.reduce((memo, locale) => {
+  memo[locale.isoAlpha3] = locale.code;
+  return memo;
+}, {});
+
+const languageKeyMap = locales.reduce((memo, locale) => {
+  memo[locale.code] = [locale.code, locale.isoAlpha3, locale.iso];
+  return memo;
+}, {});
+
+const languageKeysWithFallbacks = locales.reduce((memo, locale) => {
+  memo[locale.code] = languageKeyMap[locale.code] || [];
+
+  if (locale.code !== 'en') {
+    // Add English locale keys as fallbacks for other languages
+    memo[locale.code] = memo[locale.code].concat(languageKeyMap.en);
+  }
+
+  memo[locale.code] = memo[locale.code].concat(undefinedLocaleCodes); // Also fallback to "undefined" language literals
+
+  return memo;
+}, {});
 
 function isEntity(value) {
   return !!value && !!value.about;
@@ -34,20 +58,9 @@ function entityValue(value, locale) {
   return { code: '', values: [value.about], about: value.about };
 }
 
-const isoAlpha3Map = locales.reduce((memo, locale) => {
-  memo[locale.isoAlpha3] = locale.code;
-  return memo;
-}, {});
-
-const languageKeyMap = locales.reduce((memo, locale) => {
-  if (locale.code === 'en') return memo;
-  memo[locale.code] = [locale.code, locale.isoAlpha3];
-  return memo;
-}, {});
-
-function languageKeys(currentLocale) {
-  const languageKeys = languageKeyMap[currentLocale] || [];
-  return languageKeys.concat(['en', 'eng', 'def', 'und']); // predefined set of preferred/fallback languages
+function languageKeys(locale) {
+  const localeFallbackKeys = undefinedLocaleCodes.concat(languageKeyMap.en);
+  return languageKeysWithFallbacks[locale] || localeFallbackKeys;
 }
 
 /**
@@ -76,7 +89,7 @@ function setLangMapValuesAndCode(returnValue, langMap, key, locale) {
   if (langMap[key]) {
     setLangMapValues(returnValue, langMap, key, locale);
     setLangCode(returnValue, key, locale);
-    if (['def', 'und'].includes(key)) filterEntities(returnValue);
+    if (undefinedLocaleCodes.includes(key)) filterEntities(returnValue);
   }
 }
 
@@ -90,7 +103,7 @@ function setLangMapValues(returnValues, langMap, key) {
 }
 
 function setLangCode(map, key, locale) {
-  if (['def', 'und'].includes(key)) {
+  if (undefinedLocaleCodes.includes(key)) {
     map['code'] = '';
   } else {
     const langCode = normalizedLangCode(key);

--- a/store/entity.js
+++ b/store/entity.js
@@ -2,13 +2,25 @@ import createClient from '../plugins/contentful';
 const contentfulClient = createClient();
 
 export const state = () => ({
+  entity: null,
   id: null,
+  page: null,
+  relatedEntities: null,
   themes: {}
 });
 
 export const mutations = {
+  setEntity(state, value) {
+    state.entity = value;
+  },
   setId(state, value) {
     state.id = value;
+  },
+  setPage(state, value) {
+    state.page = value;
+  },
+  setRelatedEntities(state, value) {
+    state.relatedEntities = value;
   },
   setThemes(state, value) {
     state.themes = value;

--- a/tests/unit/components/entity/EntityDetails.spec.js
+++ b/tests/unit/components/entity/EntityDetails.spec.js
@@ -1,7 +1,7 @@
 import { createLocalVue, mount } from '@vue/test-utils';
 import BootstrapVue from 'bootstrap-vue';
 
-import EntityDetails from '../../../../components/browse/EntityDetails.vue';
+import EntityDetails from '../../../../components/entity/EntityDetails.vue';
 
 const localVue = createLocalVue();
 localVue.use(BootstrapVue);
@@ -79,5 +79,3 @@ describe('components/browse/EntityDetails', () => {
     wrapper.findAll('a[data-qa="entity show link"]').length.should.eq(1);
   });
 });
-
-

--- a/tests/unit/plugins/europeana/entity.spec.js
+++ b/tests/unit/plugins/europeana/entity.spec.js
@@ -290,7 +290,9 @@ describe('plugins/europeana/entity', () => {
 
     context('with an entity page', () => {
       const entityPage = {
-        name: 'Architectural Engineering'
+        name: {
+          'en-GB': 'Architectural Engineering'
+        }
       };
 
       it('constructs URL slug from numeric ID and entityPage.name', () => {

--- a/tests/unit/plugins/europeana/entity.spec.js
+++ b/tests/unit/plugins/europeana/entity.spec.js
@@ -286,9 +286,23 @@ describe('plugins/europeana/entity', () => {
   });
 
   describe('getEntitySlug', () => {
-    context('with an entity', () => {
-      let entity = entitiesResponse.items[0];
-      it('returns an agent URI, without any human readable labels', () => {
+    const entity = entitiesResponse.items[0];
+
+    context('with an entity page', () => {
+      const entityPage = {
+        name: 'Architectural Engineering'
+      };
+
+      it('constructs URL slug from numeric ID and entityPage.name', () => {
+        const slug = entities.getEntitySlug(entity, entityPage);
+        return slug.should.eq('147831-architectural-engineering');
+      });
+    });
+
+    context('without an entity page', () => {
+      const entity = entitiesResponse.items[0];
+
+      it('constructs URL slug from numeric ID and prefLabel.en', () => {
         const slug = entities.getEntitySlug(entity);
         return slug.should.eq('147831-architecture');
       });
@@ -297,7 +311,8 @@ describe('plugins/europeana/entity', () => {
 
   describe('getEntityDescription', () => {
     context('with an entity', () => {
-      let entity = entitiesResponse.items[0];
+      const entity = entitiesResponse.items[0];
+
       it('returns a description', () => {
         const description = entities.getEntityDescription(entity);
         return description.should.contain('Architecture');


### PR DESCRIPTION
On entity pages:
* Favour the title and description from Contentful
* If absent, use the values from the Entity API
* URL slugs also use the title from Contentful, but always in English
  * This necessitates making an additional request to the Contentful Delivery API to get the English title, if the user is using a different language. Contentful does not offer a way to request multiple locales, it's either just one or all.