### PR TITLE
GitHub workflow to deploy PRs to CF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,144 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - '**.md'
+
+env:
+  CF_API: https://api.eu-de.cf.cloud.ibm.com
+  CF_APP_NAME_PREFIX: portaljs
+  # TODO: use eanadev.org, requiring interaction with Dyn DNS API
+  CF_DOMAIN: eu-de.cf.appdomain.cloud
+  CF_ORG: europeana-dev
+  CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
+  CF_SPACE: dev
+  CF_USERNAME: apikey
+  CTF_CDA_ACCESS_TOKEN: ${{ secrets.CTF_CDA_ACCESS_TOKEN }}
+  CTF_ENVIRONMENT_ID: test
+  CTF_GRAPHQL_ORIGIN: https://portaljs-api-proxy-cache-test.eanadev.org
+  CTF_SPACE_ID: ${{ secrets.CTF_SPACE_ID }}
+  DISQUS_SHORTNAME: ${{ secrets.DISQUS_SHORTNAME }}
+  ELASTIC_APM_SERVER_URL: https://apm.eanadev.org:8200
+  EUROPEANA_ANNOTATION_API_KEY: ${{ secrets.EUROPEANA_ANNOTATION_API_KEY }}
+  EUROPEANA_ENTITY_API_KEY: ${{ secrets.EUROPEANA_ENTITY_API_KEY }}
+  EUROPEANA_RECORD_API_KEY: ${{ secrets.EUROPEANA_RECORD_API_KEY }}
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+jobs:
+  env:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: echo "::set-env name=PULL_REQUEST_NUMBER::$(jq .pull_request.number ${GITHUB_EVENT_PATH})"
+    - run: echo "::set-env name=CF_APP_NAME::${CF_APP_NAME_PREFIX}-${PULL_REQUEST_NUMBER}"
+    - run: echo "::set-env name=CF_APP_FQDN::${CF_APP_NAME}.${CF_DOMAIN}"
+    - run: envsubst < .github/workflows/support/ci/.env > .env
+    - uses: actions/upload-artifact@v2
+      with:
+        name: .env
+        path: .env
+    - id: done
+      name: Output generated env vars
+      run: |
+        echo "::set-output name=pull-request-number::${PULL_REQUEST_NUMBER}"
+        echo "::set-output name=cf-space::${CF_SPACE}"
+        echo "::set-output name=cf-app-name::${CF_APP_NAME}"
+        echo "::set-output name=cf-app-fqdn::${CF_APP_FQDN}"
+    outputs:
+      pull-request-number: ${{ steps.done.outputs.pull-request-number }}
+      cf-app-name: ${{ steps.done.outputs.cf-app-name }}
+      cf-app-fqdn: ${{ steps.done.outputs.cf-app-fqdn }}
+      cf-space:  ${{ steps.done.outputs.cf-space }}
+
+  build:
+    needs: env
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - uses: actions/download-artifact@v2
+      with:
+        path: tmp
+    - name: Restore build artifacts
+      run: mv tmp/.env/.env .
+    - uses: actions/cache@v2
+      id: cache-node
+      with:
+        path: |
+          ~/.npm
+          **/node_modules
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+    - if: steps.cache-node.outputs.cache-hit != 'true'
+      run: npm install
+    - run: npm run build
+    - uses: actions/upload-artifact@v2
+      with:
+        name: .nuxt
+        path: .nuxt/
+
+  # TODO: limit to internal PRs, i.e. those from within the repo
+  deploy:
+    needs: [env, build]
+    runs-on: ubuntu-latest
+    env:
+      PULL_REQUEST_NUMBER: ${{ needs.env.outputs.pull-request-number }}
+      CF_APP_NAME: ${{ needs.env.outputs.cf-app-name }}
+      CF_SPACE: ${{ needs.env.outputs.cf-space }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/download-artifact@v2
+      with:
+        path: tmp
+    - name: Restore build artifacts
+      run: |
+        mv tmp/.env/.env .
+        mv tmp/.nuxt .
+    # TODO: build and push a Docker image for this to speed it up?
+    - name: Install CF CLI & plugins
+      run: |
+        wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
+        echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+        sudo apt-get -q update && sudo apt-get -yq install cf-cli
+        cf install-plugin blue-green-deploy -f -r CF-Community
+        cf install-plugin app-autoscaler-plugin -f -r CF-Community
+    - name: Login to CF
+      run: cf login -a ${CF_API} -u ${CF_USERNAME} -p "${CF_PASSWORD}" -o ${CF_ORG} -s ${CF_SPACE}
+    - name: Detect first deployment of this app
+      id: detect
+      run: |
+        set +e
+        cf app ${CF_APP_NAME}
+        if [ $? -eq 1 ]; then CF_APP_FIRST_DEPLOY="true"; else CF_APP_FIRST_DEPLOY="false"; fi
+        set -e
+        echo ${CF_APP_FIRST_DEPLOY}
+        echo "::set-output name=cf-app-first-deploy::${CF_APP_FIRST_DEPLOY}"
+    - name: Blue-green deployment to CF
+      run: cf blue-green-deploy ${CF_APP_NAME} -f .github/workflows/support/ci/manifest.yml --delete-old-apps
+    outputs:
+      cf-app-first-deploy: ${{ steps.detect.outputs.cf-app-first-deploy }}
+
+  notify:
+    needs: [deploy, env]
+    if: needs.deploy.outputs.cf-app-first-deploy == 'true'
+    runs-on: ubuntu-latest
+    env:
+      PULL_REQUEST_NUMBER: ${{ needs.env.outputs.pull-request-number }}
+      PULL_REQUEST_TITLE: ${{ github.event.pull_request.title }}
+      PULL_REQUEST_USER_LOGIN: ${{ github.event.pull_request.user.login }}
+      PULL_REQUEST_USER_HTML_URL: ${{ github.event.pull_request.user.html_url }}
+      CF_APP_FQDN: ${{ needs.env.outputs.cf-app-fqdn }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          path: tmp
+      - name: Restore build artifacts
+        run: mv tmp/.env/.env .
+      - name: Notify Slack
+        run: |
+          envsubst < .github/workflows/support/ci/slack-notification.json > tmp/slack-notification.json
+          curl -d "@tmp/slack-notification.json" -X POST ${SLACK_WEBHOOK_URL}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,6 @@ jobs:
         wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
         echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
         sudo apt-get -q update && sudo apt-get -yq install cf-cli
-        cf install-plugin blue-green-deploy -f -r CF-Community
-        cf install-plugin app-autoscaler-plugin -f -r CF-Community
     - name: Login to CF
       run: cf login -a ${CF_API} -u ${CF_USERNAME} -p "${CF_PASSWORD}" -o ${CF_ORG} -s ${CF_SPACE}
     - name: Detect first deployment of this app
@@ -116,8 +114,8 @@ jobs:
         set -e
         echo ${CF_APP_FIRST_DEPLOY}
         echo "::set-output name=cf-app-first-deploy::${CF_APP_FIRST_DEPLOY}"
-    - name: Blue-green deployment to CF
-      run: cf blue-green-deploy ${CF_APP_NAME} -f .github/workflows/support/ci/manifest.yml --delete-old-apps
+    - name: Push to Cloud Foundry
+      run: cf push ${CF_APP_NAME} -f .github/workflows/support/ci/manifest.yml -d ${CF_DOMAIN}
     outputs:
       cf-app-first-deploy: ${{ steps.detect.outputs.cf-app-first-deploy }}
 

--- a/.github/workflows/recycling.yml
+++ b/.github/workflows/recycling.yml
@@ -1,0 +1,47 @@
+name: Recycling
+
+# TODO: ideally closing a PR would stop any runs of the ci workflow on the same
+#       PR first.
+
+on:
+  pull_request:
+    types: closed
+
+env:
+  CF_API: https://api.eu-de.cf.cloud.ibm.com
+  CF_APP_NAME_PREFIX: portaljs
+  # TODO: use eanadev.org, requiring interaction with Dyn DNS API
+  CF_DOMAIN: eu-de.cf.appdomain.cloud
+  CF_ORG: europeana-dev
+  CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
+  CF_SPACE: dev
+  CF_USERNAME: apikey
+
+jobs:
+  info:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo ${GITHUB_RUN_ID}
+    - run: echo ${GITHUB_ACTOR}
+    - run: echo ${GITHUB_REPOSITORY}
+    - run: echo ${GITHUB_REF}
+    - run: echo ${GITHUB_HEAD_REF}
+    - run: echo ${GITHUB_BASE_REF}
+    - run: echo ${GITHUB_SHA}
+    - run: cat ${GITHUB_EVENT_PATH}
+
+  cloud-foundry:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo "::set-env name=PULL_REQUEST_NUMBER::$(jq .pull_request.number ${GITHUB_EVENT_PATH})"
+    - run: echo "::set-env name=CF_APP_NAME::${CF_APP_NAME_PREFIX}-${PULL_REQUEST_NUMBER}"
+    - name: Install CF CLI & plugins
+      run: |
+        wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
+        echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+        sudo apt-get -q update && sudo apt-get -yq install cf-cli
+        cf install-plugin blue-green-deploy -f -r CF-Community
+        cf install-plugin app-autoscaler-plugin -f -r CF-Community
+    - run: cf login -a ${CF_API} -u ${CF_USERNAME} -p "${CF_PASSWORD}" -o ${CF_ORG} -s ${CF_SPACE}
+    - run: cf delete ${CF_APP_NAME} -f
+    - run: cf delete-route ${CF_DOMAIN} -n ${CF_APP_NAME} -f

--- a/.github/workflows/recycling.yml
+++ b/.github/workflows/recycling.yml
@@ -30,18 +30,16 @@ jobs:
     - run: echo ${GITHUB_SHA}
     - run: cat ${GITHUB_EVENT_PATH}
 
-  cloud-foundry:
+  delete-deployment:
     runs-on: ubuntu-latest
     steps:
     - run: echo "::set-env name=PULL_REQUEST_NUMBER::$(jq .pull_request.number ${GITHUB_EVENT_PATH})"
     - run: echo "::set-env name=CF_APP_NAME::${CF_APP_NAME_PREFIX}-${PULL_REQUEST_NUMBER}"
-    - name: Install CF CLI & plugins
+    - name: Install CF CLI
       run: |
         wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
         echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
         sudo apt-get -q update && sudo apt-get -yq install cf-cli
-        cf install-plugin blue-green-deploy -f -r CF-Community
-        cf install-plugin app-autoscaler-plugin -f -r CF-Community
     - run: cf login -a ${CF_API} -u ${CF_USERNAME} -p "${CF_PASSWORD}" -o ${CF_ORG} -s ${CF_SPACE}
     - run: cf delete ${CF_APP_NAME} -f
     - run: cf delete-route ${CF_DOMAIN} -n ${CF_APP_NAME} -f

--- a/.github/workflows/support/ci/.env
+++ b/.github/workflows/support/ci/.env
@@ -1,0 +1,17 @@
+# This is a template .env file for CI environments, whitelisting variables to
+# include when building and deploying the app, populated from the CI's own
+# environment variables with `envsubst`.
+
+# TODO: remove this file and the use of it when the app no longer depends on
+#       the use of dotenv.
+
+CTF_CDA_ACCESS_TOKEN=${CTF_CDA_ACCESS_TOKEN}
+CTF_ENVIRONMENT_ID=${CTF_ENVIRONMENT_ID}
+CTF_GRAPHQL_ORIGIN=${CTF_GRAPHQL_ORIGIN}
+CTF_SPACE_ID=${CTF_SPACE_ID}
+DISQUS_SHORTNAME=${DISQUS_SHORTNAME}
+ENABLE_SSL_NEGOTIATION=1
+EUROPEANA_ANNOTATION_API_KEY=${EUROPEANA_ANNOTATION_API_KEY}
+EUROPEANA_ENTITY_API_KEY=${EUROPEANA_ENTITY_API_KEY}
+EUROPEANA_RECORD_API_KEY=${EUROPEANA_RECORD_API_KEY}
+EUROPEANA_SET_API_KEY=${EUROPEANA_SET_API_KEY}

--- a/.github/workflows/support/ci/manifest.yml
+++ b/.github/workflows/support/ci/manifest.yml
@@ -2,7 +2,6 @@
 ---
 buildpack: nodejs_buildpack
 command: "npx cservice --restartOnMemUsage 134217728 --cli false server/index.js"
-domain: eu-de.cf.appdomain.cloud
 memory: 512M
 health-check-type: process
 # health-check-http-endpoint: /robots.txt

--- a/.github/workflows/support/ci/manifest.yml
+++ b/.github/workflows/support/ci/manifest.yml
@@ -1,0 +1,12 @@
+# Cloud Foundry manifest
+---
+buildpack: nodejs_buildpack
+command: "npx cservice --restartOnMemUsage 134217728 --cli false server/index.js"
+memory: 512M
+health-check-type: process
+# health-check-http-endpoint: /robots.txt
+stack: cflinuxfs3
+env:
+  CONSOLA_LEVEL: info
+  HOST: 0.0.0.0
+  OPTIMIZE_MEMORY: true

--- a/.github/workflows/support/ci/manifest.yml
+++ b/.github/workflows/support/ci/manifest.yml
@@ -2,6 +2,7 @@
 ---
 buildpack: nodejs_buildpack
 command: "npx cservice --restartOnMemUsage 134217728 --cli false server/index.js"
+domain: eu-de.cf.appdomain.cloud
 memory: 512M
 health-check-type: process
 # health-check-http-endpoint: /robots.txt

--- a/.github/workflows/support/ci/slack-notification.json
+++ b/.github/workflows/support/ci/slack-notification.json
@@ -1,5 +1,5 @@
 {
-  "username": "portal.js Github Actions robot",
+  "username": "portal.js GitHub Actions robot",
   "icon_emoji": ":robot_face:",
-  "text": "Github Actions just deployed <https://github.com/europeana/portal.js/pull/${PULL_REQUEST_NUMBER}|portal.js PR ${PULL_REQUEST_NUMBER}> \"${PULL_REQUEST_TITLE}\" by <${PULL_REQUEST_USER_HTML_URL}|${PULL_REQUEST_USER_LOGIN}> to <https://${CF_APP_FQDN}/>"
+  "text": "GitHub Actions just deployed <https://github.com/europeana/portal.js/pull/${PULL_REQUEST_NUMBER}|portal.js PR ${PULL_REQUEST_NUMBER}> \"${PULL_REQUEST_TITLE}\" by <${PULL_REQUEST_USER_HTML_URL}|${PULL_REQUEST_USER_LOGIN}> to <https://${CF_APP_FQDN}/>"
 }

--- a/.github/workflows/support/ci/slack-notification.json
+++ b/.github/workflows/support/ci/slack-notification.json
@@ -1,0 +1,5 @@
+{
+  "username": "portal.js Github Actions robot",
+  "icon_emoji": ":robot_face:",
+  "text": "Github Actions just deployed <https://github.com/europeana/portal.js/pull/${PULL_REQUEST_NUMBER}|portal.js PR ${PULL_REQUEST_NUMBER}> \"${PULL_REQUEST_TITLE}\" by <${PULL_REQUEST_USER_HTML_URL}|${PULL_REQUEST_USER_LOGIN}> to <https://${CF_APP_FQDN}/>"
+}


### PR DESCRIPTION
Introduces two [GitHub Actions workflows](https://docs.github.com/en/actions):
1. [CI](https://github.com/europeana/portal.js/actions?query=workflow%3ACI), triggered when pull requests are opened, synchronized (i.e. updated with more commits to the branch), or reopened:
    1. generates a .env file to use for the app from a template and [GitHub secrets](https://github.com/europeana/portal.js/settings/secrets) (plus some hard-coded values that are not secrets)
    1. checks out the code for the PR
    1. installs the Node packages and builds the Nuxt app
    1. pushes the app to IBM Cloud Foundry
    1. if this is the first push of this app to Cloud Foundry, sends a notification to a Slack channel
2. [Recycling](https://github.com/europeana/portal.js/actions?query=workflow%3ARecycling), triggered when pull requests are closed:
    1. deletes the app from Cloud Foundry
    1. deletes the route from Cloud Foundry