### PR TITLE
Also use entity altLabel for suggestion matches

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,13 +54,6 @@ DISABLE_SSL_NEGOTIATION=1
 # If enabled, get & show suggestions for the search form. Disabled by default.
 # ENABLE_AUTOSUGGEST=0
 
-# If enabled, entity suggestions in the search form will be validated by searching
-# the Record API. If no records are found, the suggestions will be omitted.
-#
-# Warning: this results in a Record API search request for every single
-# suggestion. Typing 3 characters therefore results in 30 searches.
-# ENABLE_ENTITY_SUGGESTION_RECORD_VALIDATION=0
-
 # Retrieve and display tagging annotations on item pages.
 # ENABLE_ITEM_TAGGING_ANNOTATIONS=0
 

--- a/components/PageHeader.vue
+++ b/components/PageHeader.vue
@@ -40,7 +40,6 @@
         class="px-lg-3 mr-lg-auto mx-xl-auto"
         aria-label="search form"
         :enable-auto-suggest="enableAutoSuggest"
-        :enable-suggestion-validation="enableSuggestionValidation"
       />
     </header>
     <b-navbar
@@ -93,10 +92,6 @@
 
     props: {
       enableAutoSuggest: {
-        type: Boolean,
-        default: false
-      },
-      enableSuggestionValidation: {
         type: Boolean,
         default: false
       }

--- a/components/search/AutoSuggest.vue
+++ b/components/search/AutoSuggest.vue
@@ -22,7 +22,7 @@
       role="option"
       data-qa="search suggestion"
       :aria-selected="index === focus"
-      :to="linkGen(val[locale])"
+      :to="linkGen(val)"
       :class="{ 'hover': index === focus }"
       :data-index="index"
       @mouseover="focus = index"
@@ -55,17 +55,11 @@
 
     props: {
       // Property names are identifiers, emitted when suggestion is selected.
-      // Property values are lang maps for labels to display.
+      // Property values are the text for.the match
       // @example
       //     {
-      //       'http://data.europeana.eu/concept/base/83': {
-      //         en: 'World War I',
-      //         es: 'Primera Guerra Mundial'
-      //       },
-      //       'http://data.europeana.eu/concept/base/1615': {
-      //         en: 'gospel music',
-      //         es: 'góspel'
-      //       }
+      //       "http://data.europeana.eu/concept/base/83": "World War I",
+      //       "http://data.europeana.eu/agent/base/60496": "Poquelin, Jean-Baptiste"
       //     }
       value: {
         type: Object,
@@ -107,10 +101,6 @@
     },
 
     computed: {
-      locale() {
-        return this.$store.state.i18n.locale;
-      },
-
       suggestionValues() {
         return Object.keys(this.value);
       },
@@ -221,46 +211,13 @@
         }
       },
 
-      // Localise a lang map
-      //
-      // Order of priority:
-      // 1. User's UI language
-      // 2. English
-      // 3. First available value
-      localiseSuggestionLabel(value) {
-        if (value[this.locale]) {
-          return value[this.locale];
-        } else if (value.en) {
-          return value.en;
-        }
-        return Object.values(value)[0];
-      },
-
       // Highlight the user's query in a suggestion
       // FIXME: only re-highlight when new suggestions come in, not immediately
       //        after the query changes?
       highlightResult(value) {
-        let matchingValues = {};
-
         // Find all the suggestion labels that match the query
-        for (const locale in value) {
-          const string = value[locale];
-          const matches = match(string, this.query);
-          if (matches.length > 0) {
-            matchingValues[locale] = parse(string, matches);
-          }
-        }
-
-        // If any suggestions match, return the localised one with higlight
-        if (Object.values(matchingValues).length > 0) {
-          return this.localiseSuggestionLabel(matchingValues);
-        }
-
-        // No matches, so return a localised suggestion without highlight
-        return [{
-          text: this.localiseSuggestionLabel(value),
-          highlight: false
-        }];
+        const matches = match(value, this.query);
+        return parse(value, matches);
       },
 
       closeDropdown() {
@@ -270,9 +227,7 @@
       },
 
       selectSuggestion() {
-        if (this.selectedSuggestionLabel) {
-          this.$emit('select', this.selectedSuggestionLabel[this.locale]);
-        }
+        if (this.selectedSuggestionLabel) this.$emit('select', this.selectedSuggestionLabel);
       }
     }
   };

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -11,7 +11,6 @@
     <PageHeader
       :enable-auto-suggest="enableAutoSuggest"
       :enable-language-selector="enableLanguageSelector"
-      :enable-suggestion-validation="enableSuggestionValidation"
     />
     <main role="main">
       <b-container v-if="breadcrumbs">
@@ -58,9 +57,6 @@
       },
       enableLanguageSelector() {
         return Boolean(Number(process.env['ENABLE_LANGUAGE_SELECTOR']));
-      },
-      enableSuggestionValidation() {
-        return Boolean(Number(process.env['ENABLE_ENTITY_SUGGESTION_RECORD_VALIDATION']));
       },
       breadcrumbs() {
         return this.$store.state.breadcrumb.data;

--- a/plugins/europeana/entity.js
+++ b/plugins/europeana/entity.js
@@ -1,7 +1,6 @@
 import axios from 'axios';
 import { apiError, langMapValueForLocale } from './utils';
 import { config } from './';
-import { search } from './search';
 
 /**
  * Get data for one entity from the API
@@ -35,11 +34,8 @@ function entityApiUrl(endpoint) {
  * @param {string} text the query text to supply suggestions for
  * @param {Object} params additional parameters sent to the API
  * @param {string} params.language language(s), comma-separated, to request
- * @param {Object} options optional settings
- * @param {boolean} options.recordValidation if `true`, filter suggestions to those with record matches
- * @return {Object[]} entity suggestions from the API
  */
-export function getEntitySuggestions(text, params = {}, options = {}) {
+export function getEntitySuggestions(text, params = {}) {
   return axios.get(entityApiUrl('/suggest'), {
     params: {
       text,
@@ -50,31 +46,11 @@ export function getEntitySuggestions(text, params = {}, options = {}) {
     }
   })
     .then((response) => {
-      if (!response.data.items) return [];
-      return options.recordValidation ? filterSuggestionsByRecordValidation(response.data.items) : response.data.items;
+      return response.data.items ? response.data.items : [];
     })
     .catch((error) => {
       throw apiError(error);
     });
-}
-
-function filterSuggestionsByRecordValidation(suggestions) {
-  const searches = suggestions.map((entity) => {
-    return search({
-      query: getEntityQuery(entity.id),
-      rows: 0,
-      profile: 'minimal',
-      qf: ['contentTier:(2 OR 3 OR 4)']
-    });
-  });
-
-  return axios.all(searches)
-    .then(axios.spread(function() {
-      const searchResponses = arguments;
-      return suggestions.filter((entity, index) => {
-        return searchResponses[index].totalResults > 0;
-      });
-    }));
 }
 
 /**

--- a/tests/unit/components/search/AutoSuggest.spec.js
+++ b/tests/unit/components/search/AutoSuggest.spec.js
@@ -46,16 +46,9 @@ const store = (options = {}) => {
 
 const query = 'dor';
 const suggestions = {
-  'http://data.europeana.eu/concept/base/17': {
-    en: 'Manuscript',
-    sq: 'Dorëshkrimi'
-  },
-  'http://data.europeana.eu/agent/base/57083': {
-    en: 'Gustave Doré'
-  },
-  'http://data.europeana.eu/agent/base/146799': {
-    en: 'Doris Day'
-  }
+  'http://data.europeana.eu/concept/base/17': 'Dorëshkrimi',
+  'http://data.europeana.eu/agent/base/57083': 'Gustave Doré',
+  'http://data.europeana.eu/agent/base/146799': 'Doris Day'
 };
 
 describe('components/search/AutoSuggest', () => {
@@ -91,7 +84,7 @@ describe('components/search/AutoSuggest', () => {
       suggestionElements.length.should.eq(suggestionValues.length);
 
       suggestionValues.forEach((value, index) => {
-        Object.values(value).should.include(suggestionElements.at(index).text());
+        value.should.include(suggestionElements.at(index).text());
       });
     });
 


### PR DESCRIPTION
In addition:
* Remove the unused & experimental entity suggestion validation against record existence
* Stop passing lang maps to the auto-suggest as only ever one will now be present; instead just pass the matching string literal
