### PR TITLE
Contentful migration: update help texts + validation

### DIFF
--- a/migrations/0019-update-reserved-slugs.js
+++ b/migrations/0019-update-reserved-slugs.js
@@ -15,18 +15,18 @@ module.exports = function(migration) {
       }
     ]);
 
-    const imageGallery = migration.editContentType('imageGallery');
-    imageGallery.changeFieldControl('identifier', 'builtin', 'slugEditor', {
-      helpText: 'Will always be prefixed with "/galleries/"'
-    });
+  const imageGallery = migration.editContentType('imageGallery');
+  imageGallery.changeFieldControl('identifier', 'builtin', 'slugEditor', {
+    helpText: 'Will always be prefixed with "/galleries/"'
+  });
 
-    const exhibitionPage = migration.editContentType('exhibitionPage');
-    exhibitionPage.changeFieldControl('identifier', 'builtin', 'slugEditor', {
-      helpText: 'Will always be prefixed with "/exhibitions/"'
-    });
+  const exhibitionPage = migration.editContentType('exhibitionPage');
+  exhibitionPage.changeFieldControl('identifier', 'builtin', 'slugEditor', {
+    helpText: 'Will always be prefixed with "/exhibitions/"'
+  });
 
-    const exhibitionChapterPage = migration.editContentType('exhibitionChapterPage');
-    exhibitionChapterPage.changeFieldControl('identifier', 'builtin', 'slugEditor', {
-      helpText: 'Will automatically be prefixed with "/exhibitions/EXHIBITION_SLUG/"'
-    });
+  const exhibitionChapterPage = migration.editContentType('exhibitionChapterPage');
+  exhibitionChapterPage.changeFieldControl('identifier', 'builtin', 'slugEditor', {
+    helpText: 'Will automatically be prefixed with "/exhibitions/EXHIBITION_SLUG/"'
+  });
 };

--- a/migrations/0019-update-reserved-slugs.js
+++ b/migrations/0019-update-reserved-slugs.js
@@ -1,0 +1,32 @@
+module.exports = function(migration) {
+  const browsePage = migration.editContentType('browsePage');
+  browsePage
+    .editField('identifier')
+    .validations([
+      {
+        unique: true
+      },
+      {
+        prohibitRegexp: {
+          pattern: '^(api$|api/|blog$|blog/|collections/|exhibitions$|exhibitions/|galleries$|galleries/|record/|schemas$|schemas/|search$)',
+          flags: null
+        },
+        message: 'This URL slug is reserved.'
+      }
+    ]);
+
+    const imageGallery = migration.editContentType('imageGallery');
+    imageGallery.changeFieldControl('identifier', 'builtin', 'slugEditor', {
+      helpText: 'Will always be prefixed with "/galleries/"'
+    });
+
+    const exhibitionPage = migration.editContentType('exhibitionPage');
+    exhibitionPage.changeFieldControl('identifier', 'builtin', 'slugEditor', {
+      helpText: 'Will always be prefixed with "/exhibitions/"'
+    });
+
+    const exhibitionChapterPage = migration.editContentType('exhibitionChapterPage');
+    exhibitionChapterPage.changeFieldControl('identifier', 'builtin', 'slugEditor', {
+      helpText: 'Will automatically be prefixed with "/exhibitions/EXHIBITION_SLUG/"'
+    });
+};


### PR DESCRIPTION
- Updated reserved slugs on browse pages
- Updated help texts for slug field on gallery and exhibition pages