### PR TITLE
Localise search results

### DIFF
--- a/components/generic/ContentCard.vue
+++ b/components/generic/ContentCard.vue
@@ -18,18 +18,10 @@
         class="card-img"
       />
       <b-card-body>
-        <b-card-title>
-          <template
-            v-if="typeof displayTitle === 'string'"
-          >
-            {{ displayTitle | truncate(90, $t('formatting.ellipsis')) }}
-          </template>
-          <span
-            v-else
-            :lang="displayTitle.code"
-          >
-            {{ displayTitle.values[0] | truncate(90, $t('formatting.ellipsis')) }}
-          </span>
+        <b-card-title
+          :lang="displayTitle.code"
+        >
+          {{ displayTitle.values[0] | truncate(90, $t('formatting.ellipsis')) }}
         </b-card-title>
         <time
           v-if="datetime"
@@ -117,7 +109,7 @@
 
       displayTitle() {
         if (typeof this.title === 'string') {
-          return this.title;
+          return { values: [this.title], code: null };
         } else {
           return langMapValueForLocale(this.title, this.$i18n.locale);
         }

--- a/components/generic/ContentCard.vue
+++ b/components/generic/ContentCard.vue
@@ -116,7 +116,7 @@
       },
 
       displayTexts() {
-        return this.texts.map((value) => {
+        return this.texts.filter(Boolean).map((value) => {
           if (typeof value === 'string') {
             return { values: [value], code: null };
           } else if (Array.isArray(value)) {

--- a/components/record/MetadataField.vue
+++ b/components/record/MetadataField.vue
@@ -89,10 +89,14 @@
           if (withoutUris.length > 0) display.values = withoutUris;
         }
 
-        if (display.values.length > this.limit) {
+        if (this.limitDisplayValues && (display.values.length > this.limit)) {
           display.values = display.values.slice(0, this.limit).concat(this.$t('formatting.ellipsis'));
         }
         return display;
+      },
+
+      limitDisplayValues() {
+        return (this.limit > -1);
       },
 
       langMappedValues() {

--- a/components/record/MetadataField.vue
+++ b/components/record/MetadataField.vue
@@ -84,11 +84,6 @@
       displayValues() {
         const display = Object.assign({}, this.langMappedValues);
 
-        if (this.omitUrisIfOtherValues) {
-          const withoutUris = display.values.filter((value) => !/^https?:\/\//.test(value));
-          if (withoutUris.length > 0) display.values = withoutUris;
-        }
-
         if (this.limitDisplayValues && (display.values.length > this.limit)) {
           display.values = display.values.slice(0, this.limit).concat(this.$t('formatting.ellipsis'));
         }
@@ -108,7 +103,7 @@
           return { values: this.fieldData, code: '' };
         }
 
-        return langMapValueForLocale(this.fieldData, this.$i18n.locale);
+        return langMapValueForLocale(this.fieldData, this.$i18n.locale, { omitUrisIfOtherValues: this.omitUrisIfOtherValues });
       },
 
       hasValuesForLocale() {

--- a/components/record/SimilarItems.stories.js
+++ b/components/record/SimilarItems.stories.js
@@ -26,24 +26,24 @@ storiesOf('Record', module)
       return {
         items: [
           {
-            identifier: '/123/abc',
-            thumbnail: 'img/landscape.jpg',
-            title: 'Woman Reading a letter'
+            europeanaId: '/123/abc',
+            edmPreview: 'img/landscape.jpg',
+            dcTitle: 'Woman Reading a letter'
           },
           {
-            identifier: '/123/abc',
-            thumbnail: 'img/portrait.jpg',
-            title: 'View of house in Delt'
+            europeanaId: '/123/abc',
+            edmPreview: 'img/portrait.jpg',
+            dcTitle: 'View of house in Delft'
           },
           {
-            identifier: '/123/abc',
-            thumbnail: 'img/landscape.jpg',
-            title: 'The Love Letter'
+            europeanaId: '/123/abc',
+            edmPreview: 'img/landscape.jpg',
+            dcTitle: 'The Love Letter'
           },
           {
-            identifier: '/123/abc',
-            thumbnail: 'img/portrait.jpg',
-            title: 'Dienstbode met een takshond in de'
+            europeanaId: '/123/abc',
+            edmPreview: 'img/portrait.jpg',
+            dcTitle: 'Dienstbode met een takshond in de'
           }
         ]
       };

--- a/components/record/SimilarItems.vue
+++ b/components/record/SimilarItems.vue
@@ -10,7 +10,7 @@
       <ContentCard
         v-for="(item, index) in items"
         :key="index"
-        :title="item.fields.dcTitle[0]"
+        :title="item.dcTitle"
         :image-url="item.edmPreview"
         :url="{ name: 'record-all', params: { pathMatch: item.europeanaId.slice(1) } }"
       />

--- a/components/search/SearchResult.vue
+++ b/components/search/SearchResult.vue
@@ -1,44 +1,33 @@
 <template>
   <b-media
-    v-if="result"
     no-body
     class="flex-column-reverse flex-md-row"
   >
     <b-media-body class="m-4">
       <div
-        v-for="(value, key) in result.fields"
-        :key="key"
-        :data-field-name="key"
-        data-qa="result field"
+        v-if="localisedHeading"
+        :lang="localisedHeading.code"
       >
-        <template v-if="Array.isArray(value) && value.length === 1">
-          <template v-if="key === 'dcTitle'">
-            {{ value[0] | truncate(90, $t('formatting.ellipsis')) }}
-          </template>
-          <template v-else>
-            {{ value[0] }}
-          </template>
-        </template>
-        <ul v-else-if="Array.isArray(value)">
-          <li
-            v-for="(element, index) in displayableValues(value)"
-            :key="index"
-          >
-            {{ element }}
-          </li>
-          <li
-            v-if="trimmedValueArray(value)"
-          >
-            {{ $t('formatting.ellipsis') }}
-          </li>
-        </ul>
+        <!-- TODO: this is _list_ view... do we need to truncate? -->
+        {{ localisedHeading.values[0] | truncate(90, $t('formatting.ellipsis')) }}
       </div>
+      <div
+        lang=""
+      >
+        {{ edmDataProvider[0] }}
+      </div>
+      <MetadataField
+        name="dcCreator"
+        :field-data="dcCreator"
+        :limit="LIMIT_CREATORS"
+        :labelled="false"
+        :omit-uris-if-other-values="true"
+      />
     </b-media-body>
     <b-media-aside class="media-image">
       <b-img
-        v-if="result.edmPreview"
         slot="aside"
-        :src="result.edmPreview"
+        :src="edmPreview"
         alt=""
         class="mw-100 w-100"
         data-field-name="edmPreview"
@@ -49,13 +38,72 @@
 </template>
 
 <script>
+  import MetadataField from '../record/MetadataField';
+  import { langMapValueForLocale } from  '../../plugins/europeana/utils';
+
   export default {
+    name: 'SearchResult',
+
+    components: {
+      MetadataField
+    },
+
     props: {
-      result: {
+      europeanaId: {
+        type: String,
+        required: true
+      },
+
+      edmPreview: {
+        type: String,
+        required: true
+      },
+
+      // only ever a single value, but in an array for some reason
+      edmDataProvider: {
+        type: Array,
+        required: true
+      },
+
+      // lang map
+      dcTitle: {
+        type: Object,
+        default: () => {}
+      },
+
+      // lang map
+      dcDescription: {
+        type: Object,
+        default: () => {}
+      },
+
+      // lang map
+      dcCreator: {
         type: Object,
         default: () => {}
       }
     },
+
+    data() {
+      return {
+        LIMIT_CREATORS: 3
+      };
+    },
+
+    computed: {
+      localisedTitle() {
+        return this.dcTitle ? langMapValueForLocale(this.dcTitle, this.$i18n.locale) : null;
+      },
+
+      localisedDescription() {
+        return this.dcDescription ? langMapValueForLocale(this.dcDescription, this.$i18n.locale) : null;
+      },
+
+      localisedHeading() {
+        return this.localisedTitle || this.localisedDescription;
+      }
+    },
+
     methods: {
       displayableValues(values) {
         if (Array.isArray(values)) {
@@ -63,6 +111,7 @@
         }
         return values;
       },
+
       trimmedValueArray(values) {
         if (Array.isArray(values)) {
           return values.length > 3;

--- a/components/search/SearchResult.vue
+++ b/components/search/SearchResult.vue
@@ -99,22 +99,6 @@
       localisedHeading() {
         return this.localisedTitle || this.localisedDescription;
       }
-    },
-
-    methods: {
-      displayableValues(values) {
-        if (Array.isArray(values)) {
-          return values.slice(0, 3);
-        }
-        return values;
-      },
-
-      trimmedValueArray(values) {
-        if (Array.isArray(values)) {
-          return values.length > 3;
-        }
-        return false;
-      }
     }
   };
 </script>

--- a/components/search/SearchResult.vue
+++ b/components/search/SearchResult.vue
@@ -7,7 +7,7 @@
       <div
         v-if="localisedHeading"
         :lang="localisedHeading.code"
-        :data-field-name="localisedTitle ? 'dcTitle' : 'dcDescription'"
+        :data-field-name="localisedHeadingFieldName"
       >
         <!-- TODO: this is _list_ view... do we need to truncate? -->
         {{ localisedHeading.values[0] | truncate(90, $t('formatting.ellipsis')) }}
@@ -88,16 +88,12 @@
     },
 
     computed: {
-      localisedTitle() {
-        return this.dcTitle ? langMapValueForLocale(this.dcTitle, this.$i18n.locale) : null;
-      },
-
-      localisedDescription() {
-        return this.dcDescription ? langMapValueForLocale(this.dcDescription, this.$i18n.locale) : null;
+      localisedHeadingFieldName() {
+        return this.dcTitle ? 'dcTitle' : (this.dcDescription ? 'dcDescription' : null);
       },
 
       localisedHeading() {
-        return this.localisedTitle || this.localisedDescription;
+        return langMapValueForLocale(this.dcTitle || this.dcDescription, this.$i18n.locale, { omitUrisIfOtherValues: true });
       }
     }
   };

--- a/components/search/SearchResult.vue
+++ b/components/search/SearchResult.vue
@@ -7,12 +7,14 @@
       <div
         v-if="localisedHeading"
         :lang="localisedHeading.code"
+        :data-field-name="localisedTitle ? 'dcTitle' : 'dcDescription'"
       >
         <!-- TODO: this is _list_ view... do we need to truncate? -->
         {{ localisedHeading.values[0] | truncate(90, $t('formatting.ellipsis')) }}
       </div>
       <div
         lang=""
+        data-field-name="edmDataProvider"
       >
         {{ edmDataProvider[0] }}
       </div>

--- a/components/search/SearchResult.vue
+++ b/components/search/SearchResult.vue
@@ -93,7 +93,7 @@
       },
 
       localisedHeading() {
-        return langMapValueForLocale(this.dcTitle || this.dcDescription, this.$i18n.locale, { omitUrisIfOtherValues: true });
+        return langMapValueForLocale(this.dcTitle || this.dcDescription || {}, this.$i18n.locale, { omitUrisIfOtherValues: true });
       }
     }
   };

--- a/components/search/SearchResult.vue
+++ b/components/search/SearchResult.vue
@@ -51,11 +51,6 @@
     },
 
     props: {
-      europeanaId: {
-        type: String,
-        required: true
-      },
-
       edmPreview: {
         type: String,
         required: true

--- a/components/search/SearchResults.vue
+++ b/components/search/SearchResults.vue
@@ -41,7 +41,7 @@
 <script>
   import ContentCard from '../generic/ContentCard';
   import SearchResult from './SearchResult';
-  
+
   export default {
     name: 'SearchResults',
 

--- a/components/search/SearchResults.vue
+++ b/components/search/SearchResults.vue
@@ -12,7 +12,6 @@
     >
       <SearchResult
         :edm-preview="result.edmPreview"
-        :europeana-id="result.europeanaId"
         :edm-data-provider="result.edmDataProvider"
         :dc-title="result.dcTitle"
         :dc-description="result.dcDescription"

--- a/components/search/SearchResults.vue
+++ b/components/search/SearchResults.vue
@@ -28,7 +28,7 @@
     <ContentCard
       v-for="result in value"
       :key="result.europeanaId"
-      :title="result.fields.dcTitle[0]"
+      :title="result.dcTitle || result.dcDescription"
       :url="{ name: 'record-all', params: { pathMatch: result.europeanaId.slice(1) } }"
       :image-url="result.edmPreview"
       :texts="cardTexts(result)"
@@ -68,25 +68,9 @@
 
     methods: {
       cardTexts(result) {
-        let texts = [];
-        for (const field of ['dcCreator', 'edmDataProvider']) {
-          if (result.fields[field]) {
-            texts.push(this.stringifyField(result.fields[field]));
-          }
-        }
+        let texts = [result.edmDataProvider];
+        if (result.dcCreator) texts.push(result.dcCreator);
         return texts;
-      },
-
-      stringifyField(field) {
-        // TODO: Rather than joining as strings, cards should handle arrays so this method can be skipped.
-        let returnString = field;
-        if (Array.isArray(field)) {
-          returnString = field.slice(0, 3).join(this.$t('formatting.listSeperator') + ' ');
-          if (field.length > 3) {
-            returnString = returnString + this.$t('formatting.listSeperator') + this.$t('formatting.ellipsis');
-          }
-        }
-        return returnString;
       }
     }
   };

--- a/components/search/SearchResults.vue
+++ b/components/search/SearchResults.vue
@@ -4,13 +4,20 @@
     data-qa="search results list"
   >
     <b-list-group-item
-      v-for="result in results"
+      v-for="result in value"
       :key="result.europeanaId"
       :to="localePath({ name: 'record-all', params: { pathMatch: result.europeanaId.slice(1) } })"
       class="flex-column align-items-start mb-3"
       data-qa="search result"
     >
-      <SearchResult :result="result" />
+      <SearchResult
+        :edm-preview="result.edmPreview"
+        :europeana-id="result.europeanaId"
+        :edm-data-provider="result.edmDataProvider"
+        :dc-title="result.dcTitle"
+        :dc-description="result.dcDescription"
+        :dc-creator="result.dcCreator"
+      />
     </b-list-group-item>
   </b-list-group>
   <b-card-group
@@ -20,7 +27,7 @@
     data-qa="search results grid"
   >
     <ContentCard
-      v-for="result in results"
+      v-for="result in value"
       :key="result.europeanaId"
       :title="result.fields.dcTitle[0]"
       :url="{ name: 'record-all', params: { pathMatch: result.europeanaId.slice(1) } }"
@@ -34,12 +41,15 @@
 <script>
   import ContentCard from '../generic/ContentCard';
   import SearchResult from './SearchResult';
-
+  
   export default {
+    name: 'SearchResults',
+
     components: {
       ContentCard,
       SearchResult
     },
+
     props: {
       value: {
         type: Array,
@@ -50,24 +60,13 @@
         default: 4
       }
     },
-    data() {
-      return {
-        results: this.value
-      };
-    },
+
     computed: {
       view() {
         return this.$store.getters['search/activeView'];
       }
     },
-    watch: {
-      value: {
-        immediate: true,
-        handler(val) {
-          this.results = val;
-        }
-      }
-    },
+
     methods: {
       cardTexts(result) {
         let texts = [];
@@ -78,6 +77,7 @@
         }
         return texts;
       },
+
       stringifyField(field) {
         // TODO: Rather than joining as strings, cards should handle arrays so this method can be skipped.
         let returnString = field;

--- a/components/search/SearchResults.vue
+++ b/components/search/SearchResults.vue
@@ -33,6 +33,8 @@
       :image-url="result.edmPreview"
       :texts="cardTexts(result)"
       data-qa="search result"
+      :limit-values-within-each-text="3"
+      :omit-uris-if-other-values="true"
     />
   </b-card-group>
 </template>
@@ -68,8 +70,8 @@
 
     methods: {
       cardTexts(result) {
-        let texts = [result.edmDataProvider];
-        if (result.dcCreator) texts.push(result.dcCreator);
+        const texts = [result.edmDataProvider];
+        if (result.dcCreator) texts.unshift(result.dcCreator);
         return texts;
       }
     }

--- a/plugins/europeana/search.js
+++ b/plugins/europeana/search.js
@@ -39,63 +39,6 @@ function genericThumbnail(edmType) {
 }
 
 /**
- * Extract the value to display for a field
- * @param {Object} field language map field from API response
- * @return {?(Object|String)} value to display
- */
-function display(field) {
-  if (!field) {
-    return null;
-  }
-
-  let value;
-  if (field.eng) {
-    value = field.eng;
-  } else if (field.en) {
-    value = field.en;
-  } else if (field.def) {
-    value = field.def;
-  } else if (Object.keys(field).length === 1) {
-    value = field[Object.keys(field)[0]];
-  } else {
-    return field;
-  }
-
-  value = [...new Set(value)]; // remove duplicates
-  // Remove URIs, but only if other values exist
-  const withoutUris = value.filter((element) => {
-    return !element.startsWith('http://') && !element.startsWith('https://');
-  });
-  if (withoutUris.length > 0) {
-    value = withoutUris;
-  }
-
-  return value;
-}
-
-/**
- * Construct fields to display for one search result
- * @param {Object} item individual item returned by the API
- * @return {Object} fields to display for this item
- */
-function fieldsForSearchResult(item) {
-  let fields = {
-    // TODO: fallback to description when API returns dcDescriptionLangAware
-    dcTitle: display(item.dcTitleLangAware) || [],
-    // TODO: enable when API returns dcDescriptionLangAware
-    // dcDescription: item.dcDescriptionLangAware,
-    edmDataProvider: item.dataProvider
-  };
-
-  const dcCreator = display(item.dcCreatorLangAware);
-  if (dcCreator) {
-    fields.dcCreator = dcCreator;
-  }
-
-  return fields;
-}
-
-/**
  * Extract search results from API response
  * @param  {Object} response API response
  * @return {Object[]} search results
@@ -107,7 +50,10 @@ function resultsFromApiResponse(response) {
     return {
       europeanaId: item.id,
       edmPreview: item.edmPreview ? `${item.edmPreview[0]}&size=w200` : genericThumbnail(item.type),
-      fields: fieldsForSearchResult(item)
+      dcTitle: item.dcTitleLangAware,
+      dcDescription: item.dcDescriptionLangAware,
+      dcCreator: item.dcCreatorLangAware,
+      edmDataProvider: item.dataProvider
     };
   });
 

--- a/plugins/europeana/utils.js
+++ b/plugins/europeana/utils.js
@@ -70,7 +70,7 @@ function languageKeys(locale) {
  * @param {String} locale Current locale as a 2 letter code
  * @return {{Object[]{language: String, values: Object[]}}} Language code and values, values may be strings or language maps themselves.
  */
-export function langMapValueForLocale(langMap, locale) {
+export function langMapValueForLocale(langMap, locale, options = {}) {
   let returnVal = { values: [] };
   for (let key of languageKeys(locale)) { // loop through all language key to find a match
     setLangMapValuesAndCode(returnVal, langMap, key, locale);
@@ -82,7 +82,16 @@ export function langMapValueForLocale(langMap, locale) {
     setLangMapValuesAndCode(returnVal, langMap, Object.keys(langMap)[0], locale);
   }
 
-  return addEntityValues(returnVal, entityValues(langMap['def'], locale));
+  const withEntities = addEntityValues(returnVal, entityValues(langMap['def'], locale));
+  if (!options.omitUrisIfOtherValues) return withEntities;
+
+  return omitUrisIfOtherValues(withEntities);
+}
+
+function omitUrisIfOtherValues(localizedLangmap) {
+  const withoutUris = localizedLangmap.values.filter((value) => !/^https?:\/\//.test(value));
+  if (withoutUris.length > 0) localizedLangmap.values = withoutUris;
+  return localizedLangmap;
 }
 
 function setLangMapValuesAndCode(returnValue, langMap, key, locale) {

--- a/tests/unit/components/generic/ContentCard.spec.js
+++ b/tests/unit/components/generic/ContentCard.spec.js
@@ -18,6 +18,9 @@ const $store = {
 const factory = () => mount(ContentCard, {
   localVue,
   mocks: {
+    $i18n: {
+      locale: 'en'
+    },
     $t: () => {},
     $store
   }

--- a/tests/unit/components/record/MetadataField.spec.js
+++ b/tests/unit/components/record/MetadataField.spec.js
@@ -101,6 +101,28 @@ describe('components/record/MetadataField', () => {
         fieldValues.at(0).text().should.eq(props.fieldData.def[0]);
         fieldValues.at(1).text().should.eq('formatting.ellipsis');
       });
+
+      describe('URIs', () => {
+        it('omits them if there are other values', () => {
+          const props = { name: 'dcCreator', fieldData: { def: ['http://data.europeana.eu/agent/base/123', 'Artist'] }, omitUrisIfOtherValues: true };
+          const wrapper = factory();
+
+          wrapper.setProps(props);
+
+          const fieldValue = wrapper.find('[data-qa="metadata field"] ul [data-qa="literal value"]');
+          fieldValue.text().should.eq(props.fieldData.def[1]);
+        });
+
+        it('includes them if there are no other values', () => {
+          const props = { name: 'dcCreator', fieldData: { def: ['http://data.europeana.eu/agent/base/123'] }, omitUrisIfOtherValues: true };
+          const wrapper = factory();
+
+          wrapper.setProps(props);
+
+          const fieldValue = wrapper.find('[data-qa="metadata field"] ul [data-qa="literal value"]');
+          fieldValue.text().should.eq(props.fieldData.def[0]);
+        });
+      });
     });
 
     context('when value is not available in the preferred languages', () => {

--- a/tests/unit/components/record/MetadataField.spec.js
+++ b/tests/unit/components/record/MetadataField.spec.js
@@ -69,13 +69,38 @@ describe('components/record/MetadataField', () => {
       });
     });
 
-    it('outputs the field value', () => {
-      const wrapper = factory();
+    describe('field values', () => {
+      it('outputs a single value', () => {
+        const props = { name: 'dcCreator', fieldData: { def: ['Artist'] } };
+        const wrapper = factory();
 
-      wrapper.setProps(props);
+        wrapper.setProps(props);
 
-      const fieldValue = wrapper.find('[data-qa="metadata field"] ul [data-qa="literal value"]');
-      fieldValue.text().should.include(props.fieldData.def);
+        const fieldValue = wrapper.find('[data-qa="metadata field"] ul [data-qa="literal value"]');
+        fieldValue.text().should.eq(props.fieldData.def[0]);
+      });
+
+      it('outputs multiple values', () => {
+        const props = { name: 'dcCreator', fieldData: { def: ['Artist1', 'Artist2'] } };
+        const wrapper = factory();
+
+        wrapper.setProps(props);
+
+        const fieldValues = wrapper.findAll('[data-qa="metadata field"] ul [data-qa="literal value"]');
+        fieldValues.at(0).text().should.eq(props.fieldData.def[0]);
+        fieldValues.at(1).text().should.eq(props.fieldData.def[1]);
+      });
+
+      it('optionally limits the number of values output', () => {
+        const props = { name: 'dcCreator', fieldData: { def: ['Artist1', 'Artist2'] }, limit: 1 };
+        const wrapper = factory();
+
+        wrapper.setProps(props);
+
+        const fieldValues = wrapper.findAll('[data-qa="metadata field"] ul [data-qa="literal value"]');
+        fieldValues.at(0).text().should.eq(props.fieldData.def[0]);
+        fieldValues.at(1).text().should.eq('formatting.ellipsis');
+      });
     });
 
     context('when value is not available in the preferred languages', () => {

--- a/tests/unit/components/record/MetadataField.spec.js
+++ b/tests/unit/components/record/MetadataField.spec.js
@@ -51,11 +51,20 @@ describe('components/record/MetadataField', () => {
           context: 'webResource'
         };
         it('outputs the context specific translated label', () => {
-
           wrapper.setProps(props);
 
           const fieldName = wrapper.find('[data-qa="metadata field"] [data-qa="label"]');
           fieldName.text().should.eq('fieldLabels.webResource.edmRights');
+        });
+      });
+
+      context('with labelling disabled', () => {
+        const props = { name: 'dcCreator', fieldData: { def: ['Artist'] }, labelled: false };
+        it('does not output a label', () => {
+          wrapper.setProps(props);
+
+          const label = wrapper.find('[data-qa="metadata field"] [data-qa="label"]');
+          label.exists().should.be.false;
         });
       });
     });

--- a/tests/unit/components/search/SearchInterface.spec.js
+++ b/tests/unit/components/search/SearchInterface.spec.js
@@ -9,6 +9,7 @@ import SearchInterface from '../../../../components/search/SearchInterface.vue';
 const localVue = createLocalVue();
 localVue.filter('localise', (number) => number);
 localVue.filter('truncate', (string) => string);
+localVue.filter('optimisedImageUrl', (string) => string);
 localVue.use(BootstrapVue);
 localVue.use(VueRouter);
 localVue.use(Vuex);
@@ -28,6 +29,9 @@ const router = new VueRouter({
 
 const factory = (options = {}) => {
   const mocks = {
+    $i18n: {
+      locale: 'en'
+    },
     $t: (key) => key,
     $tc: (key) => key,
     $te: () => false,
@@ -135,9 +139,9 @@ describe('components/search/SearchInterface', () => {
               totalResults: 100,
               results: [{
                 europeanaId: '/123/abc',
-                fields: {
-                  dcTitle: ['Title']
-                }
+                dcTitle: { def: ['Record 123/abc'] },
+                edmPreview: 'https://www.example.org/abc.jpg',
+                edmDataProvider: ['Provider 123']
               }]
             }
           });

--- a/tests/unit/components/search/SearchResult.spec.js
+++ b/tests/unit/components/search/SearchResult.spec.js
@@ -5,40 +5,85 @@ import SearchResult from '../../../../components/search/SearchResult.vue';
 const localVue = createLocalVue();
 localVue.use(BootstrapVue);
 
-const factory = () => mount(SearchResult, {
-  localVue
+const factory = (propsData) => mount(SearchResult, {
+  localVue,
+  propsData,
+  mocks: {
+    $i18n: {
+      locale: 'en'
+    },
+    $t: (key) => key
+  }
 });
 
 describe('components/search/SearchResult', () => {
-  describe('result.edmPreview', () => {
-    it('is displayed as an img element', () => {
-      const wrapper = factory();
+  const requiredProps = {
+    edmPreview: 'https://www.example.org/thumbnail.jpg',
+    edmDataProvider: ['Data Provider']
+  };
 
-      wrapper.setProps({ result: { edmPreview: 'https://www.example.org/thumbnail.jpg' } });
-      const image =  wrapper.find('img[data-field-name="edmPreview"]');
+  it('displays edmPreview as an img element', () => {
+    const wrapper = factory(requiredProps);
 
-      image.attributes().src.should.eq('https://www.example.org/thumbnail.jpg');
+    const image =  wrapper.find('img[data-field-name="edmPreview"]');
+
+    image.attributes().src.should.eq(requiredProps.edmPreview);
+  });
+
+  it('displays edmDataProvider', () => {
+    const wrapper = factory(requiredProps);
+
+    const element = wrapper.find('[data-field-name="edmDataProvider"]');
+
+    element.text().should.eq(requiredProps.edmDataProvider[0]);
+  });
+
+  it('displays dcCreator as a list', () => {
+    const props = Object.assign({
+      dcCreator: { def: ['Anna', 'Bob'] }
+    }, requiredProps);
+    const wrapper = factory(props);
+
+    const fields = wrapper.findAll('[data-field-name="dcCreator"] ul li');
+
+    fields.at(0).text().should.eq(props.dcCreator.def[0]);
+    fields.at(1).text().should.eq(props.dcCreator.def[1]);
+  });
+
+  context('when dcTitle is present', () => {
+    const props = Object.assign({
+      dcTitle: { def: ['Title'] },
+      dcDescription: { def: ['Description'] }
+    }, requiredProps);
+
+    it('displays dcTitle', () => {
+      const wrapper = factory(props);
+
+      const title = wrapper.find('[data-field-name="dcTitle"]');
+
+      title.text().should.eq(props.dcTitle.def[0]);
+    });
+
+    it('ignores dcDescription', () => {
+      const wrapper = factory(props);
+
+      const description = wrapper.find('[data-field-name="dcDescription"]');
+
+      description.exists().should.be.false;
     });
   });
 
-  describe('result.fields properties', () => {
-    it('is displayed unadorned if a single value', () => {
-      const wrapper = factory();
+  context('when dcTitle is absent', () => {
+    const props = Object.assign({
+      dcDescription: { def: ['Description'] }
+    }, requiredProps);
 
-      wrapper.setProps({ result: { fields: { dcSpatial: ['Paris'] } } });
+    it('displays dcDescription', () => {
+      const wrapper = factory(props);
 
-      const field =  wrapper.find('[data-field-name="dcSpatial"]');
-      field.text().should.eq('Paris');
-    });
+      const title = wrapper.find('[data-field-name="dcDescription"]');
 
-    it('is displayed as a list if multi-value', () => {
-      const wrapper = factory();
-
-      wrapper.setProps({ result: { fields: { dcSpatial: ['Paris', 'London'] } } });
-
-      const fields = wrapper.findAll('[data-field-name="dcSpatial"] ul li');
-      fields.at(0).text().should.eq('Paris');
-      fields.at(1).text().should.eq('London');
+      title.text().should.eq(props.dcDescription.def[0]);
     });
   });
 });

--- a/tests/unit/components/search/SearchResults.spec.js
+++ b/tests/unit/components/search/SearchResults.spec.js
@@ -24,41 +24,40 @@ const factory = (options = {}) => {
     store,
     mocks: {
       localePath: (opts) => `/record/${opts.params.pathMatch}`,
+      $i18n: {
+        locale: 'en'
+      },
       $t: () => {}
     }
   });
 };
 
+const results = [
+  {
+    europeanaId: '/123/abc',
+    dcTitle: { def: ['Record 123/abc'] },
+    edmPreview: 'https://www.example.org/abc.jpg',
+    edmDataProvider: ['Provider 123']
+  },
+  {
+    europeanaId: '/123/def',
+    dcTitle: { def: ['Record 123/def'] },
+    edmPreview: 'https://www.example.org/def.jpg',
+    edmDataProvider: ['Provider 123']
+  }
+];
+
 describe('components/search/SearchResults', () => {
   context('when view is grid', () => {
     const wrapper = factory({ view: 'grid' });
+
     it('renders each result with a link', () => {
-      const results = [
-        {
-          linkTo: '/record/123/abc',
-          europeanaId: '/123/abc',
-          fields: {
-            dcTitle: [
-              'Record 123/abc'
-            ]
-          }
-        },
-        {
-          linkTo: '/record/123/def',
-          europeanaId: '/123/def',
-          fields: {
-            dcTitle: [
-              'Record 123/def'
-            ]
-          }
-        }
-      ];
-
       wrapper.setProps({ value: results });
-      const renderedResults =  wrapper.findAll('[data-qa="search result"]');
 
-      renderedResults.at(0).html().should.contain(results[0].linkTo);
-      renderedResults.at(1).html().should.contain(results[1].linkTo);
+      const renderedResults =  wrapper.findAll('[data-qa="search result"] a');
+
+      renderedResults.at(0).attributes().href.should.endWith(`/record${results[0].europeanaId}`);
+      renderedResults.at(1).attributes().href.should.endWith(`/record${results[1].europeanaId}`);
     });
   });
 
@@ -66,22 +65,12 @@ describe('components/search/SearchResults', () => {
     const wrapper = factory({ view: 'list' });
 
     it('renders each result with a link', () => {
-      const results = [
-        {
-          linkTo: '/record/123/abc',
-          europeanaId: '/123/abc'
-        },
-        {
-          linkTo: '/record/123/def',
-          europeanaId: '/123/def'
-        }
-      ];
-
       wrapper.setProps({ value: results });
-      const renderedResults =  wrapper.findAll('[data-qa="search result"]');
 
-      renderedResults.at(0).html().should.contain(results[0].linkTo);
-      renderedResults.at(1).html().should.contain(results[1].linkTo);
+      const renderedResults =  wrapper.findAll('a[data-qa="search result"]');
+
+      renderedResults.at(0).attributes().href.should.endWith(`/record${results[0].europeanaId}`);
+      renderedResults.at(1).attributes().href.should.endWith(`/record${results[1].europeanaId}`);
     });
   });
 });

--- a/tests/unit/plugins/europeana/search.spec.js
+++ b/tests/unit/plugins/europeana/search.spec.js
@@ -213,6 +213,9 @@ describe('plugins/europeana/search', () => {
               dcTitleLangAware: {
                 en: ['A painting']
               },
+              dcDescriptionLangAware: {
+                en: ['More information about this painting']
+              },
               dcCreatorLangAware: {
                 en: ['An artist']
               },
@@ -266,24 +269,28 @@ describe('plugins/europeana/search', () => {
             response.results[0].europeanaId.should.eq(apiResponse.items[0].id);
           });
 
-          describe('.fields', () => {
-            it('includes dcTitleLangAware in .dcTitle', async() => {
-              const response = await searchResponse();
+          it('includes dcTitleLangAware in .dcTitle', async() => {
+            const response = await searchResponse();
 
-              response.results[0].fields.dcTitle.should.deep.eq(apiResponse.items[0].dcTitleLangAware['en']);
-            });
+            response.results[0].dcTitle.should.deep.eq(apiResponse.items[0].dcTitleLangAware);
+          });
 
-            it('includes dcCreatorLangAware in .dcCreator', async() => {
-              const response = await searchResponse();
+          it('includes dcDescriptionLangAware in .dcTitle', async() => {
+            const response = await searchResponse();
 
-              response.results[0].fields.dcCreator.should.deep.eq(apiResponse.items[0].dcCreatorLangAware['en']);
-            });
+            response.results[0].dcDescription.should.deep.eq(apiResponse.items[0].dcDescriptionLangAware);
+          });
 
-            it('includes dataProvider in .edmDataProvider', async() => {
-              const response = await searchResponse();
+          it('includes dcCreatorLangAware in .dcCreator', async() => {
+            const response = await searchResponse();
 
-              response.results[0].fields.edmDataProvider.should.deep.eq(apiResponse.items[0].dataProvider);
-            });
+            response.results[0].dcCreator.should.deep.eq(apiResponse.items[0].dcCreatorLangAware);
+          });
+
+          it('includes dataProvider in .edmDataProvider', async() => {
+            const response = await searchResponse();
+
+            response.results[0].edmDataProvider.should.deep.eq(apiResponse.items[0].dataProvider);
           });
         });
 


### PR DESCRIPTION
* Change structure of returned search results:
  * Move all fields to top level of each object
  * Return lang maps as-is instead of partially localising
  * Add lang-aware dc:description
* Extend lang map l10n utility function to optionally omit URIs from values if other values are present
* Refactor search result and content card plugins to handle localised lang maps, outputting HTML lang attributes as necessary
* In content cards, permit each text to be a string, array of strings, or lang map, and normalise all to the format of localised lang map