### PR TITLE
API request logger & display

### DIFF
--- a/assets/scss/modal.scss
+++ b/assets/scss/modal.scss
@@ -26,4 +26,32 @@
     justify-content: space-between;
     padding: 1rem 0;
   }
+  &#api-requests {
+    font-family: $font-family-sans-serif;
+    .modal-title {
+      font-size: 1.5rem;
+      font-weight: 600;
+    }
+    ol {
+      list-style: none;
+      counter-reset: item;
+      padding-left: 0;
+    }
+    li {
+      counter-increment: item;
+      margin-bottom: 10px;
+      line-height: 1.2;
+      padding-left: 2rem;
+    }
+    li:before {
+      content: counter(item);
+      margin-left: -2rem;
+      background: #e83e8c;
+      border-radius: 100%;
+      color: white;
+      width: 1.2rem;
+      text-align: center;
+      display: inline-block;
+    }
+  }
 }

--- a/components/PageFooter.vue
+++ b/components/PageFooter.vue
@@ -62,6 +62,10 @@
             </figcaption>
             <LangSelector data-qa="language selector" />
           </figure>
+          <ApiRequests
+            v-if="showApiRequestsModal"
+            :requests="axiosLoggerRequests"
+          />
         </b-col>
       </b-row>
       <hr class="my-5">
@@ -85,11 +89,14 @@
 </template>
 
 <script>
+  import { mapState } from 'vuex';
+
   import LangSelector from './generic/LanguageSelector';
   import LinkGroup from './generic/LinkGroup';
 
   export default {
     components: {
+      ApiRequests: () => import('./debug/ApiRequests'),
       LangSelector,
       LinkGroup
     },
@@ -130,6 +137,17 @@
           }
         ]
       };
+    },
+
+    computed: {
+      ...mapState({
+        axiosLoggerRequests: state => state.axiosLogger.requests
+      }),
+
+      // TODO: change to be based on a localStorage property set by a UI toggle at /debug
+      showApiRequestsModal() {
+        return Object.prototype.hasOwnProperty.call(this.$route.query, 'debug');
+      }
     }
   };
 </script>

--- a/components/PageFooter.vue
+++ b/components/PageFooter.vue
@@ -144,9 +144,8 @@
         axiosLoggerRequests: state => state.axiosLogger.requests
       }),
 
-      // TODO: change to be based on a localStorage property set by a UI toggle at /debug
       showApiRequestsModal() {
-        return Object.prototype.hasOwnProperty.call(this.$route.query, 'debug');
+        return this.$store.getters['debug/settings'].apiRequests;
       }
     }
   };

--- a/components/PageFooter.vue
+++ b/components/PageFooter.vue
@@ -62,9 +62,9 @@
             </figcaption>
             <LangSelector data-qa="language selector" />
           </figure>
-          <ApiRequests
-            v-if="showApiRequestsModal"
-            :requests="axiosLoggerRequests"
+
+          <DebugMenu
+            v-if="showDebugMenu"
           />
         </b-col>
       </b-row>
@@ -89,14 +89,12 @@
 </template>
 
 <script>
-  import { mapState } from 'vuex';
-
   import LangSelector from './generic/LanguageSelector';
   import LinkGroup from './generic/LinkGroup';
 
   export default {
     components: {
-      ApiRequests: () => import('./debug/ApiRequests'),
+      DebugMenu: () => import('./debug/DebugMenu'),
       LangSelector,
       LinkGroup
     },
@@ -140,11 +138,7 @@
     },
 
     computed: {
-      ...mapState({
-        axiosLoggerRequests: state => state.axiosLogger.requests
-      }),
-
-      showApiRequestsModal() {
+      showDebugMenu() {
         return this.$store.getters['debug/settings'].apiRequests;
       }
     }

--- a/components/debug/ApiRequests.vue
+++ b/components/debug/ApiRequests.vue
@@ -1,0 +1,51 @@
+<template>
+  <div
+    data-qa="API requests"
+  >
+    <b-button
+      v-b-modal.api-requests
+    >
+      API requests
+    </b-button>
+    <b-modal
+      id="api-requests"
+      centered
+      size="xl"
+      title="API requests"
+    >
+      <ol>
+        <li
+          v-for="(request, index) of requests"
+          :key="index"
+        >
+          <code>
+            {{ request.method }}
+            <a
+              v-if="request.method === 'GET'"
+              target="blank"
+              :href="request.uri"
+            >
+              {{ request.uri }}
+            </a>
+            <template
+              v-else
+            >
+              {{ request.uri }}
+            </template>
+          </code>
+        </li>
+      </ol>
+    </b-modal>
+  </div>
+</template>
+
+<script>
+  export default {
+    props: {
+      requests: {
+        type: Array,
+        default: () => []
+      }
+    }
+  };
+</script>

--- a/components/debug/ApiRequests.vue
+++ b/components/debug/ApiRequests.vue
@@ -4,14 +4,15 @@
   >
     <b-button
       v-b-modal.api-requests
+      variant="light"
     >
       API requests
     </b-button>
     <b-modal
       id="api-requests"
-      centered
       size="xl"
       title="API requests"
+      hide-footer
     >
       <ol>
         <li

--- a/components/debug/ApiRequests.vue
+++ b/components/debug/ApiRequests.vue
@@ -23,7 +23,7 @@
             {{ request.method }}
             <a
               v-if="request.method === 'GET'"
-              target="blank"
+              target="_blank"
               :href="request.uri"
             >
               {{ request.uri }}

--- a/components/debug/DebugMenu.vue
+++ b/components/debug/DebugMenu.vue
@@ -1,0 +1,37 @@
+<template>
+  <figure>
+    <figcaption class="text-uppercase font-weight-bold">
+      Debug
+    </figcaption>
+    <ul
+      class="m-0 p-0 footer-link-list"
+    >
+      <li>
+        <ApiRequests
+          v-if="showApiRequestsModal"
+          :requests="axiosLoggerRequests"
+        />
+      </li>
+    </ul>
+  </figure>
+</template>
+
+<script>
+  import { mapState } from 'vuex';
+
+  export default {
+    components: {
+      ApiRequests: () => import('./ApiRequests')
+    },
+
+    computed: {
+      ...mapState({
+        axiosLoggerRequests: state => state.axiosLogger.requests
+      }),
+
+      showApiRequestsModal() {
+        return this.$store.getters['debug/settings'].apiRequests;
+      }
+    }
+  };
+</script>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -85,8 +85,7 @@
     data() {
       return {
         ...config,
-        linkGroups: {},
-        axiosRequests: []
+        linkGroups: {}
       };
     },
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -85,7 +85,8 @@
     data() {
       return {
         ...config,
-        linkGroups: {}
+        linkGroups: {},
+        axiosRequests: []
       };
     },
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -85,6 +85,7 @@ const config = {
   ** Plugins to load before mounting the App
   */
   plugins: [
+    '~/plugins/axiosLogger',
     '~/plugins/europeana',
     '~/plugins/vue/index',
     '~/plugins/i18n.js',

--- a/pages/debug/index.vue
+++ b/pages/debug/index.vue
@@ -1,0 +1,51 @@
+<template>
+  <b-container data-qa="debug page">
+    <ContentHeader
+      :title="title"
+    />
+    <b-row class="flex-md-row pb-5">
+      <b-col cols="12">
+        <b-form>
+          <b-form-checkbox
+            v-model="settings.apiRequests"
+            switch
+          >
+            API requests
+          </b-form-checkbox>
+        </b-form>
+      </b-col>
+    </b-row>
+  </b-container>
+</template>
+
+<script>
+  import ContentHeader from '../../components/generic/ContentHeader';
+
+  export default {
+    components: {
+      ContentHeader
+    },
+
+    data() {
+      return {
+        settings: { ...this.$store.getters['debug/settings'] },
+        title: 'Debug'
+      };
+    },
+
+    watch: {
+      settings: {
+        deep: true,
+        handler(value) {
+          this.$store.commit('debug/updateSettings', value);
+        }
+      }
+    },
+
+    head() {
+      return {
+        title: this.title
+      };
+    }
+  };
+</script>

--- a/plugins/axiosLogger.js
+++ b/plugins/axiosLogger.js
@@ -1,0 +1,50 @@
+import axios from 'axios';
+
+const storeModule = {
+  namespaced: true,
+
+  state: () => ({
+    requests: [],
+    recording: false
+  }),
+
+  mutations: {
+    start(state) {
+      state.recording = true;
+    },
+    stop(state) {
+      state.recording = false;
+    },
+    push(state, request) {
+      state.requests.push(request);
+    },
+    reset(state) {
+      state.requests = [];
+    }
+  }
+};
+
+export default ({ store, app }) => {
+  store.registerModule('axiosLogger', storeModule);
+
+  axios.interceptors.request.use(config => {
+    const uri = axios.getUri(config);
+    const method = config.method.toUpperCase();
+    store.commit('axiosLogger/push', { method, uri });
+    return config;
+  });
+
+  app.router.beforeEach((to, from, next) => {
+    if (!store.state.axiosLogger.recording) {
+      store.commit('axiosLogger/reset');
+      store.commit('axiosLogger/start');
+    }
+    next();
+  });
+
+  app.router.afterEach(() => {
+    // Only stop recording client side to prevent SSR then CSR `afterEach` calls
+    // for the same routing resetting the logger before the CSR.
+    if (process.client) store.commit('axiosLogger/stop');
+  });
+};

--- a/plugins/axiosLogger.js
+++ b/plugins/axiosLogger.js
@@ -27,6 +27,7 @@ const storeModule = {
 export default ({ store, app }) => {
   store.registerModule('axiosLogger', storeModule);
 
+  // TODO: only if enabled. store enabled state, and active with debug UI.
   axios.interceptors.request.use(config => {
     const uri = axios.getUri(config);
     const method = config.method.toUpperCase();

--- a/store/debug.js
+++ b/store/debug.js
@@ -1,0 +1,24 @@
+const defaults = {
+  apiRequests: false
+};
+
+export const state = () => ({
+  settings: {}
+});
+
+export const getters = {
+  settings(state) {
+    let settings = state.settings;
+    if (process.browser && localStorage.debugSettings) {
+      settings = { ...defaults, ...JSON.parse(localStorage.debugSettings) };
+    }
+    return settings;
+  }
+};
+
+export const mutations = {
+  updateSettings(state, settings) {
+    state.settings = { ...settings };
+    if (process.browser) localStorage.debugSettings = JSON.stringify(settings);
+  }
+};


### PR DESCRIPTION
* Go to /en/debug and you will see a very simple page with a checkbox styled as a toggle and labelled "API requests".
* Switch that on, and you will see a new "Debug" menu appear in the footer underneath the language switcher.
* There's an "API requests" button there that opens a modal showing API requests that have been made for the current page.
* Once you've switched it on, try doing a search, then hit the "API requests" button and you'll see a list of the requests that were made.
* For GET requests, the URL is a link to facilitate inspecting the response; for other method requests, just the URL.
* It's essentially like the browser dev tools network tab, but aimed at our non-developer users still needing to get to upstream API responses.