### PR TITLE
Client-side rendering

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -2,7 +2,7 @@
   {
     "name": "portal.js client (en)",
     "running": false,
-    "limit": "405 KB",
+    "limit": "450 KB",
     "path": [
       "./.nuxt/dist/client/*.js"
     ]
@@ -10,7 +10,7 @@
   {
     "name": "portal.js server (en)",
     "running": false,
-    "limit": "255 KB",
+    "limit": "275 KB",
     "path": [
       "./.nuxt/dist/server/*.js"
     ]

--- a/components/browse/BrowseSections.vue
+++ b/components/browse/BrowseSections.vue
@@ -38,40 +38,28 @@
         :right-image-width="section.fields.hasPart[1].fields.image.fields.file.details.image.width"
         :right-image-height="section.fields.hasPart[1].fields.image.fields.file.details.image.height"
       />
-      <template
+      <ImageWithAttribution
         v-else-if="contentType(section, 'imageWithAttribution')"
-      >
-        <client-only>
-          <ImageWithAttribution
-            :key="section.sys.id"
-            :src="section.fields.image.fields.file.url"
-            :content-type="section.fields.image.fields.file.contentType"
-            :width="section.fields.image.fields.file.details.image.width"
-            :height="section.fields.image.fields.file.details.image.height"
-            :attribution="attributionFields(section.fields)"
-          />
-        </client-only>
-      </template>
+        :key="section.sys.id"
+        :src="section.fields.image.fields.file.url"
+        :content-type="section.fields.image.fields.file.contentType"
+        :width="section.fields.image.fields.file.details.image.width"
+        :height="section.fields.image.fields.file.details.image.height"
+        :attribution="attributionFields(section.fields)"
+      />
     </template>
   </div>
 </template>
 
 <script>
-  import CompareImageSlider from '../generic/CompareImageSlider';
-  import ContentCardSection from './ContentCardSection';
-  import LatestSection from './LatestSection';
-  import HTMLEmbed from '../generic/HTMLEmbed';
-  import ImageWithAttribution from '../generic/ImageWithAttribution';
-  import RichText from './RichText';
-
   export default {
     components: {
-      CompareImageSlider,
-      ContentCardSection,
-      LatestSection,
-      HTMLEmbed,
-      ImageWithAttribution,
-      RichText
+      CompareImageSlider: () => import('../generic/CompareImageSlider'),
+      ContentCardSection: () => import('./ContentCardSection'),
+      LatestSection: () => import('./LatestSection'),
+      HTMLEmbed: () => import('../generic/HTMLEmbed'),
+      ImageWithAttribution: () => import('../generic/ImageWithAttribution'),
+      RichText: () => import('./RichText')
     },
 
     props: {

--- a/components/browse/BrowseSections.vue
+++ b/components/browse/BrowseSections.vue
@@ -38,15 +38,20 @@
         :right-image-width="section.fields.hasPart[1].fields.image.fields.file.details.image.width"
         :right-image-height="section.fields.hasPart[1].fields.image.fields.file.details.image.height"
       />
-      <ImageWithAttribution
+      <template
         v-else-if="contentType(section, 'imageWithAttribution')"
-        :key="section.sys.id"
-        :src="section.fields.image.fields.file.url"
-        :content-type="section.fields.image.fields.file.contentType"
-        :width="section.fields.image.fields.file.details.image.width"
-        :height="section.fields.image.fields.file.details.image.height"
-        :attribution="attributionFields(section.fields)"
-      />
+      >
+        <client-only>
+          <ImageWithAttribution
+            :key="section.sys.id"
+            :src="section.fields.image.fields.file.url"
+            :content-type="section.fields.image.fields.file.contentType"
+            :width="section.fields.image.fields.file.details.image.width"
+            :height="section.fields.image.fields.file.details.image.height"
+            :attribution="attributionFields(section.fields)"
+          />
+        </client-only>
+      </template>
     </template>
   </div>
 </template>

--- a/components/search/SearchInterface.vue
+++ b/components/search/SearchInterface.vue
@@ -17,36 +17,38 @@
         <b-col
           data-qa="search filters"
         >
-          <SearchFilters />
-          <div class="position-relative">
-            <FacetDropdown
-              v-for="facet in coreFacets"
-              :key="facet.name"
-              :name="facet.name"
-              :fields="facet.fields"
-              :type="facetDropdownType(facet.name)"
-              :selected="filters[facet.name]"
-              role="search"
-              :aria-label="`${facet.name} dropdown button`"
-              @changed="changeFacet"
-            />
-            <MoreFiltersDropdown
-              v-if="enableMoreFacets"
-              :more-facets="moreFacets"
-              :selected="moreSelectedFacets"
-              role="search"
-              aria-label="more filters dropdown button"
-              @changed="changeMoreFacets"
-            />
-            <button
-              v-if="isFilteredByDropdowns()"
-              class="reset"
-              data-qa="reset filters button"
-              @click="resetFilters"
-            >
-              {{ $t('reset') }}
-            </button>
-          </div>
+          <client-only>
+            <SearchFilters />
+            <div class="position-relative">
+              <FacetDropdown
+                v-for="facet in coreFacets"
+                :key="facet.name"
+                :name="facet.name"
+                :fields="facet.fields"
+                :type="facetDropdownType(facet.name)"
+                :selected="filters[facet.name]"
+                role="search"
+                :aria-label="`${facet.name} dropdown button`"
+                @changed="changeFacet"
+              />
+              <MoreFiltersDropdown
+                v-if="enableMoreFacets"
+                :more-facets="moreFacets"
+                :selected="moreSelectedFacets"
+                role="search"
+                aria-label="more filters dropdown button"
+                @changed="changeMoreFacets"
+              />
+              <button
+                v-if="isFilteredByDropdowns()"
+                class="reset"
+                data-qa="reset filters button"
+                @click="resetFilters"
+              >
+                {{ $t('reset') }}
+              </button>
+            </div>
+          </client-only>
         </b-col>
       </b-row>
       <b-row

--- a/components/search/SearchInterface.vue
+++ b/components/search/SearchInterface.vue
@@ -106,13 +106,15 @@
           </b-row>
           <b-row>
             <b-col>
-              <PaginationNav
-                v-if="showPagination"
-                v-model="page"
-                :total-results="totalResults"
-                :per-page="perPage"
-                :link-gen="paginationLink"
-              />
+              <client-only>
+                <PaginationNav
+                  v-if="showPagination"
+                  v-model="page"
+                  :total-results="totalResults"
+                  :per-page="perPage"
+                  :link-gen="paginationLink"
+                />
+              </client-only>
             </b-col>
           </b-row>
         </b-col>
@@ -134,32 +136,27 @@
 </template>
 
 <script>
-  import AlertMessage from '../../components/generic/AlertMessage';
   import SearchResults from '../../components/search/SearchResults'; // Sorted before InfoMessage to prevent Conflicting CSS sorting warning
   import InfoMessage from '../../components/generic/InfoMessage';
-  import FacetDropdown from '../../components/search/FacetDropdown';
-  import MoreFiltersDropdown from '../../components/search/MoreFiltersDropdown';
-  import SearchFilters from '../../components/search/SearchFilters';
-  import PaginationNav from '../../components/generic/PaginationNav';
   import ViewToggles from '../../components/search/ViewToggles';
-  import { thematicCollections } from '../../plugins/europeana/search';
 
   import isEqual from 'lodash/isEqual';
   import pickBy from 'lodash/pickBy';
   import { mapState, mapGetters } from 'vuex';
+  import { thematicCollections } from '../../plugins/europeana/search';
   import { queryUpdatesForFilters } from '../../store/search';
 
   export default {
     name: 'SearchInterface',
 
     components: {
-      AlertMessage,
+      AlertMessage: () => import('../../components/generic/AlertMessage'),
       InfoMessage,
-      FacetDropdown,
-      MoreFiltersDropdown,
+      FacetDropdown: () => import('../../components/search/FacetDropdown'),
+      MoreFiltersDropdown: () => import('../../components/search/MoreFiltersDropdown'),
       SearchResults,
-      SearchFilters,
-      PaginationNav,
+      SearchFilters: () => import('../../components/search/SearchFilters'),
+      PaginationNav: () => import('../../components/generic/PaginationNav'),
       ViewToggles
     },
     props: {

--- a/components/search/SearchInterface.vue
+++ b/components/search/SearchInterface.vue
@@ -136,9 +136,10 @@
 </template>
 
 <script>
-  import SearchResults from '../../components/search/SearchResults'; // Sorted before InfoMessage to prevent Conflicting CSS sorting warning
-  import InfoMessage from '../../components/generic/InfoMessage';
-  import ViewToggles from '../../components/search/ViewToggles';
+  import ClientOnly from 'vue-client-only';
+  import SearchResults from './SearchResults'; // Sorted before InfoMessage to prevent Conflicting CSS sorting warning
+  import InfoMessage from '../generic/InfoMessage';
+  import ViewToggles from './ViewToggles';
 
   import isEqual from 'lodash/isEqual';
   import pickBy from 'lodash/pickBy';
@@ -151,6 +152,7 @@
 
     components: {
       AlertMessage: () => import('../../components/generic/AlertMessage'),
+      ClientOnly,
       InfoMessage,
       FacetDropdown: () => import('../../components/search/FacetDropdown'),
       MoreFiltersDropdown: () => import('../../components/search/MoreFiltersDropdown'),

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,6 +1,8 @@
 <template>
   <div>
-    <CookieDisclaimer />
+    <client-only>
+      <CookieDisclaimer />
+    </client-only>
     <a
       class="skip-main"
       href="#main"
@@ -28,25 +30,43 @@
         id="main"
       />
     </main>
-    <PageFooter />
+    <client-only>
+      <PageFooter />
+    </client-only>
   </div>
 </template>
 
 <script>
-  import { mapGetters } from 'vuex';
+  import { mapGetters, mapState } from 'vuex';
 
-  import PageHeader from '../components/PageHeader.vue';
-  import PageFooter from '../components/PageFooter.vue';
+  import PageFooter from '../components/PageFooter';
+  import PageHeader from '../components/PageHeader';
   import CookieDisclaimer from '../components/generic/CookieDisclaimer';
+
+  const config = {
+    enableLanguageSelector: Boolean(Number(process.env['ENABLE_LANGUAGE_SELECTOR'])),
+    enableSuggestionValidation: Boolean(Number(process.env['ENABLE_ENTITY_SUGGESTION_RECORD_VALIDATION'])),
+    bootstrapVersion: require('bootstrap/package.json').version,
+    bootstrapVueVersion: require('bootstrap-vue/package.json').version
+  };
 
   export default {
     components: {
+      CookieDisclaimer,
       PageHeader,
-      PageFooter,
-      CookieDisclaimer
+      PageFooter
+    },
+
+    data() {
+      return {
+        ...config
+      };
     },
 
     computed: {
+      ...mapState({
+        breadcrumbs: state => state.breadcrumb.data
+      }),
       ...mapGetters({
         canonicalUrl: 'http/canonicalUrl',
         canonicalUrlWithoutLocale: 'http/canonicalUrlWithoutLocale'
@@ -55,21 +75,6 @@
         // Auto suggest on search form will be disabled unless toggled on by env var,
         // and always disabled on entity pages.
         return Boolean(Number(process.env['ENABLE_AUTOSUGGEST'])) && !(this.$store.state.entity && this.$store.state.entity.id);
-      },
-      enableLanguageSelector() {
-        return Boolean(Number(process.env['ENABLE_LANGUAGE_SELECTOR']));
-      },
-      enableSuggestionValidation() {
-        return Boolean(Number(process.env['ENABLE_ENTITY_SUGGESTION_RECORD_VALIDATION']));
-      },
-      breadcrumbs() {
-        return this.$store.state.breadcrumb.data;
-      },
-      bootstrapVersion() {
-        return require('bootstrap/package.json').version;
-      },
-      bootstrapVueVersion() {
-        return require('bootstrap-vue/package.json').version;
       }
     },
 
@@ -89,6 +94,7 @@
         meta: [
           { hid: 'description', property: 'description', content: 'Europeana' },
           { hid: 'og:url', property: 'og:url', content: this.canonicalUrl },
+          { hid: 'og:locale', property: 'og:locale', content: this.$i18n.isoLocale() },
           ...i18nSeo.meta
         ]
       };

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -39,6 +39,7 @@
 <script>
   import { mapGetters, mapState } from 'vuex';
 
+  import ClientOnly from 'vue-client-only';
   import PageHeader from '../components/PageHeader';
 
   const config = {
@@ -50,6 +51,7 @@
 
   export default {
     components: {
+      ClientOnly,
       CookieDisclaimer: () => import('../components/generic/CookieDisclaimer'),
       PageHeader,
       PageFooter: () => import('../components/PageFooter')

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -94,7 +94,6 @@
         meta: [
           { hid: 'description', property: 'description', content: 'Europeana' },
           { hid: 'og:url', property: 'og:url', content: this.canonicalUrl },
-          { hid: 'og:locale', property: 'og:locale', content: this.$i18n.isoLocale() },
           ...i18nSeo.meta
         ]
       };

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -39,9 +39,7 @@
 <script>
   import { mapGetters, mapState } from 'vuex';
 
-  import PageFooter from '../components/PageFooter';
   import PageHeader from '../components/PageHeader';
-  import CookieDisclaimer from '../components/generic/CookieDisclaimer';
 
   const config = {
     enableLanguageSelector: Boolean(Number(process.env['ENABLE_LANGUAGE_SELECTOR'])),
@@ -52,9 +50,9 @@
 
   export default {
     components: {
-      CookieDisclaimer,
+      CookieDisclaimer: () => import('../components/generic/CookieDisclaimer'),
       PageHeader,
-      PageFooter
+      PageFooter: () => import('../components/PageFooter')
     },
 
     data() {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "nuxt-i18n": "^6.10.1",
     "qs": "^6.6.0",
     "vue": "^2.6.11",
+    "vue-client-only": "^2.0.0",
     "vue-disqus": "^3.0.5",
     "vue-i18n": "^8.17.3",
     "vue-scrollto": "^2.17.1"

--- a/pages/blog/_.vue
+++ b/pages/blog/_.vue
@@ -59,18 +59,14 @@
   import { mapGetters } from 'vuex';
   import createClient from '../../plugins/contentful';
   import BlogPost from '../../components/blog/BlogPost';
-  import BlogTags from '../../components/blog/BlogTags';
-  import BlogAuthors from '../../components/blog/BlogAuthors';
-  import BlogCategories from '../../components/blog/BlogCategories';
-  import HeroImage from '../../components/generic/HeroImage';
 
   export default {
     components: {
       BlogPost,
-      BlogTags,
-      BlogAuthors,
-      BlogCategories,
-      HeroImage
+      BlogTags: () => import('../../components/blog/BlogTags'),
+      BlogAuthors: () => import('../../components/blog/BlogAuthors'),
+      BlogCategories: () => import('../../components/blog/BlogCategories'),
+      HeroImage: () => import('../../components/generic/HeroImage')
     },
 
     data() {

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -41,7 +41,6 @@
   import ContentHeader from '../../components/generic/ContentHeader';
   import createClient from '../../plugins/contentful';
   import ContentCard from '../../components/generic/ContentCard';
-  import PaginationNav from '../../components/generic/PaginationNav';
   import { pageFromQuery } from '../../plugins/utils';
 
   const PER_PAGE = 20;
@@ -51,7 +50,7 @@
     components: {
       ContentHeader,
       ContentCard,
-      PaginationNav
+      PaginationNav: () => import('../../components/generic/PaginationNav')
     },
 
     head() {

--- a/pages/collections/_type/_.vue
+++ b/pages/collections/_type/_.vue
@@ -76,10 +76,6 @@
 <script>
   import axios from 'axios';
 
-  import AlertMessage from '../../../components/generic/AlertMessage';
-  import EntityCards from '../../../components/entity/EntityCards';
-  import BrowseContentCard from '../../../components/browse/BrowseContentCard';
-  import BrowseSections from '../../../components/browse/BrowseSections';
   import EntityDetails from '../../../components/entity/EntityDetails';
   import SearchInterface from '../../../components/search/SearchInterface';
 
@@ -92,10 +88,10 @@
 
   export default {
     components: {
-      AlertMessage,
-      BrowseContentCard,
-      BrowseSections,
-      EntityCards,
+      AlertMessage: () => import('../../../components/generic/AlertMessage'),
+      BrowseContentCard: () => import('../../../components/browse/BrowseContentCard'),
+      BrowseSections: () => import('../../../components/browse/BrowseSections'),
+      EntityCards: () => import('../../../components/entity/EntityCards'),
       EntityDetails,
       SearchInterface
     },

--- a/pages/collections/_type/_.vue
+++ b/pages/collections/_type/_.vue
@@ -34,36 +34,40 @@
         md="3"
         class="pb-3"
       >
-        <h2
-          v-if="relatedEntities.length > 0"
-          class="related-heading text-uppercase"
-        >
-          {{ $t('contentYouMightLike') }}
-        </h2>
-        <section
-          v-if="relatedCollectionCards"
-        >
-          <BrowseContentCard
-            v-for="card in relatedCollectionCards"
-            :key="card.sys.id"
-            :fields="card.fields"
-            :card-type="card.sys.contentType ? card.sys.contentType.sys.id : ''"
-            :data-qa="card.fields.name + ' entity card'"
+        <client-only>
+          <h2
+            v-if="relatedEntities.length > 0"
+            class="related-heading text-uppercase"
+          >
+            {{ $t('contentYouMightLike') }}
+          </h2>
+          <section
+            v-if="relatedCollectionCards"
+          >
+            <BrowseContentCard
+              v-for="card in relatedCollectionCards"
+              :key="card.sys.id"
+              :fields="card.fields"
+              :card-type="card.sys.contentType ? card.sys.contentType.sys.id : ''"
+              :data-qa="card.fields.name + ' entity card'"
+            />
+          </section>
+          <EntityCards
+            v-else-if="relatedEntities"
+            :entities="relatedEntities"
+            data-qa="related entities"
           />
-        </section>
-        <EntityCards
-          v-else-if="relatedEntities"
-          :entities="relatedEntities"
-          data-qa="related entities"
-        />
+        </client-only>
       </b-col>
     </b-row>
     <b-row>
       <b-col>
-        <BrowseSections
-          v-if="page"
-          :sections="page.hasPart"
-        />
+        <client-only>
+          <BrowseSections
+            v-if="page"
+            :sections="page.hasPart"
+          />
+        </client-only>
       </b-col>
     </b-row>
   </b-container>

--- a/pages/collections/_type/_.vue
+++ b/pages/collections/_type/_.vue
@@ -76,6 +76,7 @@
 <script>
   import axios from 'axios';
 
+  import ClientOnly from 'vue-client-only';
   import EntityDetails from '../../../components/entity/EntityDetails';
   import SearchInterface from '../../../components/search/SearchInterface';
 
@@ -91,6 +92,7 @@
       AlertMessage: () => import('../../../components/generic/AlertMessage'),
       BrowseContentCard: () => import('../../../components/browse/BrowseContentCard'),
       BrowseSections: () => import('../../../components/browse/BrowseSections'),
+      ClientOnly,
       EntityCards: () => import('../../../components/entity/EntityCards'),
       EntityDetails,
       SearchInterface

--- a/pages/exhibitions/_exhibition/_chapter.vue
+++ b/pages/exhibitions/_exhibition/_chapter.vue
@@ -73,6 +73,7 @@
 
 <script>
   import createClient from '../../../plugins/contentful';
+  import ClientOnly from 'vue-client-only';
   import BrowseSections from '../../../components/browse/BrowseSections';
   import ExhibitionChapters from '../../../components/exhibition/ExhibitionChapters';
   import ExhibitionChaptersNavigation from '../../../components/exhibition/ExhibitionChaptersNavigation';
@@ -82,6 +83,7 @@
   export default {
     components: {
       BrowseSections,
+      ClientOnly,
       ExhibitionChapters,
       ExhibitionChaptersNavigation,
       HeroImage,

--- a/pages/exhibitions/_exhibition/_chapter.vue
+++ b/pages/exhibitions/_exhibition/_chapter.vue
@@ -49,22 +49,24 @@
           />
         </b-col>
       </b-row>
-      <b-row v-if="chapters">
-        <b-col class="my-3">
-          <ExhibitionChaptersNavigation
-            :exhibition-identifier="exhibitionIdentifier"
-            :chapter-navigation="chapterNavigation"
-          />
-          <h2 class="is-size-1-5">
-            {{ $t('exhibitions.chapters') }}
-          </h2>
-          <ExhibitionChapters
-            :exhibition-identifier="exhibitionIdentifier"
-            :chapters="chapters"
-            :credits="credits"
-          />
-        </b-col>
-      </b-row>
+      <client-only>
+        <b-row v-if="chapters">
+          <b-col class="my-3">
+            <ExhibitionChaptersNavigation
+              :exhibition-identifier="exhibitionIdentifier"
+              :chapter-navigation="chapterNavigation"
+            />
+            <h2 class="is-size-1-5">
+              {{ $t('exhibitions.chapters') }}
+            </h2>
+            <ExhibitionChapters
+              :exhibition-identifier="exhibitionIdentifier"
+              :chapters="chapters"
+              :credits="credits"
+            />
+          </b-col>
+        </b-row>
+      </client-only>
     </b-container>
   </div>
 </template>

--- a/pages/exhibitions/_exhibition/index.vue
+++ b/pages/exhibitions/_exhibition/index.vue
@@ -40,18 +40,20 @@
           />
         </b-col>
       </b-row>
-      <b-row v-if="page.hasPart">
-        <b-col class="my-3">
-          <h2 class="is-size-1-5">
-            {{ $t('exhibitions.chapters') }}
-          </h2>
-          <ExhibitionChapters
-            :exhibition-identifier="page.identifier"
-            :chapters="page.hasPart"
-            :credits="page.credits"
-          />
-        </b-col>
-      </b-row>
+      <client-only>
+        <b-row v-if="page.hasPart">
+          <b-col class="my-3">
+            <h2 class="is-size-1-5">
+              {{ $t('exhibitions.chapters') }}
+            </h2>
+            <ExhibitionChapters
+              :exhibition-identifier="page.identifier"
+              :chapters="page.hasPart"
+              :credits="page.credits"
+            />
+          </b-col>
+        </b-row>
+      </client-only>
     </b-container>
   </div>
 </template>

--- a/pages/exhibitions/_exhibition/index.vue
+++ b/pages/exhibitions/_exhibition/index.vue
@@ -40,20 +40,18 @@
           />
         </b-col>
       </b-row>
-      <client-only>
-        <b-row v-if="page.hasPart">
-          <b-col class="my-3">
-            <h2 class="is-size-1-5">
-              {{ $t('exhibitions.chapters') }}
-            </h2>
-            <ExhibitionChapters
-              :exhibition-identifier="page.identifier"
-              :chapters="page.hasPart"
-              :credits="page.credits"
-            />
-          </b-col>
-        </b-row>
-      </client-only>
+      <b-row v-if="page.hasPart">
+        <b-col class="my-3">
+          <h2 class="is-size-1-5">
+            {{ $t('exhibitions.chapters') }}
+          </h2>
+          <ExhibitionChapters
+            :exhibition-identifier="page.identifier"
+            :chapters="page.hasPart"
+            :credits="page.credits"
+          />
+        </b-col>
+      </b-row>
     </b-container>
   </div>
 </template>

--- a/pages/galleries/_.vue
+++ b/pages/galleries/_.vue
@@ -29,6 +29,7 @@
 </template>
 
 <script>
+  import ClientOnly from 'vue-client-only';
   import createClient from '../../plugins/contentful';
   import ContentHeader from '../../components/generic/ContentHeader';
 
@@ -37,6 +38,7 @@
   export default {
     name: 'ImageGallery',
     components: {
+      ClientOnly,
       ContentHeader,
       ContentCard: () => import('../../components/generic/ContentCard')
     },

--- a/pages/galleries/_.vue
+++ b/pages/galleries/_.vue
@@ -12,14 +12,16 @@
           deck
           data-qa="gallery images"
         >
-          <ContentCard
-            v-for="image in images"
-            :key="image.fields.identifier"
-            :title="imageTitle(image)"
-            :image-url="imageUrl(image)"
-            :lazy="false"
-            :url="{ name: 'item-all', params: { pathMatch: image.fields.identifier.slice(1) } }"
-          />
+          <client-only>
+            <ContentCard
+              v-for="image in images"
+              :key="image.fields.identifier"
+              :title="imageTitle(image)"
+              :image-url="imageUrl(image)"
+              :lazy="false"
+              :url="{ name: 'item-all', params: { pathMatch: image.fields.identifier.slice(1) } }"
+            />
+          </client-only>
         </b-card-group>
       </b-col>
     </b-row>
@@ -29,7 +31,6 @@
 <script>
   import createClient from '../../plugins/contentful';
   import ContentHeader from '../../components/generic/ContentHeader';
-  import ContentCard from '../../components/generic/ContentCard';
 
   import marked from 'marked';
 
@@ -37,7 +38,7 @@
     name: 'ImageGallery',
     components: {
       ContentHeader,
-      ContentCard
+      ContentCard: () => import('../../components/generic/ContentCard')
     },
     computed: {
       shareMediaUrl() {

--- a/pages/galleries/index.vue
+++ b/pages/galleries/index.vue
@@ -40,7 +40,6 @@
 <script>
   import ContentHeader from '../../components/generic/ContentHeader';
   import ContentCard from '../../components/generic/ContentCard';
-  import PaginationNav from '../../components/generic/PaginationNav';
   import createClient, { getLinkedItems } from '../../plugins/contentful';
   import { pageFromQuery } from '../../plugins/utils';
 
@@ -51,7 +50,7 @@
     components: {
       ContentHeader,
       ContentCard,
-      PaginationNav
+      PaginationNav: () => import('../../components/generic/PaginationNav')
     },
     head() {
       return {

--- a/pages/item/_.vue
+++ b/pages/item/_.vue
@@ -339,6 +339,29 @@
         });
     },
 
+    fetchOnServer: false,
+
+    fetch() {
+      const taggingAnnotationSearchParams = {
+        query: `target_record_id:"${this.identifier}"`,
+        profile: 'dereference',
+        qf:[
+          'motivation:tagging'
+        ]
+      };
+
+      axios.all([
+        Number(process.env['ENABLE_ITEM_TAGGING_ANNOTATIONS']) ? searchAnnotations(taggingAnnotationSearchParams) : [],
+        searchEntities(this.europeanaEntityUris),
+        this.getSimilarItems()
+      ])
+        .then(axios.spread((taggingAnnotations, entities, similar) => {
+          this.taggingAnnotations = taggingAnnotations;
+          this.relatedEntities = entities;
+          this.similarItems = similar.results;
+        }));
+    },
+
     created() {
       this.cardGridClass = this.isRichMedia && 'card-grid-richmedia';
     },
@@ -362,29 +385,6 @@
           this.selectedMedia.about = msg.data.id;
         }
       });
-    },
-
-    fetchOnServer: false,
-
-    fetch() {
-      const taggingAnnotationSearchParams = {
-        query: `target_record_id:"${this.identifier}"`,
-        profile: 'dereference',
-        qf:[
-          'motivation:tagging'
-        ]
-      };
-
-      axios.all([
-        Number(process.env['ENABLE_ITEM_TAGGING_ANNOTATIONS']) ? searchAnnotations(taggingAnnotationSearchParams) : [],
-        searchEntities(this.europeanaEntityUris),
-        this.getSimilarItems()
-      ])
-        .then(axios.spread((taggingAnnotations, entities, similar) => {
-          this.taggingAnnotations = taggingAnnotations;
-          this.relatedEntities = entities;
-          this.similarItems = similar.results;
-        }));
     },
 
     methods: {

--- a/pages/item/_.vue
+++ b/pages/item/_.vue
@@ -173,6 +173,7 @@
   import axios from 'axios';
   import { mapGetters } from 'vuex';
 
+  import ClientOnly from 'vue-client-only';
   import MediaActionBar from '../../components/item/MediaActionBar';
   import MediaPresentation from '../../components/item/MediaPresentation';
   import MetadataField from '../../components/item/MetadataField';
@@ -187,6 +188,7 @@
   export default {
     components: {
       AlertMessage: () => import('../../components/generic/AlertMessage'),
+      ClientOnly,
       EntityCards: () => import('../../components/entity/EntityCards'),
       MediaActionBar,
       SimilarItems: () => import('../../components/item/SimilarItems'),

--- a/pages/item/_.vue
+++ b/pages/item/_.vue
@@ -174,10 +174,8 @@
   import axios from 'axios';
   import { mapGetters } from 'vuex';
 
-  import AlertMessage from '../../components/generic/AlertMessage';
   import MediaActionBar from '../../components/item/MediaActionBar';
   import MediaPresentation from '../../components/item/MediaPresentation';
-  import MediaThumbnailGrid from '../../components/item/MediaThumbnailGrid';
   import MetadataField from '../../components/item/MetadataField';
 
   import { getRecord, similarItemsQuery } from '../../plugins/europeana/record';
@@ -186,18 +184,17 @@
   import { langMapValueForLocale } from  '../../plugins/europeana/utils';
   import { searchEntities } from '../../plugins/europeana/entity';
   import { search as searchAnnotations } from '../../plugins/europeana/annotation';
-  import NotificationBanner from '../../components/generic/NotificationBanner';
 
   export default {
     components: {
-      AlertMessage,
+      AlertMessage: () => import('../../components/generic/AlertMessage'),
       EntityCards: () => import('../../components/entity/EntityCards'),
       MediaActionBar,
       SimilarItems: () => import('../../components/item/SimilarItems'),
       MediaPresentation,
-      MediaThumbnailGrid,
+      MediaThumbnailGrid: () => import('../../components/item/MediaThumbnailGrid'),
       MetadataField,
-      NotificationBanner
+      NotificationBanner: () => import('../../components/generic/NotificationBanner')
     },
 
     data() {


### PR DESCRIPTION
This work seeks to improve performance, of SSRs in particular, by:
1. Moving the rendering of certain components to client-side only, where deemed auxilliary content
2. Having the footer render client-side brings a significant improvement to every page
3. Introducing code-splitting for some components where their use is conditional