### PR TITLE
Metadata box refactor

### DIFF
--- a/components/item/MetadataBox.stories.js
+++ b/components/item/MetadataBox.stories.js
@@ -1,6 +1,5 @@
 import { storiesOf } from '@storybook/vue';
 import VueI18n from 'vue-i18n';
-import StoryRouter from 'storybook-vue-router';
 import MetadataBox from './MetadataBox';
 
 const i18n = new VueI18n({
@@ -70,7 +69,7 @@ const i18n = new VueI18n({
 });
 
 const formattedMetadata = {
-  coreFields: {
+  coreMetadata: {
     edmDataProvider: {
       def: ['Provider']
     },
@@ -86,7 +85,7 @@ const formattedMetadata = {
     },
     dcType: { en: ['Format'] }
   },
-  allMetaData: {
+  allMetadata: {
     edmDataProvider: {
       def: ['Provider']
     },
@@ -123,12 +122,7 @@ const formattedMetadata = {
   transcribingAnnotations: []
 };
 
-storiesOf('Item page', module)
-  .addDecorator(StoryRouter({}, {
-    routes: [
-      { name: 'item-all', path: '/item/*' }
-    ]
-  }))
+storiesOf('Item page/MetadataBox', module)
   .add('Metadata Box 12 columns', () => ({
     i18n,
     components: { MetadataBox },
@@ -142,8 +136,8 @@ storiesOf('Item page', module)
           lg="12"
         >
           <metadata-box
-            :all-meta-data="allMetaData"
-            :core-fields="coreFields"
+            :all-metadata="allMetadata"
+            :core-metadata="coreMetadata"
             :transcribing-annotations="transcribingAnnotations"
           />
         </b-col>
@@ -162,8 +156,8 @@ storiesOf('Item page', module)
           lg="9"
         >
           <metadata-box
-            :all-meta-data="allMetaData"
-            :core-fields="coreFields"
+            :all-metadata="allMetadata"
+            :core-metadata="coreMetadata"
             :transcribing-annotations="transcribingAnnotations"
           />
         </b-col>

--- a/components/item/MetadataBox.stories.js
+++ b/components/item/MetadataBox.stories.js
@@ -1,0 +1,145 @@
+import { storiesOf } from '@storybook/vue';
+import VueI18n from 'vue-i18n';
+import StoryRouter from 'storybook-vue-router';
+import MetadataBox from './MetadataBox';
+
+const i18n = new VueI18n({
+  locale: 'en',
+  messages: {
+    en: {
+      'record.goodToKnow': 'Good to konw',
+      'record.allMetaData': 'All metadata',
+      'fieldLabels': {
+        'default': {
+          'dcContributor': 'Contributors',
+          'dcCoverage': 'Place-Time',
+          'dcCreator': 'Creator',
+          'dcDate': 'Date',
+          'dcDescription': 'Description',
+          'dcDuration': 'Duration',
+          'dcFormat': 'Format',
+          'dcIdentifier': 'Identifier',
+          'dcLanguage': 'Language',
+          'dcMedium': 'Medium',
+          'dcPublisher': 'Publisher',
+          'dcRelation': 'Relations',
+          'dcRights': 'Rights',
+          'dcSource': 'Source',
+          'dcSubject': 'Subject',
+          'dctermsCreated': 'Creation date',
+          'dctermsExtent': 'Extent',
+          'dctermsHasPart': 'Consists of',
+          'dctermsHasVersion': 'Has version',
+          'dctermsIsFormatOf': 'Is format of',
+          'dctermsIsPartOf': 'Is part of',
+          'dctermsIsReferencedBy': 'Is referenced by',
+          'dctermsIsReplacedBy': 'Is replaced by',
+          'dctermsIsRequiredBy': 'Is required by',
+          'dctermsIssued': 'Issue date',
+          'dctermsMedium': 'Medium',
+          'dctermsProvenance': 'Provenance',
+          'dctermsPublished': 'Publication date',
+          'dctermsReferences': 'References',
+          'dctermsSpatial': 'Places',
+          'dctermsTemporal': 'Temporal',
+          'dcTitle': 'Title',
+          'dcType': 'Type of object',
+          'edmCountry': 'Providing country',
+          'edmCurrentLocation': 'Current location',
+          'edmDataProvider': 'Providing institution',
+          'edmHasMet': 'Has Met',
+          'edmIncorporates': 'Incorporates',
+          'edmIntermediateProvider': 'Intermediate provider',
+          'edmIsDerivativeOf': 'Is derivative of',
+          'edmIsRepresentationOf': 'Is representation of',
+          'edmIsSimilarTo': 'Is similar to',
+          'edmIsSuccessorOf': 'Is successor of',
+          'edmProvider': 'Provider',
+          'edmRealizes': 'Realises',
+          'edmRights': 'Rights statement for the media in this item (unless otherwise specified)',
+          'edmUgc': 'User generated content',
+          'europeanaCollectionName': 'Collection name',
+          'keywords': 'Keywords (provided by the community)',
+          'timestampCreated': 'Timestamp created',
+          'timestampUpdate': 'Timestamp updated',
+          'wasPresentAt': 'Was present at'
+        }
+      }
+    }
+  }
+});
+
+storiesOf('Item page', module)
+  .addDecorator(StoryRouter({}, {
+    routes: [
+      { name: 'item-all', path: '/item/*' }
+    ]
+  }))
+  .add('Metadata Box', () => ({
+    i18n,
+    components: { MetadataBox },
+    data() {
+      return {
+        coreFields: {
+          edmDataProvider: {
+            def: ['Provider']
+          },
+          dcContributor: {
+            en: ['Contributor']
+          },
+          dcSubject: {
+            de: ['Subjekt'],
+            def: [{
+              about: 'https://term.museum-digital.de/md-de/tag/132',
+              prefLabel: { de: ['Fotografie'], en: ['Photography'] }
+            }]
+          },
+          dcType: { en: ['Format'] }
+        },
+        allMetaData: {
+          edmDataProvider: {
+            def: ['Provider']
+          },
+          dcContributor: {
+            en: ['Contributor']
+          },
+          dcSubject: {
+            de: ['Subjekt'],
+            def: [{
+              about: 'https://term.museum-digital.de/md-de/tag/132',
+              prefLabel: { de: ['Fotografie'], en: ['Photography'] }
+            }]
+          },
+          dcType: { en: ['Format'] },
+          edmProvider: { def: ['Provider'] },
+          edmIntermediateProvider: { def: ['museum-digital'] },
+          edmCountry: { def: ['Germany'] },
+          edmRights: { def: ['https://creativecommons.org/publicdomain/mark/1.0/'] },
+          dcRights: { de: ['AlliiertenMuseum'] },
+          dctermsCreated: { de: ['1994'] },
+          dctermsSpatial: { de: ['Straße des 17. Juni (Berlin)'] },
+          edmUgc: 'false',
+          dctermsProvenance: { de: ['AlliiertenMuseum, Berlin'] },
+          dcIdentifier: { def: ['B 2018/05.06542 (inventory number)', 'http://mint-projects.image.ntua.gr/Museu/ProvidedCHO/museum-digital/48697 (technical number)'] },
+          europeanaCollectionName: ['247_AlliedMuseum'],
+          timestampCreated: '2020-07-15T22:01:31.356Z',
+          timestampUpdate: '2020-07-15T22:01:31.356Z',
+          dctermsExtent: { de: ['24 x 36 mm'] },
+          dcFormat: {
+            en: ['Photography']
+          },
+          keywords: {}
+        },
+        transcribingAnnotations: []
+      };
+    },
+    template: ` <b-container
+      class="mt-3"
+      >
+        <metadata-box
+          :all-meta-data="allMetaData"
+          :core-fields="coreFields"
+          :transcribing-annotations="transcribingAnnotations"
+        />
+      </b-container>`
+  }));

--- a/components/item/MetadataBox.stories.js
+++ b/components/item/MetadataBox.stories.js
@@ -75,7 +75,7 @@ storiesOf('Item page', module)
       { name: 'item-all', path: '/item/*' }
     ]
   }))
-  .add('Metadata Box', () => ({
+  .add('Metadata Box 12 columns', () => ({
     i18n,
     components: { MetadataBox },
     data() {
@@ -133,13 +133,90 @@ storiesOf('Item page', module)
         transcribingAnnotations: []
       };
     },
-    template: ` <b-container
-      class="mt-3"
-      >
-        <metadata-box
-          :all-meta-data="allMetaData"
-          :core-fields="coreFields"
-          :transcribing-annotations="transcribingAnnotations"
-        />
-      </b-container>`
+    template: `<b-container>
+      <b-row class="my-5">
+        <b-col
+          cols="12"
+          lg="12"
+        >
+          <metadata-box
+            :all-meta-data="allMetaData"
+            :core-fields="coreFields"
+            :transcribing-annotations="transcribingAnnotations"
+          />
+        </b-col>
+      </b-row>
+    </b-container>`
+  })).add('Metadata Box 9 columns', () => ({
+    i18n,
+    components: { MetadataBox },
+    data() {
+      return {
+        coreFields: {
+          edmDataProvider: {
+            def: ['Provider']
+          },
+          dcContributor: {
+            en: ['Contributor']
+          },
+          dcSubject: {
+            de: ['Subjekt'],
+            def: [{
+              about: 'https://term.museum-digital.de/md-de/tag/132',
+              prefLabel: { de: ['Fotografie'], en: ['Photography'] }
+            }]
+          },
+          dcType: { en: ['Format'] }
+        },
+        allMetaData: {
+          edmDataProvider: {
+            def: ['Provider']
+          },
+          dcContributor: {
+            en: ['Contributor']
+          },
+          dcSubject: {
+            de: ['Subjekt'],
+            def: [{
+              about: 'https://term.museum-digital.de/md-de/tag/132',
+              prefLabel: { de: ['Fotografie'], en: ['Photography'] }
+            }]
+          },
+          dcType: { en: ['Format'] },
+          edmProvider: { def: ['Provider'] },
+          edmIntermediateProvider: { def: ['museum-digital'] },
+          edmCountry: { def: ['Germany'] },
+          edmRights: { def: ['https://creativecommons.org/publicdomain/mark/1.0/'] },
+          dcRights: { de: ['AlliiertenMuseum'] },
+          dctermsCreated: { de: ['1994'] },
+          dctermsSpatial: { de: ['Straße des 17. Juni (Berlin)'] },
+          edmUgc: 'false',
+          dctermsProvenance: { de: ['AlliiertenMuseum, Berlin'] },
+          dcIdentifier: { def: ['B 2018/05.06542 (inventory number)', 'http://mint-projects.image.ntua.gr/Museu/ProvidedCHO/museum-digital/48697 (technical number)'] },
+          europeanaCollectionName: ['247_AlliedMuseum'],
+          timestampCreated: '2020-07-15T22:01:31.356Z',
+          timestampUpdate: '2020-07-15T22:01:31.356Z',
+          dctermsExtent: { de: ['24 x 36 mm'] },
+          dcFormat: {
+            en: ['Photography']
+          },
+          keywords: {}
+        },
+        transcribingAnnotations: []
+      };
+    },
+    template: `<b-container>
+      <b-row class="my-5">
+        <b-col
+          cols="12"
+          lg="9"
+        >
+          <metadata-box
+            :all-meta-data="allMetaData"
+            :core-fields="coreFields"
+            :transcribing-annotations="transcribingAnnotations"
+          />
+        </b-col>
+      </b-row>
+    </b-container>`
   }));

--- a/components/item/MetadataBox.stories.js
+++ b/components/item/MetadataBox.stories.js
@@ -69,6 +69,60 @@ const i18n = new VueI18n({
   }
 });
 
+const formattedMetadata = {
+  coreFields: {
+    edmDataProvider: {
+      def: ['Provider']
+    },
+    dcContributor: {
+      en: ['Contributor']
+    },
+    dcSubject: {
+      de: ['Subjekt'],
+      def: [{
+        about: 'https://term.museum-digital.de/md-de/tag/132',
+        prefLabel: { de: ['Fotografie'], en: ['Photography'] }
+      }]
+    },
+    dcType: { en: ['Format'] }
+  },
+  allMetaData: {
+    edmDataProvider: {
+      def: ['Provider']
+    },
+    dcContributor: {
+      en: ['Contributor']
+    },
+    dcSubject: {
+      de: ['Subjekt'],
+      def: [{
+        about: 'https://term.museum-digital.de/md-de/tag/132',
+        prefLabel: { de: ['Fotografie'], en: ['Photography'] }
+      }]
+    },
+    dcType: { en: ['Format'] },
+    edmProvider: { def: ['Provider'] },
+    edmIntermediateProvider: { def: ['museum-digital'] },
+    edmCountry: { def: ['Germany'] },
+    edmRights: { def: ['https://creativecommons.org/publicdomain/mark/1.0/'] },
+    dcRights: { de: ['AlliiertenMuseum'] },
+    dctermsCreated: { de: ['1994'] },
+    dctermsSpatial: { de: ['Straße des 17. Juni (Berlin)'] },
+    edmUgc: 'false',
+    dctermsProvenance: { de: ['AlliiertenMuseum, Berlin'] },
+    dcIdentifier: { def: ['B 2018/05.06542 (inventory number)', 'http://mint-projects.image.ntua.gr/Museu/ProvidedCHO/museum-digital/48697 (technical number)'] },
+    europeanaCollectionName: ['247_AlliedMuseum'],
+    timestampCreated: '2020-07-15T22:01:31.356Z',
+    timestampUpdate: '2020-07-15T22:01:31.356Z',
+    dctermsExtent: { de: ['24 x 36 mm'] },
+    dcFormat: {
+      en: ['Photography']
+    },
+    keywords: {}
+  },
+  transcribingAnnotations: []
+};
+
 storiesOf('Item page', module)
   .addDecorator(StoryRouter({}, {
     routes: [
@@ -79,59 +133,7 @@ storiesOf('Item page', module)
     i18n,
     components: { MetadataBox },
     data() {
-      return {
-        coreFields: {
-          edmDataProvider: {
-            def: ['Provider']
-          },
-          dcContributor: {
-            en: ['Contributor']
-          },
-          dcSubject: {
-            de: ['Subjekt'],
-            def: [{
-              about: 'https://term.museum-digital.de/md-de/tag/132',
-              prefLabel: { de: ['Fotografie'], en: ['Photography'] }
-            }]
-          },
-          dcType: { en: ['Format'] }
-        },
-        allMetaData: {
-          edmDataProvider: {
-            def: ['Provider']
-          },
-          dcContributor: {
-            en: ['Contributor']
-          },
-          dcSubject: {
-            de: ['Subjekt'],
-            def: [{
-              about: 'https://term.museum-digital.de/md-de/tag/132',
-              prefLabel: { de: ['Fotografie'], en: ['Photography'] }
-            }]
-          },
-          dcType: { en: ['Format'] },
-          edmProvider: { def: ['Provider'] },
-          edmIntermediateProvider: { def: ['museum-digital'] },
-          edmCountry: { def: ['Germany'] },
-          edmRights: { def: ['https://creativecommons.org/publicdomain/mark/1.0/'] },
-          dcRights: { de: ['AlliiertenMuseum'] },
-          dctermsCreated: { de: ['1994'] },
-          dctermsSpatial: { de: ['Straße des 17. Juni (Berlin)'] },
-          edmUgc: 'false',
-          dctermsProvenance: { de: ['AlliiertenMuseum, Berlin'] },
-          dcIdentifier: { def: ['B 2018/05.06542 (inventory number)', 'http://mint-projects.image.ntua.gr/Museu/ProvidedCHO/museum-digital/48697 (technical number)'] },
-          europeanaCollectionName: ['247_AlliedMuseum'],
-          timestampCreated: '2020-07-15T22:01:31.356Z',
-          timestampUpdate: '2020-07-15T22:01:31.356Z',
-          dctermsExtent: { de: ['24 x 36 mm'] },
-          dcFormat: {
-            en: ['Photography']
-          },
-          keywords: {}
-        },
-        transcribingAnnotations: []
-      };
+      return formattedMetadata;
     },
     template: `<b-container>
       <b-row class="my-5">
@@ -151,59 +153,7 @@ storiesOf('Item page', module)
     i18n,
     components: { MetadataBox },
     data() {
-      return {
-        coreFields: {
-          edmDataProvider: {
-            def: ['Provider']
-          },
-          dcContributor: {
-            en: ['Contributor']
-          },
-          dcSubject: {
-            de: ['Subjekt'],
-            def: [{
-              about: 'https://term.museum-digital.de/md-de/tag/132',
-              prefLabel: { de: ['Fotografie'], en: ['Photography'] }
-            }]
-          },
-          dcType: { en: ['Format'] }
-        },
-        allMetaData: {
-          edmDataProvider: {
-            def: ['Provider']
-          },
-          dcContributor: {
-            en: ['Contributor']
-          },
-          dcSubject: {
-            de: ['Subjekt'],
-            def: [{
-              about: 'https://term.museum-digital.de/md-de/tag/132',
-              prefLabel: { de: ['Fotografie'], en: ['Photography'] }
-            }]
-          },
-          dcType: { en: ['Format'] },
-          edmProvider: { def: ['Provider'] },
-          edmIntermediateProvider: { def: ['museum-digital'] },
-          edmCountry: { def: ['Germany'] },
-          edmRights: { def: ['https://creativecommons.org/publicdomain/mark/1.0/'] },
-          dcRights: { de: ['AlliiertenMuseum'] },
-          dctermsCreated: { de: ['1994'] },
-          dctermsSpatial: { de: ['Straße des 17. Juni (Berlin)'] },
-          edmUgc: 'false',
-          dctermsProvenance: { de: ['AlliiertenMuseum, Berlin'] },
-          dcIdentifier: { def: ['B 2018/05.06542 (inventory number)', 'http://mint-projects.image.ntua.gr/Museu/ProvidedCHO/museum-digital/48697 (technical number)'] },
-          europeanaCollectionName: ['247_AlliedMuseum'],
-          timestampCreated: '2020-07-15T22:01:31.356Z',
-          timestampUpdate: '2020-07-15T22:01:31.356Z',
-          dctermsExtent: { de: ['24 x 36 mm'] },
-          dcFormat: {
-            en: ['Photography']
-          },
-          keywords: {}
-        },
-        transcribingAnnotations: []
-      };
+      return formattedMetadata;
     },
     template: `<b-container>
       <b-row class="my-5">

--- a/components/item/MetadataBox.vue
+++ b/components/item/MetadataBox.vue
@@ -87,7 +87,3 @@
     }
   };
 </script>
-
-<style lang="scss" scoped>
-
-</style>

--- a/components/item/MetadataBox.vue
+++ b/components/item/MetadataBox.vue
@@ -14,7 +14,7 @@
             data-qa="main metadata section"
           >
             <MetadataField
-              v-for="(value, name) in coreFields"
+              v-for="(value, name) in coreMetadata"
               :key="name"
               :name="name"
               :field-data="value"
@@ -28,7 +28,7 @@
             text-tag="div"
           >
             <MetadataField
-              v-for="(value, name) in allMetaData"
+              v-for="(value, name) in allMetadata"
               :key="name"
               :name="name"
               :field-data="value"
@@ -72,11 +72,11 @@
       MetadataField
     },
     props: {
-      coreFields: {
+      coreMetadata: {
         type: Object,
         default: null
       },
-      allMetaData: {
+      allMetadata: {
         type: Object,
         default: null
       },

--- a/components/item/MetadataBox.vue
+++ b/components/item/MetadataBox.vue
@@ -1,0 +1,93 @@
+<template>
+  <div>
+    <b-card
+      no-body
+      class="mb-3 rounded-0"
+    >
+      <b-tabs card>
+        <b-tab
+          :title="$t('record.goodToKnow')"
+          active
+        >
+          <b-card-text
+            text-tag="div"
+            data-qa="main metadata section"
+          >
+            <MetadataField
+              v-for="(value, name) in coreFields"
+              :key="name"
+              :name="name"
+              :field-data="value"
+            />
+          </b-card-text>
+        </b-tab>
+        <b-tab
+          :title="$t('record.allMetaData')"
+        >
+          <b-card-text
+            text-tag="div"
+          >
+            <MetadataField
+              v-for="(value, name) in allMetaData"
+              :key="name"
+              :name="name"
+              :field-data="value"
+            />
+          </b-card-text>
+        </b-tab>
+        <b-tab
+          v-if="Boolean(transcribingAnnotations.length)"
+          :title="$t('record.transcription')"
+        >
+          <b-card-text
+            text-tag="div"
+          >
+            <p
+              class="disclaimer px-2 pb-3 d-flex"
+            >
+              {{ $t('record.transcriptionDisclaimer') }}
+            </p>
+            <div
+              v-for="(transcription, index) in transcribingAnnotations"
+              :key="index"
+              :lang="transcription.body.language"
+            >
+              <p>{{ transcription.body.value }}</p>
+              <hr
+                v-if="index !== (transcribingAnnotations.length - 1)"
+              >
+            </div>
+          </b-card-text>
+        </b-tab>
+      </b-tabs>
+    </b-card>
+  </div>
+</template>
+
+<script>
+  import MetadataField from './MetadataField';
+  export default {
+    name: 'MetadataBox',
+    components: {
+      MetadataField
+    },
+    props: {
+      coreFields: {
+        type: Object,
+        default: null
+      },
+      allMetaData: {
+        type: Object,
+        default: null
+      },
+      transcribingAnnotations: {
+        type: Array,
+        default: () => []
+      }
+    }
+  };
+</script>
+
+<style lang="scss" scoped>
+
+</style>

--- a/pages/item/_.vue
+++ b/pages/item/_.vue
@@ -97,69 +97,11 @@
             />
           </div>
 
-          <div>
-            <b-card
-              no-body
-              class="mb-3 rounded-0"
-            >
-              <b-tabs card>
-                <b-tab
-                  :title="$t('record.goodToKnow')"
-                  active
-                >
-                  <b-card-text
-                    text-tag="div"
-                    data-qa="main metadata section"
-                  >
-                    <MetadataField
-                      v-for="(value, name) in coreFields"
-                      :key="name"
-                      :name="name"
-                      :field-data="value"
-                    />
-                  </b-card-text>
-                </b-tab>
-                <b-tab
-                  :title="$t('record.allMetaData')"
-                >
-                  <b-card-text
-                    text-tag="div"
-                  >
-                    <MetadataField
-                      v-for="(value, name) in allMetaData"
-                      :key="name"
-                      :name="name"
-                      :field-data="value"
-                    />
-                  </b-card-text>
-                </b-tab>
-                <b-tab
-                  v-if="Boolean(transcribingAnnotations.length)"
-                  :title="$t('record.transcription')"
-                >
-                  <b-card-text
-                    text-tag="div"
-                  >
-                    <p
-                      class="disclaimer px-2 pb-3 d-flex"
-                    >
-                      {{ $t('record.transcriptionDisclaimer') }}
-                    </p>
-                    <div
-                      v-for="(transcription, index) in transcribingAnnotations"
-                      :key="index"
-                      :lang="transcription.body.language"
-                    >
-                      <p>{{ transcription.body.value }}</p>
-                      <hr
-                        v-if="index !== (transcribingAnnotations.length - 1)"
-                      >
-                    </div>
-                  </b-card-text>
-                </b-tab>
-              </b-tabs>
-            </b-card>
-          </div>
+          <MetadataBox
+            :all-meta-data="allMetaData"
+            :core-fields="coreFields"
+            :transcribing-annotations="transcribingAnnotations"
+          />
 
           <section
             v-if="similarItems.length > 0"
@@ -199,7 +141,7 @@
   import ClientOnly from 'vue-client-only';
   import MediaActionBar from '../../components/item/MediaActionBar';
   import MediaPresentation from '../../components/item/MediaPresentation';
-  import MetadataField from '../../components/item/MetadataField';
+  import MetadataBox from '../../components/item/MetadataBox';
 
   import { getRecord, similarItemsQuery } from '../../plugins/europeana/record';
   import { search } from '../../plugins/europeana/search';
@@ -217,7 +159,7 @@
       SimilarItems: () => import('../../components/item/SimilarItems'),
       MediaPresentation,
       MediaThumbnailGrid: () => import('../../components/item/MediaThumbnailGrid'),
-      MetadataField,
+      MetadataBox,
       NotificationBanner: () => import('../../components/generic/NotificationBanner')
     },
 

--- a/pages/item/_.vue
+++ b/pages/item/_.vue
@@ -98,8 +98,8 @@
           </div>
 
           <MetadataBox
-            :all-meta-data="allMetaData"
-            :core-fields="coreFields"
+            :all-metadata="allMetaData"
+            :core-metadata="coreFields"
             :transcribing-annotations="transcribingAnnotations"
           />
 


### PR DESCRIPTION
Refactor the metadatabox into it's own component in order to use it in storybook and demonstrate how it expands to the width of it's container.