### PR TITLE
Extra lookups for metadata URI values

### DIFF
--- a/components/generic/ContentCard.vue
+++ b/components/generic/ContentCard.vue
@@ -128,6 +128,10 @@
         type: String,
         default: 'default' // other options: entity, mini, list
       },
+      omitAllUris: {
+        type: Boolean,
+        default: false
+      },
       omitUrisIfOtherValues: {
         type: Boolean,
         default: false
@@ -175,7 +179,7 @@
           } else if (Array.isArray(value)) {
             return { values: value, code: null };
           } else {
-            return langMapValueForLocale(value, this.$i18n.locale, { omitUrisIfOtherValues: this.omitUrisIfOtherValues });
+            return langMapValueForLocale(value, this.$i18n.locale, { omitUrisIfOtherValues: this.omitUrisIfOtherValues, omitAllUris: this.omitAllUris });
           }
         });
       },

--- a/components/record/MetadataField.vue
+++ b/components/record/MetadataField.vue
@@ -74,6 +74,10 @@
         type: Number,
         default: -1
       },
+      omitAllUris: {
+        type: Boolean,
+        default: false
+      },
       omitUrisIfOtherValues: {
         type: Boolean,
         default: false
@@ -102,8 +106,7 @@
         } else if (Array.isArray(this.fieldData)) {
           return { values: this.fieldData, code: '' };
         }
-
-        return langMapValueForLocale(this.fieldData, this.$i18n.locale, { omitUrisIfOtherValues: this.omitUrisIfOtherValues });
+        return langMapValueForLocale(this.fieldData, this.$i18n.locale, { omitUrisIfOtherValues: this.omitUrisIfOtherValues, omitAllUris: this.omitAllUris });
       },
 
       hasValuesForLocale() {

--- a/components/search/SearchResults.vue
+++ b/components/search/SearchResults.vue
@@ -14,7 +14,6 @@
       :texts="cardTexts(result, 'list')"
       data-qa="search result"
       :limit-values-within-each-text="3"
-      :omit-uris-if-other-values="true"
       :omit-all-uris="true"
       variant="list"
       class="mx-0"
@@ -35,7 +34,6 @@
       :texts="cardTexts(result)"
       data-qa="search result"
       :limit-values-within-each-text="3"
-      :omit-uris-if-other-values="true"
       :omit-all-uris="true"
       :blank-image-height="280"
     />

--- a/components/search/SearchResults.vue
+++ b/components/search/SearchResults.vue
@@ -15,6 +15,7 @@
       data-qa="search result"
       :limit-values-within-each-text="3"
       :omit-uris-if-other-values="true"
+      :omit-all-uris="true"
       variant="list"
       class="mx-0"
     />
@@ -35,6 +36,7 @@
       data-qa="search result"
       :limit-values-within-each-text="3"
       :omit-uris-if-other-values="true"
+      :omit-all-uris="true"
       :blank-image-height="280"
     />
   </b-card-group>

--- a/plugins/europeana/utils.js
+++ b/plugins/europeana/utils.js
@@ -14,6 +14,7 @@ export function apiError(error) {
 
 const locales = require('../i18n/locales.js');
 const undefinedLocaleCodes = ['def', 'und'];
+const uriRegex = /^https?:\/\//; // Used to determine if a value is a URI
 
 const isoAlpha3Map = locales.reduce((memo, locale) => {
   memo[locale.isoAlpha3] = locale.code;
@@ -66,33 +67,71 @@ function languageKeys(locale) {
 /**
  * Get the localised value for the current locale, with preferred fallbacks.
  * Will return the first value if no value was found in any of the preferred locales.
+ * Will favour non URI values even in non preferred languages if otherwise only URI(s) would be returned.
+ * With the setting omitUrisIfOtherValues set to true URI values will be removed if any plain text value is available.
+ * With the setting omitAllUris set to true, when no other values were found all values matching the URI pattern will be
+ * omitted.
  * @param {Object} The LangMap
  * @param {String} locale Current locale as a 2 letter code
+ * @param {Boolean} options.omitUrisIfOtherValues Setting to prefer any value over URIs
+ * @param {Boolean} options.omitAllUris Setting to remove all URIs
  * @return {{Object[]{language: String, values: Object[]}}} Language code and values, values may be strings or language maps themselves.
  */
 export function langMapValueForLocale(langMap, locale, options = {}) {
   let returnVal = { values: [] };
   for (let key of languageKeys(locale)) { // loop through all language key to find a match
     setLangMapValuesAndCode(returnVal, langMap, key, locale);
-    if (returnVal['values'].length >= 1) break;
+    if (returnVal.values.length >= 1) break;
   }
 
   // No preferred language found, so just add the first
-  if (returnVal['values'].length === 0) {
+  if (returnVal.values.length === 0) {
     setLangMapValuesAndCode(returnVal, langMap, Object.keys(langMap)[0], locale);
   }
 
-  const withEntities = addEntityValues(returnVal, entityValues(langMap['def'], locale));
+  let withEntities = addEntityValues(returnVal, entityValues(langMap['def'], locale));
+  // In case an entity resolves as only its URI as is the case in search responses on the  minimal profile
+  // as no linked entity data is returned so the prefLabel can't be retrieved.
+  if (onlyUriValues(withEntities.values) && returnVal.code === '' && hasNonDefValues(langMap)) {
+    withEntities = localizedLangMapFromFirstNonDefValue(langMap);
+  }
   if (!options.omitUrisIfOtherValues) return withEntities;
-
+  if (options.omitAllUris) return omitAllUris(withEntities);
   return omitUrisIfOtherValues(withEntities);
 }
 
 function omitUrisIfOtherValues(localizedLangmap) {
-  const withoutUris = localizedLangmap.values.filter((value) => !/^https?:\/\//.test(value));
-  localizedLangmap.values = withoutUris.length > 0 ? withoutUris : [];
+  const withoutUris = localizedLangmap.values.filter((value) => !uriRegex.test(value));
+  if (withoutUris.length > 0) localizedLangmap.values = withoutUris;
 
   return localizedLangmap;
+}
+
+function omitAllUris(localizedLangmap) {
+  const withoutUris = localizedLangmap.values.filter((value) => !uriRegex.test(value));
+  localizedLangmap.values = withoutUris;
+
+  return localizedLangmap;
+}
+
+function localizedLangMapFromFirstNonDefValue(langMap) {
+  for (let key in langMap) {
+    if (key !== 'def') {
+      return { values: langMap[key], code: key };
+    }
+  }
+}
+
+function hasNonDefValues(langMap) {
+  const keys = Object.keys(langMap);
+  return  keys.some((key) => {
+    return key !== 'def';
+  });
+}
+
+// check if values are exclusively URIs.
+function onlyUriValues(values) {
+  return values.every((value) => uriRegex.test(value));
 }
 
 function isJSONLDExpanded(values) {
@@ -120,17 +159,17 @@ function langMapValueAndCodeFromMap(returnValue, langMap, key, locale) {
 
 function langMapValueAndCodeFromJSONLD(returnValue, langMap, key, locale) {
   const matchedValue = langMapValueFromJSONLD(langMap, key);
-  if (matchedValue) returnValue['values'] = [matchedValue];
+  if (matchedValue) returnValue.values = [matchedValue];
   setLangCode(returnValue, key, locale);
 }
 
 function addEntityValues(localizedLangmap, localizedEntities) {
-  localizedLangmap['values'] = localizedLangmap['values'].concat(localizedEntities);
+  localizedLangmap.values = localizedLangmap.values.concat(localizedEntities);
   return localizedLangmap;
 }
 
 function setLangMapValues(returnValues, langMap, key) {
-  returnValues['values'] = [].concat(langMap[key]);
+  returnValues.values = [].concat(langMap[key]);
 }
 
 function setLangCode(map, key, locale) {
@@ -147,5 +186,5 @@ function normalizedLangCode(key) {
 }
 
 function filterEntities(mappedObject) {
-  mappedObject['values'] = mappedObject['values'].filter(v => !isEntity(v));
+  mappedObject.values = mappedObject.values.filter(v => !isEntity(v));
 }

--- a/plugins/europeana/utils.js
+++ b/plugins/europeana/utils.js
@@ -90,13 +90,13 @@ export function langMapValueForLocale(langMap, locale, options = {}) {
   }
 
   let withEntities = addEntityValues(returnVal, entityValues(langMap['def'], locale));
-  // In case an entity resolves as only its URI as is the case in search responses on the  minimal profile
+  // In case an entity resolves as only its URI as is the case in search responses
   // as no linked entity data is returned so the prefLabel can't be retrieved.
   if (onlyUriValues(withEntities.values) && returnVal.code === '' && hasNonDefValues(langMap)) {
     withEntities = localizedLangMapFromFirstNonDefValue(langMap);
   }
-  if (!options.omitUrisIfOtherValues) return withEntities;
   if (options.omitAllUris) return omitAllUris(withEntities);
+  if (!options.omitUrisIfOtherValues) return withEntities;
   return omitUrisIfOtherValues(withEntities);
 }
 

--- a/plugins/europeana/utils.js
+++ b/plugins/europeana/utils.js
@@ -90,7 +90,8 @@ export function langMapValueForLocale(langMap, locale, options = {}) {
 
 function omitUrisIfOtherValues(localizedLangmap) {
   const withoutUris = localizedLangmap.values.filter((value) => !/^https?:\/\//.test(value));
-  if (withoutUris.length > 0) localizedLangmap.values = withoutUris;
+  localizedLangmap.values = withoutUris.length > 0 ? withoutUris : [];
+
   return localizedLangmap;
 }
 

--- a/tests/unit/components/record/MetadataField.spec.js
+++ b/tests/unit/components/record/MetadataField.spec.js
@@ -103,24 +103,69 @@ describe('components/record/MetadataField', () => {
       });
 
       describe('URIs', () => {
-        it('omits them if there are other values', () => {
-          const props = { name: 'dcCreator', fieldData: { def: ['http://data.europeana.eu/agent/base/123', 'Artist'] }, omitUrisIfOtherValues: true };
-          const wrapper = factory();
+        context('with omitUrisIfOtherValues set to true', () => {
+          it('ommits them if there are other values in any language', () => {
+            const props = { name: 'dcCreator', fieldData: { def: ['http://example.org/unresolvable'], pl: ['Polish Value'] }, omitUrisIfOtherValues: true  };
+            const wrapper = factory();
 
-          wrapper.setProps(props);
+            wrapper.setProps(props);
 
-          const fieldValue = wrapper.find('[data-qa="metadata field"] ul [data-qa="literal value"]');
-          fieldValue.text().should.eq(props.fieldData.def[1]);
-        });
+            const fieldValue = wrapper.find('[data-qa="metadata field"] ul [data-qa="literal value"]');
+            fieldValue.text().should.eq(props.fieldData.pl[0]);
+          });
 
-        it('do not include them if there are no other values', () => {
-          const props = { name: 'dcCreator', fieldData: { def: ['http://data.europeana.eu/agent/base/123'] }, omitUrisIfOtherValues: true };
-          const wrapper = factory();
+          it('omits them if there are other values', () => {
+            const props = { name: 'dcCreator', fieldData: { def: ['http://data.europeana.eu/agent/base/123', 'Artist'] }, omitUrisIfOtherValues: true };
+            const wrapper = factory();
 
-          wrapper.setProps(props);
+            wrapper.setProps(props);
 
-          const fieldValue = wrapper.find('[data-qa="metadata field"] ul [data-qa="literal value"]');
-          fieldValue.exists().should.be.false;
+            const fieldValue = wrapper.find('[data-qa="metadata field"] ul [data-qa="literal value"]');
+            fieldValue.text().should.eq(props.fieldData.def[1]);
+          });
+
+          it('only include them if there are no other values in any other language', () => {
+            const props = { name: 'dcCreator', fieldData: { def: ['http://data.europeana.eu/agent/base/123'] }, omitUrisIfOtherValues: true };
+            const wrapper = factory();
+
+            wrapper.setProps(props);
+
+            const fieldValue = wrapper.find('[data-qa="metadata field"] ul [data-qa="literal value"]');
+            fieldValue.text().should.eq(props.fieldData.def[0]);
+          });
+          context('with the omitAllUris setting set to true', () => {
+            const options = { omitUrisIfOtherValues: true, omitAllUris: true };
+
+            it('ommits them if there are other values in any language', () => {
+              const props = { name: 'dcCreator', fieldData: { def: ['http://data.europeana.eu/agent/base/123'], pl: ['Polish Value'] }, ...options };
+              const wrapper = factory();
+
+              wrapper.setProps(props);
+
+              const fieldValue = wrapper.find('[data-qa="metadata field"] ul [data-qa="literal value"]');
+              fieldValue.text().should.eq(props.fieldData.pl[0]);
+            });
+
+            it('omits them if there are other values', () => {
+              const props = { name: 'dcCreator', fieldData: { def: ['http://data.europeana.eu/agent/base/123', 'Artist'] }, ...options };
+              const wrapper = factory();
+
+              wrapper.setProps(props);
+
+              const fieldValue = wrapper.find('[data-qa="metadata field"] ul [data-qa="literal value"]');
+              fieldValue.text().should.eq(props.fieldData.def[1]);
+            });
+
+            it('omits them if it is the only value', () => {
+              const props = { name: 'dcCreator', fieldData: { def: ['http://data.europeana.eu/agent/base/123'] }, ...options };
+              const wrapper = factory();
+
+              wrapper.setProps(props);
+
+              const fieldValue = wrapper.find('[data-qa="metadata field"] ul [data-qa="literal value"]');
+              fieldValue.exists().should.be.false;
+            });
+          });
         });
       });
     });

--- a/tests/unit/components/record/MetadataField.spec.js
+++ b/tests/unit/components/record/MetadataField.spec.js
@@ -113,14 +113,14 @@ describe('components/record/MetadataField', () => {
           fieldValue.text().should.eq(props.fieldData.def[1]);
         });
 
-        it('includes them if there are no other values', () => {
+        it('do not include them if there are no other values', () => {
           const props = { name: 'dcCreator', fieldData: { def: ['http://data.europeana.eu/agent/base/123'] }, omitUrisIfOtherValues: true };
           const wrapper = factory();
 
           wrapper.setProps(props);
 
           const fieldValue = wrapper.find('[data-qa="metadata field"] ul [data-qa="literal value"]');
-          fieldValue.text().should.eq(props.fieldData.def[0]);
+          fieldValue.exists().should.be.false;
         });
       });
     });


### PR DESCRIPTION
Always prefer Text values which aren't URIs for metadata display. Even if they are only available in non preferred languages.

Introduce a new option to be used on search results to omit any URIs when they're the only info to display. As this is configurable, record pages will still output these URIs.