### PR TITLE
Restore lazy-loading on test env

### DIFF
--- a/components/generic/ContentCard.vue
+++ b/components/generic/ContentCard.vue
@@ -14,7 +14,7 @@
         class="card-img"
       >
         <b-img-lazy
-          v-if="lazyLoad"
+          v-if="lazy"
           :src="optimisedImageUrl"
           :blank-width="blankImageWidth"
           :blank-height="blankImageHeight"
@@ -22,7 +22,7 @@
           @error.native="imageNotFound"
         />
         <b-img
-          v-if="!lazyLoad"
+          v-else
           :src="optimisedImageUrl"
           alt=""
           @error="imageNotFound"
@@ -182,10 +182,6 @@
     computed: {
       cardClass() {
         return `${this.variant}-card`;
-      },
-
-      lazyLoad() {
-        return this.lazy && (process.env.NODE_ENV !== 'test');
       },
 
       displayTitle() {

--- a/components/generic/OptimisedImage.vue
+++ b/components/generic/OptimisedImage.vue
@@ -57,10 +57,6 @@
     },
 
     computed: {
-      lazyLoad() {
-        return this.lazy && !process.env.NODE_ENV === 'test';
-      },
-
       aspectRatio() {
         return this.width / this.height;
       },

--- a/tests/features/support/step-runners.js
+++ b/tests/features/support/step-runners.js
@@ -169,6 +169,13 @@ module.exports = {
   },
   async paginateToPage(page) {
     const containerSelector = qaSelector('pagination navigation');
+
+    // Move down to the nav container and wait one second to allow lazy-loading
+    // of images which may interfere with clicking on pagination.
+    // FIXME: this is not 100% reliable
+    await client.moveToElement(containerSelector, 0, 0);
+    await this.waitSomeSeconds(1);
+
     await client.waitForElementVisible(containerSelector);
     const selector = containerSelector + ` a[aria-posinset="${page}"]`;
     await client.waitForElementVisible(selector);


### PR DESCRIPTION
And pause after moving to pagination container before clicking on links, in e2e tests.