### PR TITLE
Searchbox accessibility: remove duplicated button label

### DIFF
--- a/components/search/SearchForm.vue
+++ b/components/search/SearchForm.vue
@@ -38,9 +38,6 @@
         data-qa="search button"
         variant="primary"
       >
-        <span class="sr-only">
-          {{ $t('search') }}
-        </span>
         <img
           src="../../assets/img/magnifier.svg"
           :alt="$t('search')"


### PR DESCRIPTION
Having both an image alt and a off screen element causes browser to label the main search button with both. Causing screen readers and other assistive tools to announce "search" twice.

Accessibility tree Firefox:
![image](https://user-images.githubusercontent.com/2631719/70176984-be060000-16d9-11ea-9f32-3c02be277b96.png)
