### PR TITLE
Store and watch set interaction timestamps

### DIFF
--- a/components/account/UserButtons.vue
+++ b/components/account/UserButtons.vue
@@ -25,12 +25,6 @@
           data-qa="add item to set modal"
           :modal-id="addItemToSetModalId"
           :item-id="value"
-          @clickCreateSet="clickCreateSet"
-        />
-        <SetFormModal
-          :modal-id="setFormModalId"
-          @create="setCreatedOrUpdated"
-          @update="setCreatedOrUpdated"
         />
       </template>
     </client-only>
@@ -45,8 +39,7 @@
 
     components: {
       AddItemToSetModal: () => import('../set/AddItemToSetModal'),
-      ClientOnly,
-      SetFormModal: () => import('../set/SetFormModal')
+      ClientOnly
     },
 
     props: {
@@ -59,8 +52,7 @@
 
     data() {
       return {
-        addItemToSetModalId: `add-item-to-set-modal-${this.value}`,
-        setFormModalId: `set-form-modal-${this.value}`
+        addItemToSetModalId: `add-item-to-set-modal-${this.value}`
       };
     },
 
@@ -74,13 +66,6 @@
     },
 
     methods: {
-      clickCreateSet() {
-        this.$bvModal.hide(this.addItemToSetModalId);
-        this.$bvModal.show(this.setFormModalId);
-      },
-      setCreatedOrUpdated() {
-        this.$bvModal.show(this.addItemToSetModalId);
-      },
       async toggleLiked() {
         await (this.liked ? this.unlike() : this.like());
       },
@@ -98,7 +83,6 @@
       addToSet() {
         if (this.$auth.loggedIn) {
           this.$bvModal.show(this.addItemToSetModalId);
-          this.$emit('add', this.value);
         } else {
           this.$auth.loginWith('keycloak');
         }

--- a/components/account/UserSets.vue
+++ b/components/account/UserSets.vue
@@ -63,6 +63,13 @@
         userSets: []
       };
     },
+    watch: {
+      '$store.state.set.timestamps.any.created': '$fetch',
+      '$store.state.set.timestamps.any.updated': '$fetch',
+      '$store.state.set.timestamps.any.deleted': '$fetch',
+      '$store.state.set.timestamps.any.itemAdded': '$fetch',
+      '$store.state.set.timestamps.any.itemRemoved': '$fetch'
+    },
     methods: {
       setSubTitle(set) {
         const setTotal = set.total || 0;

--- a/components/set/DeleteSetModal.vue
+++ b/components/set/DeleteSetModal.vue
@@ -32,6 +32,7 @@
     name: 'DeleteSetModal',
 
     props: {
+      // Set ID as data.europeana.eu URI
       setId: {
         type: String,
         required: true
@@ -63,10 +64,14 @@
       // TODO: error handling
       submitForm() {
         this.$sets.deleteSet(this.setId)
-          .then(response => {
-            this.makeToast();
+          .then(() => {
             this.hide();
-            this.$emit('delete', response);
+            this.makeToast();
+
+            this.$store.commit('set/timestamp', {
+              action: 'deleted',
+              id: this.setId
+            });
           });
       },
 

--- a/components/set/SetFormModal.vue
+++ b/components/set/SetFormModal.vue
@@ -6,6 +6,7 @@
       :static="modalStatic"
       hide-footer
       @show="init"
+      @hide="$emit('hide')"
     >
       <b-form @submit.stop.prevent="submitForm">
         <b-form-group
@@ -70,7 +71,6 @@
       :modal-id="deleteSetModalId"
       :modal-static="modalStatic"
       @cancel="cancelDelete"
-      @delete="deleteSet"
     />
   </b-container>
 </template>
@@ -169,14 +169,22 @@
         if (this.isNew) {
           this.$sets.createSet(this.setBody)
             .then(response => {
+              this.$store.commit('set/timestamp', {
+                action: 'created',
+                id: response.id
+              });
+
               this.hide();
-              this.$emit('create', response);
             });
         } else {
           this.$sets.updateSet(this.setId, this.setBody)
             .then(response => {
+              this.$store.commit('set/timestamp', {
+                action: 'updated',
+                id: response.id
+              });
+
               this.hide();
-              this.$emit('update', response);
             });
         }
       },
@@ -196,11 +204,6 @@
 
       cancelDelete() {
         this.show();
-      },
-
-      deleteSet() {
-        const path = this.$path({ name: 'account' });
-        this.$goto(path);
       }
     }
   };

--- a/pages/set/_.vue
+++ b/pages/set/_.vue
@@ -147,6 +147,8 @@
     // TODO: error handling for Nuxt 2.12 fetch()
     //       https://nuxtjs.org/blog/understanding-how-fetch-works-in-nuxt-2-12/#error-handling
     async fetch() {
+      // TODO: set to `null` when leaving page
+      this.$store.commit('set/setActiveSet', this.id);
       this.page = this.$store.state.sanitised.page - 1; // Set API paging starts at 0 ¯\_(ツ)_/¯
 
       const set = await this.$sets.getSet(this.$route.params.pathMatch, {
@@ -155,7 +157,7 @@
         profile: 'itemDescriptions'
       });
 
-      this.id = set.id;
+      // this.id = set.id;
       this.title = set.title;
       this.description = set.description;
       this.visibility = set.visibility;
@@ -166,7 +168,7 @@
 
     data() {
       return {
-        id: null,
+        id: `http://data.europeana.eu/set/${this.$route.params.pathMatch}`,
         creator: null,
         description: null,
         items: [],
@@ -195,7 +197,13 @@
     },
 
     watch: {
-      '$route.query.page': '$fetch'
+      '$route.query.page': '$fetch',
+      '$store.state.set.timestamps.active.itemAdded': '$fetch',
+      '$store.state.set.timestamps.active.itemRemoved': '$fetch',
+      '$store.state.set.timestamps.active.deleted'() {
+        const path = this.$path({ name: 'account' });
+        this.$goto(path);
+      }
     },
 
     mounted() {

--- a/store/set.js
+++ b/store/set.js
@@ -1,11 +1,56 @@
 const setIdFromUri = (uri) => uri.split('/item').pop();
 
 export const state = () => ({
+  activeSet: null,
   likesId: null,
-  liked: []
+  liked: [],
+  timestamps: {
+    any: {
+      created: null,
+      updated: null,
+      deleted: null,
+      itemAdded: null,
+      itemRemoved: null
+    },
+    active: {
+      created: null,
+      updated: null,
+      deleted: null,
+      itemAdded: null,
+      itemRemoved: null
+    }
+  }
 });
 
 export const mutations = {
+  setActiveSet(state, id) {
+    state.activeSet = id;
+  },
+  // Timestamp modification of set data
+  //
+  // Numeric timestamps are updated when various set-related data were last modified
+  // by the application. Watch the relevant state properties in components to react
+  // to changes, e.g. by re-requesting source data from the Set API.
+  //
+  // Available actions to timestamp:
+  // * created: a new set was created
+  // * updated: an existing set was updated
+  // * deleted: an existing set was deleted
+  // * itemAdded: an item was added to a set
+  // * itemRemoved: an item was removed from a set
+  //
+  // Why do this instead of storing the updated data itself? Because the Set API
+  // is the source-of-truth, not the application. Also, scalability, e.g. for
+  // paginated public sets.
+  //
+  // @param {Object} body Timestamp properties
+  // @param {string} body.action Action to timestamp
+  // @param {string} body.id ID of the set the action occurred on
+  timestamp(state, body) {
+    const timestamp = Date.now();
+    state.timestamps.any[body.action] = timestamp;
+    if (body.id === state.activeSet) state.timestamps.active[body.action] = timestamp;
+  },
   setLikesId(state, value) {
     state.likesId = value;
   },


### PR DESCRIPTION
Set store updated to log timestamps for various actions on sets:
* Create
* Update
* Delete
* Add item
* Remove item
Each action is logged for any set, and separately for the active set.

Pages and components are updated to watch the timestamp updates that may affect their content, and react by refetching their data from the Set API.

Interactions this affects:
* On the account page, create a new set via the plus icon on the likes tab, and the sets in the public/private collections tabs will be updated
* On a set page, delete it via the edit modal, and the page will redirect to the account page
* On a set page, remove items from it via the plus icon modal, or add items from the recommendations and the items displayed will be re-requested

TODO:
* Update tests
* Extend to cover liking/unliking functionality?