### PR TITLE
Record API specification by URL param

### DIFF
--- a/components/browse/BrowseContentCard.vue
+++ b/components/browse/BrowseContentCard.vue
@@ -11,6 +11,7 @@
 
 <script>
   import ContentCard from '../generic/ContentCard';
+  import apiConfig from '../../plugins/europeana/api';
   import { getEntityTypeHumanReadable, getWikimediaThumbnailUrl } from '../../plugins/europeana/entity';
   import { isEuropeanaRecordId } from '../../plugins/europeana/record';
 
@@ -84,10 +85,10 @@
         return (typeof this.fields.identifier === 'string') && isEuropeanaRecordId(this.fields.identifier);
       },
       forEuropeanaEntity() {
-        return (typeof this.fields.identifier === 'string') && this.fields.identifier.includes('://data.europeana.eu/');
+        return (typeof this.fields.identifier === 'string') && this.fields.identifier.includes(apiConfig.data.origin);
       },
       entityRouterLink(uri, slug) {
-        const uriMatch = uri.match('^http://data.europeana.eu/([^/]+)(/base)?/(.+)$');
+        const uriMatch = uri.match(`^${apiConfig.data.origin}/([^/]+)(/base)?/(.+)$`);
         return {
           name: 'entity-type-all', params: { type: getEntityTypeHumanReadable(uriMatch[1]), pathMatch: slug ? slug : uriMatch[3] }
         };

--- a/components/search/SearchForm.vue
+++ b/components/search/SearchForm.vue
@@ -58,6 +58,7 @@
 <script>
   import AutoSuggest from './AutoSuggest';
   import SearchBarPill from './SearchBarPill';
+  import apiConfig from '../../plugins/europeana/api';
   import { getEntitySuggestions, getEntityTypeHumanReadable, getEntitySlug } from '../../plugins/europeana/entity';
   import { mapGetters } from 'vuex';
 
@@ -203,7 +204,7 @@
           id: entityUri,
           prefLabel: this.suggestions[entityUri]
         };
-        const uriMatch = entityUri.match('^http://data.europeana.eu/([^/]+)(/base)?/(.+)$');
+        const uriMatch = entityUri.match(`^${apiConfig.data.origin}/([^/]+)(/base)?/(.+)$`);
 
         return this.localePath({
           name: 'entity-type-all', params: {

--- a/pages/entity/_type/_.vue
+++ b/pages/entity/_type/_.vue
@@ -196,7 +196,7 @@
 
       return axios.all([
         entities.getEntity(params.type, params.pathMatch),
-        entities.relatedEntities(params.type, params.pathMatch)
+        entities.relatedEntities(params.type, params.pathMatch, { origin: query.recordApi })
       ].concat(!store.state.entity.curatedEntities.includes(entityUri) ? [] : contentfulClient.getEntries({
         'locale': app.i18n.isoLocale(),
         'content_type': 'entityPage',

--- a/pages/record/_.vue
+++ b/pages/record/_.vue
@@ -162,6 +162,7 @@
   import MediaThumbnailGrid from '../../components/record/MediaThumbnailGrid';
   import MetadataField from '../../components/record/MetadataField';
 
+  import apiConfig from '../../plugins/europeana/api';
   import getRecord, { similarItemsQuery } from '../../plugins/europeana/record';
   import search from '../../plugins/europeana/search';
   import { isIIIFPresentation, isRichMedia } from '../../plugins/media';
@@ -204,10 +205,10 @@
 
     computed: {
       europeanaAgents() {
-        return (this.agents || []).filter((agent) => agent.about.startsWith('http://data.europeana.eu/agent/'));
+        return (this.agents || []).filter((agent) => agent.about.startsWith(`${apiConfig.data.origin}/agent/`));
       },
       europeanaConcepts() {
-        return (this.concepts || []).filter((concept) => concept.about.startsWith('http://data.europeana.eu/concept/'));
+        return (this.concepts || []).filter((concept) => concept.about.startsWith(`${apiConfig.data.origin}/concept/`));
       },
       europeanaEntityUris() {
         const entities = this.europeanaConcepts.concat(this.europeanaAgents);

--- a/pages/record/_.vue
+++ b/pages/record/_.vue
@@ -285,12 +285,12 @@
       }
     },
 
-    asyncData({ env, params, res, app, redirect }) {
+    asyncData({ env, params, res, app, redirect, query }) {
       if (env.RECORD_PAGE_REDIRECT_PATH) {
         return redirect(app.localePath({ path: env.RECORD_PAGE_REDIRECT_PATH }));
       }
 
-      return getRecord(`/${params.pathMatch}`)
+      return getRecord(`/${params.pathMatch}`, { origin: query.recordApi })
         .then((result) => {
           return result.record;
         })
@@ -356,6 +356,8 @@
           rows: 4,
           profile: 'minimal',
           facet: ''
+        }, {
+          origin: this.$route.query.recordApi
         })
           .catch(() => {
             return noSimilarItems;

--- a/plugins/europeana/api.js
+++ b/plugins/europeana/api.js
@@ -1,4 +1,3 @@
-// TODO: deprecate EUROPEANA_API_KEY env var
 export default {
   entity: {
     origin: process.env.EUROPEANA_ENTITY_API_ORIGIN || process.env.EUROPEANA_API_ORIGIN || 'https://api.europeana.eu',
@@ -6,10 +5,10 @@ export default {
   },
   newspaper: {
     origin: process.env.EUROPEANA_NEWSPAPER_API_ORIGIN || 'https://newspapers.eanadev.org',
-    key: process.env.EUROPEANA_NEWSPAPER_API_KEY || process.env.EUROPEANA_RECORD_API_KEY || process.env.EUROPEANA_API_KEY
+    key: process.env.EUROPEANA_NEWSPAPER_API_KEY || process.env.EUROPEANA_RECORD_API_KEY
   },
   record: {
     origin: process.env.EUROPEANA_RECORD_API_ORIGIN || process.env.EUROPEANA_API_ORIGIN || 'https://api.europeana.eu',
-    key: process.env.EUROPEANA_RECORD_API_KEY || process.env.EUROPEANA_API_KEY
+    key: process.env.EUROPEANA_RECORD_API_KEY
   }
 };

--- a/plugins/europeana/api.js
+++ b/plugins/europeana/api.js
@@ -1,14 +1,24 @@
 export default {
   entity: {
-    origin: process.env.EUROPEANA_ENTITY_API_ORIGIN || process.env.EUROPEANA_API_ORIGIN || 'https://api.europeana.eu',
+    origin: process.env.EUROPEANA_ENTITY_API_ORIGIN || 'https://api.europeana.eu',
+    path: '/entity',
     key: process.env.EUROPEANA_ENTITY_API_KEY
+  },
+  data: {
+    origin: process.env.EUROPEANA_DATA_API_ORIGIN || 'http://data.europeana.eu'
   },
   newspaper: {
     origin: process.env.EUROPEANA_NEWSPAPER_API_ORIGIN || 'https://newspapers.eanadev.org',
+    path: '/api/v2',
     key: process.env.EUROPEANA_NEWSPAPER_API_KEY || process.env.EUROPEANA_RECORD_API_KEY
   },
   record: {
-    origin: process.env.EUROPEANA_RECORD_API_ORIGIN || process.env.EUROPEANA_API_ORIGIN || 'https://api.europeana.eu',
+    origin: process.env.EUROPEANA_RECORD_API_ORIGIN || 'https://api.europeana.eu',
+    path: '/record',
     key: process.env.EUROPEANA_RECORD_API_KEY
+  },
+  thumbnail: {
+    origin: process.env.EUROPEANA_THUMBNAIL_API_ORIGIN || 'https://api.europeana.eu',
+    path: '/api/v2'
   }
 };

--- a/plugins/europeana/entity.js
+++ b/plugins/europeana/entity.js
@@ -5,10 +5,10 @@ import search from './search';
 
 export const constants = Object.freeze({
   API_ORIGIN: config.entity.origin,
-  API_PATH_PREFIX: '/entity',
+  API_PATH_PREFIX: config.entity.path,
   API_ENDPOINT_SEARCH: '/search',
   API_ENDPOINT_SUGGEST: '/suggest',
-  URI_ORIGIN: 'http://data.europeana.eu'
+  URI_ORIGIN: config.data.origin
 });
 
 /**
@@ -199,6 +199,7 @@ export function getEntitySlug(entity, entityPage) {
  */
 export function relatedEntities(type, id, options = {}) {
   const origin = options.origin || config.record.origin;
+  const path = options.path || config.record.path;
 
   const entityUri = getEntityUri(type, id);
   let apiParams = {
@@ -209,7 +210,7 @@ export function relatedEntities(type, id, options = {}) {
     rows: 0
   };
 
-  return axios.get(`${origin}/api/v2/search.json`, {
+  return axios.get(`${origin}${path}/search.json`, {
     params: apiParams
   })
     .then((response) => {

--- a/plugins/europeana/entity.js
+++ b/plugins/europeana/entity.js
@@ -1,6 +1,7 @@
+import axios from 'axios';
 import { apiError, langMapValueForLocale } from './utils';
 import config from './api';
-import axios from 'axios';
+import search from './search';
 
 export const constants = Object.freeze({
   API_ORIGIN: config.entity.origin,
@@ -36,8 +37,6 @@ export function getEntity(type, id) {
 function entityApiUrl(endpoint) {
   return `${constants.API_ORIGIN}${constants.API_PATH_PREFIX}${endpoint}`;
 }
-
-import search from './search';
 
 /**
  * Get entity suggestions from the API
@@ -198,7 +197,9 @@ export function getEntitySlug(entity, entityPage) {
  * TODO: add people as related entities again
  * TODO: use search() function?
  */
-export function relatedEntities(type, id) {
+export function relatedEntities(type, id, options = {}) {
+  const origin = options.origin || config.record.origin;
+
   const entityUri = getEntityUri(type, id);
   let apiParams = {
     wskey: config.record.key,
@@ -208,7 +209,7 @@ export function relatedEntities(type, id) {
     rows: 0
   };
 
-  return axios.get(`${config.record.origin}/api/v2/search.json`, {
+  return axios.get(`${origin}/api/v2/search.json`, {
     params: apiParams
   })
     .then((response) => {

--- a/plugins/europeana/record.js
+++ b/plugins/europeana/record.js
@@ -250,8 +250,9 @@ function setMatchingEntities(fields, key, entities) {
  */
 function getRecord(europeanaId, options = {}) {
   const origin = options.origin || config.record.origin;
+  const path = options.path || config.record.path;
 
-  return axios.get(`${origin}/api/v2/record${europeanaId}.json`, {
+  return axios.get(`${origin}${path}${europeanaId}.json`, {
     params: {
       wskey: config.record.key
     }

--- a/plugins/europeana/record.js
+++ b/plugins/europeana/record.js
@@ -248,8 +248,10 @@ function setMatchingEntities(fields, key, entities) {
  * @param {string} europeanaId ID of Europeana record
  * @return {Object} parsed record data
  */
-function getRecord(europeanaId) {
-  return axios.get(`${config.record.origin}/api/v2/record${europeanaId}.json`, {
+function getRecord(europeanaId, options = {}) {
+  const origin = options.origin || config.record.origin;
+
+  return axios.get(`${origin}/api/v2/record${europeanaId}.json`, {
     params: {
       wskey: config.record.key
     }

--- a/plugins/europeana/search.js
+++ b/plugins/europeana/search.js
@@ -112,6 +112,7 @@ function search(params, options = {}) {
   const rows = Math.max(0, Math.min(maxResults + 1 - start, perPage));
 
   const origin = options.origin || config.record.origin;
+  console.log('origin', origin);
   const query = (typeof params.query === 'undefined' || params.query === '') ? '*:*' : params.query;
 
   return axios.get(`${origin}/api/v2/search.json`, {

--- a/plugins/europeana/search.js
+++ b/plugins/europeana/search.js
@@ -102,6 +102,7 @@ function resultsFromApiResponse(response) {
  * @param {string} params.wskey API key, to override `config.record.key`
  * @param {Object} options search options
  * @param {string} options.origin base URL for API, overriding default `config.record.origin`
+ * @param {string} options.path path prefix for API, overriding default `config.record.path`
  * @return {{results: Object[], totalResults: number, facets: FacetSet, error: string}} search results for display
  */
 function search(params, options = {}) {
@@ -112,10 +113,11 @@ function search(params, options = {}) {
   const rows = Math.max(0, Math.min(maxResults + 1 - start, perPage));
 
   const origin = options.origin || config.record.origin;
-  console.log('origin', origin);
+  const path = options.path || config.record.path;
+
   const query = (typeof params.query === 'undefined' || params.query === '') ? '*:*' : params.query;
 
-  return axios.get(`${origin}/api/v2/search.json`, {
+  return axios.get(`${origin}${path}/search.json`, {
     paramsSerializer(params) {
       return qs.stringify(params, { arrayFormat: 'repeat' });
     },

--- a/plugins/europeana/thumbnail.js
+++ b/plugins/europeana/thumbnail.js
@@ -8,9 +8,10 @@ import { URL } from '../url';
 import config from './api';
 
 export default function thumbnailUrl(uri, params = {}, options = {}) {
-  const origin = options.origin || config.record.origin;
+  const origin = options.origin || config.thumbnail.origin;
+  const path = options.path || config.thumbnail.path;
 
-  const url = new URL(`${origin}/api/v2/thumbnail-by-url.json`);
+  const url = new URL(`${origin}${path}/thumbnail-by-url.json`);
   for (const key of Object.keys(params)) {
     url.searchParams.set(key, params[key]);
   }
@@ -42,6 +43,6 @@ export function thumbnailTypeForMimeType(mimeType) {
 }
 
 export function genericThumbnail(itemId, params = {}) {
-  const uri = `http://data.europeana.eu/item${itemId}`;
+  const uri = `${config.data.origin}/item${itemId}`;
   return thumbnailUrl(uri, params);
 }

--- a/plugins/europeana/thumbnail.js
+++ b/plugins/europeana/thumbnail.js
@@ -7,8 +7,10 @@
 import { URL } from '../url';
 import config from './api';
 
-export default function thumbnailUrl(uri, params = {}) {
-  const url = new URL(`${config.record.origin}/api/v2/thumbnail-by-url.json`);
+export default function thumbnailUrl(uri, params = {}, options = {}) {
+  const origin = options.origin || config.record.origin;
+
+  const url = new URL(`${origin}/api/v2/thumbnail-by-url.json`);
   for (const key of Object.keys(params)) {
     url.searchParams.set(key, params[key]);
   }

--- a/store/collections/newspaper.js
+++ b/store/collections/newspaper.js
@@ -11,6 +11,7 @@ export const getters = {
 
     if (getters.apiParams.api === 'fulltext') {
       options.origin = apiConfig.newspaper.origin;
+      options.path = apiConfig.newspaper.path;
     }
 
     return options;

--- a/store/search.js
+++ b/store/search.js
@@ -262,8 +262,14 @@ export const actions = {
       }
     }
 
+    const apiOptions = {};
+    if (apiParams.recordApi) {
+      apiOptions.origin = apiParams.recordApi;
+      delete apiParams.recordApi;
+    }
+
     commit('setApiParams', apiParams);
-    commit('setApiOptions', {});
+    commit('setApiOptions', apiOptions);
 
     await dispatch('applyCollectionSpecificSettings');
   },

--- a/tests/unit/plugins/europeana/entity.spec.js
+++ b/tests/unit/plugins/europeana/entity.spec.js
@@ -15,8 +15,8 @@ const entityFilterField = 'skos_concept';
 const apiKey = 'abcdef';
 const baseRequest = nock(apiUrl).get(apiEndpoint);
 
-const apiUrlSearch = 'https://api.europeana.eu';
-const apiEndpointSearch = '/api/v2/search.json';
+const recordApiUrl = config.record.origin;
+const recordApiEndpoint = `${config.record.path}/search.json`;
 
 const searchResponse = {
   facets: [
@@ -233,8 +233,8 @@ describe('plugins/europeana/entity', () => {
     });
 
     it('returns related entities', async() => {
-      nock(apiUrlSearch)
-        .get(apiEndpointSearch)
+      nock(recordApiUrl)
+        .get(recordApiEndpoint)
         .query(true)
         .reply(200, searchResponse);
 
@@ -243,8 +243,8 @@ describe('plugins/europeana/entity', () => {
     });
 
     it('filters on entity URI', async() => {
-      nock(apiUrlSearch)
-        .get(apiEndpointSearch)
+      nock(recordApiUrl)
+        .get(recordApiEndpoint)
         .query(query => {
           return query.query === `${entityFilterField}:"${entityUri}"`;
         })

--- a/tests/unit/plugins/europeana/record.spec.js
+++ b/tests/unit/plugins/europeana/record.spec.js
@@ -10,7 +10,7 @@ axios.defaults.adapter = require('axios/lib/adapters/http');
 
 const europeanaId = '/123/abc';
 const apiUrl = config.record.origin;
-const apiEndpoint = `/api/v2/record${europeanaId}.json`;
+const apiEndpoint = `${config.record.path}${europeanaId}.json`;
 const apiKey = 'abcdef';
 
 const baseRequest = nock(apiUrl).get(apiEndpoint);

--- a/tests/unit/plugins/europeana/search.spec.js
+++ b/tests/unit/plugins/europeana/search.spec.js
@@ -153,6 +153,20 @@ describe('plugins/europeana/search', () => {
 
         nock.isDone().should.be.true;
       });
+
+      context('with origin supplied', () => {
+        const customOrigin = 'https://api.example.org';
+        it('queries that API', async() => {
+          nock(customOrigin)
+            .get(apiEndpoint)
+            .query(true)
+            .reply(200, defaultResponse);
+
+          await search({ query: 'anything' }, { origin: customOrigin });
+
+          nock.isDone().should.be.true;
+        });
+      });
     });
 
     describe('API response', () => {

--- a/tests/unit/plugins/europeana/search.spec.js
+++ b/tests/unit/plugins/europeana/search.spec.js
@@ -8,7 +8,7 @@ import axios from 'axios';
 axios.defaults.adapter = require('axios/lib/adapters/http');
 
 const apiOrigin = config.record.origin;
-const apiEndpoint = '/api/v2/search.json';
+const apiEndpoint = `${config.record.path}/search.json`;
 const apiKey = 'abcdef';
 
 const baseRequest = nock(apiOrigin).get(apiEndpoint);

--- a/tests/unit/store/search.spec.js
+++ b/tests/unit/store/search.spec.js
@@ -6,8 +6,8 @@ import sinon from 'sinon';
 
 axios.defaults.adapter = require('axios/lib/adapters/http');
 
-const apiUrl = 'https://api.europeana.eu';
-const apiEndpoint = '/api/v2/search.json';
+const apiUrl = apiConfig.record.origin;
+const apiEndpoint = `${apiConfig.record.path}/search.json`;
 const apiKey = '1234';
 
 const baseRequest = nock(apiUrl).get(apiEndpoint);


### PR DESCRIPTION
Named `recordApi`, to:
* Permit future specification of other APIs by other params, e.g. `entityApi`
* Prevent conflict with existing parameter `api` used in Newspapers collection

In addition:
* Switch to using shorter API gateway URLs where possible, e.g. api.europeana.eu/record/ instead of api.europeana.eu/api/v2/
* Use plugins/europeana/api.js as the SSOT for API origins and path prefixes, including for data.europeana.eu