### PR TITLE
Fix for initial list view detection

### DIFF
--- a/components/search/SearchInterface.vue
+++ b/components/search/SearchInterface.vue
@@ -308,21 +308,20 @@
       }
     },
     watch: {
-      routeQueryView() {
-        this.view = this.routeQueryView;
-      },
+      routeQueryView: 'viewFromRouteQuery',
       contentTierZeroPresent: 'showContentTierToast',
       contentTierZeroActive: 'showContentTierToast'
     },
     fetch() {
-      // FIXME: this is a quick fix to ensure it's set on initial SSR, but duplicates
-      //        the `routeQueryView` watch.
-      this.view = this.routeQueryView;
+      this.viewFromRouteQuery();
     },
     mounted() {
       this.showContentTierToast();
     },
     methods: {
+      viewFromRouteQuery() {
+        if (this.routeQueryView) this.view = this.routeQueryView;
+      },
       facetDropdownType(name) {
         return name === 'collection' ? 'radio' : 'checkbox';
       },

--- a/components/search/SearchInterface.vue
+++ b/components/search/SearchInterface.vue
@@ -183,6 +183,11 @@
         PROXY_DCTERMS_ISSUED: 'proxy_dcterms_issued'
       };
     },
+    fetch() {
+      // FIXME: this is a quick fix to ensure it's set on initial SSR, but duplicates
+      //        the `routeQueryView` watch.
+      this.view = this.routeQueryView;
+    },
     computed: {
       ...mapState({
         userParams: state => state.search.userParams,

--- a/components/search/SearchInterface.vue
+++ b/components/search/SearchInterface.vue
@@ -183,11 +183,6 @@
         PROXY_DCTERMS_ISSUED: 'proxy_dcterms_issued'
       };
     },
-    fetch() {
-      // FIXME: this is a quick fix to ensure it's set on initial SSR, but duplicates
-      //        the `routeQueryView` watch.
-      this.view = this.routeQueryView;
-    },
     computed: {
       ...mapState({
         userParams: state => state.search.userParams,
@@ -318,6 +313,11 @@
       },
       contentTierZeroPresent: 'showContentTierToast',
       contentTierZeroActive: 'showContentTierToast'
+    },
+    fetch() {
+      // FIXME: this is a quick fix to ensure it's set on initial SSR, but duplicates
+      //        the `routeQueryView` watch.
+      this.view = this.routeQueryView;
     },
     mounted() {
       this.showContentTierToast();


### PR DESCRIPTION
This would be a temporary fix for initial load and detection of the 'view' param.
There are issues/inconsistencies with preservation of the param when navigating after the initial load. 