### PR TITLE
Update set when items change

### DIFF
--- a/components/account/UserButtons.vue
+++ b/components/account/UserButtons.vue
@@ -25,6 +25,7 @@
         :modal-id="addItemToSetModalId"
         :item-id="value"
         @clickCreateSet="clickCreateSet"
+        @remove="itemRemovedFromSet"
       />
       <SetFormModal
         :modal-id="setFormModalId"
@@ -97,6 +98,9 @@
         } else {
           this.$auth.loginWith('keycloak');
         }
+      },
+      itemRemovedFromSet(setId) {
+        this.$emit('removeFromSet', setId);
       }
     }
   };

--- a/components/account/UserButtons.vue
+++ b/components/account/UserButtons.vue
@@ -7,7 +7,7 @@
       class="icon-ic-add"
       data-qa="add button"
       :aria-label="$t('set.actions.addTo')"
-      @click="addToSet"
+      @click="clickAddButton"
     />
     <b-button
       :pressed="liked"
@@ -25,6 +25,7 @@
         :modal-id="addItemToSetModalId"
         :item-id="value"
         @clickCreateSet="clickCreateSet"
+        @add="itemAddedToSet"
         @remove="itemRemovedFromSet"
       />
       <SetFormModal
@@ -91,7 +92,7 @@
         await this.$store.dispatch('set/unlike', this.value);
         this.$emit('unlike', this.value);
       },
-      addToSet() {
+      clickAddButton() {
         if (this.$auth.loggedIn) {
           this.$bvModal.show(this.addItemToSetModalId);
           this.$emit('add', this.value);
@@ -99,8 +100,11 @@
           this.$auth.loginWith('keycloak');
         }
       },
+      itemAddedToSet(setId) {
+        this.$emit('addToSet', setId, this.value);
+      },
       itemRemovedFromSet(setId) {
-        this.$emit('removeFromSet', setId);
+        this.$emit('removeFromSet', setId, this.value);
       }
     }
   };

--- a/components/item/ItemPreviewCard.vue
+++ b/components/item/ItemPreviewCard.vue
@@ -18,6 +18,7 @@
           v-model="identifier"
           @like="$emit('like', identifier)"
           @unlike="$emit('unlike', identifier)"
+          @removeFromSet="$emit('removeFromSet', identifier)"
         />
       </client-only>
     </template>

--- a/components/item/ItemPreviewCard.vue
+++ b/components/item/ItemPreviewCard.vue
@@ -18,7 +18,8 @@
           v-model="identifier"
           @like="$emit('like', identifier)"
           @unlike="$emit('unlike', identifier)"
-          @removeFromSet="$emit('removeFromSet', identifier)"
+          @addToSet="(setId, itemId) => $emit('addToSet', setId, itemId)"
+          @removeFromSet="(setId, itemId) => $emit('removeFromSet', setId, itemId)"
         />
       </client-only>
     </template>

--- a/components/item/ItemPreviewCardGroup.vue
+++ b/components/item/ItemPreviewCardGroup.vue
@@ -13,6 +13,7 @@
       data-qa="item preview"
       @like="$emit('like', item.id)"
       @unlike="$emit('unlike', item.id)"
+      @removeFromSet="$emit('removeFromSet', identifier)"
     />
     <b-toast
       id="new-collection-toast"

--- a/components/item/ItemPreviewCardGroup.vue
+++ b/components/item/ItemPreviewCardGroup.vue
@@ -13,7 +13,7 @@
       data-qa="item preview"
       @like="$emit('like', item.id)"
       @unlike="$emit('unlike', item.id)"
-      @removeFromSet="$emit('removeFromSet', identifier)"
+      @removeFromSet="$emit('removeFromSet', item.id)"
     />
     <b-toast
       id="new-collection-toast"

--- a/components/item/ItemPreviewCardGroup.vue
+++ b/components/item/ItemPreviewCardGroup.vue
@@ -13,7 +13,8 @@
       data-qa="item preview"
       @like="$emit('like', item.id)"
       @unlike="$emit('unlike', item.id)"
-      @removeFromSet="$emit('removeFromSet', item.id)"
+      @addToSet="(setId, itemId) => $emit('addToSet', setId, itemId)"
+      @removeFromSet="(setId, itemId) => $emit('removeFromSet', setId, itemId)"
     />
     <b-toast
       id="new-collection-toast"

--- a/components/set/AddItemToSetModal.vue
+++ b/components/set/AddItemToSetModal.vue
@@ -108,6 +108,7 @@
           .then(() => {
             this.$bvToast.show('new-collection-toast');
             this.hideModal();
+            this.$emit('add', setId, this.itemId);
           });
       },
 
@@ -115,6 +116,7 @@
         this.$sets.modifyItems('delete', setId, this.itemId)
           .then(() => {
             this.fetchCollections();
+            this.$emit('remove', setId, this.itemId);
           });
       },
 

--- a/pages/set/_.vue
+++ b/pages/set/_.vue
@@ -91,7 +91,8 @@
               <b-col cols="12">
                 <ItemPreviewCardGroup
                   v-model="items"
-                  @removeFromSet="$fetch"
+                  @removeFromSet="itemAddedToOrRemovedFromSet"
+                  @addToSet="itemAddedToOrRemovedFromSet"
                 />
               </b-col>
             </b-row>
@@ -122,6 +123,8 @@
           <h2>{{ $t('items.youMightLike') }}</h2>
           <ItemPreviewCardGroup
             v-model="recommendations"
+            @removeFromSet="itemAddedToOrRemovedFromSet"
+            @addToSet="itemAddedToOrRemovedFromSet"
           />
         </b-col>
       </b-row>
@@ -214,6 +217,10 @@
         this.description = set.description;
         this.visibility = set.visibility;
         this.$bvModal.hide(this.setFormModalId);
+      },
+
+      itemAddedToOrRemovedFromSet(setId) {
+        if (setId === this.id) this.$fetch();
       }
     },
 

--- a/pages/set/_.vue
+++ b/pages/set/_.vue
@@ -91,6 +91,7 @@
               <b-col cols="12">
                 <ItemPreviewCardGroup
                   v-model="items"
+                  @removeFromSet="$fetch"
                 />
               </b-col>
             </b-row>


### PR DESCRIPTION
When viewing one of your own sets, and either removing an item from that set (by clicking the add icon then toggling via the tick icon), or adding an item to that set (by clicking the add icon on a recommended item), then the set should be immediately updated to reflect the change in contents without needing to be reloaded.