### PR TITLE
Restore og:image for item page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,10 @@ OAUTH_CLIENT="YOUR_CLIENT"
 # Used by @nuxtjs/google-tag-manager to allow injection of scripts via google tag manager.
 # GOOGLE_TAG_MANAGER_ID="GTM-XXXXXXX"
 
+# robots.txt config for @nuxtjs/robots module, as stringified JSON
+# @see https://github.com/nuxt-community/robots-module
+# APP_ROBOTS='{"UserAgent":"*","Disallow":"/"}'
+
 # Used to determine if links are internal paths or not
 # INTERNAL_LINK_DOMAIN=.europeana.eu
 

--- a/.github/workflows/support/ci/.env
+++ b/.github/workflows/support/ci/.env
@@ -5,6 +5,7 @@
 # TODO: remove this file and the use of it when the app no longer depends on
 #       the use of dotenv.
 
+APP_ROBOTS='[{"UserAgent":"Twitterbot","Disallow":""},{"UserAgent":"*","Disallow":"/"}]'
 CTF_CDA_ACCESS_TOKEN=${CTF_CDA_ACCESS_TOKEN}
 CTF_ENVIRONMENT_ID=${CTF_ENVIRONMENT_ID}
 CTF_GRAPHQL_ORIGIN=${CTF_GRAPHQL_ORIGIN}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -128,12 +128,12 @@ module.exports = {
     }],
     '~/modules/query-sanitiser',
     '@nuxtjs/auth',
-    '@nuxtjs/gtm'
+    ['@nuxtjs/gtm', {
+      id: process.env.GOOGLE_TAG_MANAGER_ID,
+      pageTracking: true
+    }],
+    ['@nuxtjs/robots', JSON.parse(process.env.APP_ROBOTS || '{"UserAgent":"*","Disallow":"/"}')]
   ],
-  gtm: {
-    id: process.env.GOOGLE_TAG_MANAGER_ID,
-    pageTracking: true
-  },
 
   /*
   ** Nuxt.js modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -4880,6 +4880,11 @@
         }
       }
     },
+    "@nuxtjs/robots": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/robots/-/robots-2.4.2.tgz",
+      "integrity": "sha512-BW3qhvxlPBKlMkZHtARFPeliFraiZHS28G3j4qgRbSfOBtHC0yDX3Dnq1LkQMzAbPfbw6A1L3sdjgBVZZnfFAw=="
+    },
     "@nuxtjs/youch": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/@nuxtjs/youch/-/youch-4.2.3.tgz",
@@ -21894,21 +21899,21 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
               "dev": true,
               "optional": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true,
               "optional": true
             },
             "aproba": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true,
               "optional": true
@@ -21926,14 +21931,14 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
               "dev": true,
               "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "dev": true,
               "optional": true,
@@ -21944,35 +21949,35 @@
             },
             "chownr": {
               "version": "1.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
               "dev": true,
               "optional": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
               "dev": true,
               "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
               "dev": true,
               "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
               "dev": true,
               "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "dev": true,
               "optional": true
@@ -21989,21 +21994,21 @@
             },
             "deep-extend": {
               "version": "0.6.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
               "dev": true,
               "optional": true
             },
             "delegates": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
               "dev": true,
               "optional": true
             },
             "detect-libc": {
               "version": "1.0.3",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
               "dev": true,
               "optional": true
@@ -22020,7 +22025,7 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "dev": true,
               "optional": true
@@ -22059,14 +22064,14 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "dev": true,
               "optional": true
             },
             "iconv-lite": {
               "version": "0.4.24",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
               "dev": true,
               "optional": true,
@@ -22076,7 +22081,7 @@
             },
             "ignore-walk": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
               "dev": true,
               "optional": true,
@@ -22097,21 +22102,21 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "dev": true,
               "optional": true
             },
             "ini": {
               "version": "1.3.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
               "dev": true,
               "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "optional": true,
@@ -22121,14 +22126,14 @@
             },
             "isarray": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "dev": true,
               "optional": true
             },
             "minimatch": {
               "version": "3.0.4",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "optional": true,
@@ -22183,14 +22188,14 @@
             },
             "ms": {
               "version": "2.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
               "dev": true,
               "optional": true
             },
             "needle": {
               "version": "2.3.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
               "dev": true,
               "optional": true,
@@ -22221,7 +22226,7 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "dev": true,
               "optional": true,
@@ -22232,14 +22237,14 @@
             },
             "npm-bundled": {
               "version": "1.0.6",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
               "dev": true,
               "optional": true
             },
             "npm-packlist": {
               "version": "1.4.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
               "dev": true,
               "optional": true,
@@ -22263,14 +22268,14 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
               "dev": true,
               "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "dev": true,
               "optional": true
@@ -22287,21 +22292,21 @@
             },
             "os-homedir": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "dev": true,
               "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "dev": true,
               "optional": true
             },
             "osenv": {
               "version": "0.1.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
               "dev": true,
               "optional": true,
@@ -22312,14 +22317,14 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "dev": true,
               "optional": true
             },
             "process-nextick-args": {
               "version": "2.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
               "dev": true,
               "optional": true
@@ -22374,28 +22379,28 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
               "dev": true,
               "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
               "dev": true,
               "optional": true
             },
             "sax": {
               "version": "1.2.4",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
               "dev": true,
               "optional": true
             },
             "semver": {
               "version": "5.7.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
               "dev": true,
               "optional": true

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@nuxtjs/axios": "^5.11.0",
     "@nuxtjs/dotenv": "^1.3.0",
     "@nuxtjs/gtm": "^2.2.3",
+    "@nuxtjs/robots": "^2.4.2",
     "autosuggest-highlight": "^3.1.1",
     "axios": "^0.20.0",
     "bootstrap-vue": "^2.0.0",

--- a/pages/item/_.vue
+++ b/pages/item/_.vue
@@ -157,7 +157,7 @@
         coreFields: null,
         description: null,
         error: null,
-        fields: null,
+        fields: {},
         identifier: null,
         isShownAt: null,
         media: [],
@@ -249,6 +249,9 @@
       },
       redirectNotificationsEnabled() {
         return Boolean(Number(process.env.ENABLE_LINKS_TO_CLASSIC));
+      },
+      pageHeadMetaOgImage() {
+        return this.media[0] ? this.media[0].thumbnails.large : null;
       }
     },
 
@@ -314,7 +317,7 @@
           { hid: 'description', name: 'description', content: this.metaDescription },
           { hid: 'og:title', property: 'og:title', content: this.metaTitle },
           { hid: 'og:description', property: 'og:description', content: this.metaDescription },
-          { hid: 'og:image', property: 'og:image', content: typeof this.media[0] !== 'undefined' && this.media[0].src ? this.media[0].src : '' },
+          { hid: 'og:image', property: 'og:image', content: this.pageHeadMetaOgImage },
           { hid: 'og:type', property: 'og:type', content: 'article' }
         ]
       };

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /

--- a/tests/unit/pages/item/_.spec.js
+++ b/tests/unit/pages/item/_.spec.js
@@ -1,0 +1,62 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import BootstrapVue from 'bootstrap-vue';
+import sinon from 'sinon';
+
+import page from '../../../../pages/item/_';
+
+const localVue = createLocalVue();
+localVue.use(BootstrapVue);
+
+const factory = () => shallowMount(page, {
+  localVue,
+  data() {
+    return {
+      identifier: '/123/abc'
+    };
+  },
+  mocks: {
+    $pageHeadTitle: key => key,
+    $t: key => key,
+    $auth: {
+      loggedIn: false
+    },
+    $store: {
+      getters: {
+        'apis/annotation': {
+          search: sinon.spy()
+        },
+        'apis/entity': {
+          findEntities: sinon.spy()
+        },
+        'api/record': {
+          getRecord: sinon.stub().resolves({}),
+          search: sinon.spy()
+        },
+        'set/isLiked': sinon.stub()
+      }
+    }
+  }
+});
+
+describe('pages/item/_.vue', () => {
+  describe('head()', () => {
+    it('uses first media large thumbnail for og:image', () => {
+      const thumbnailUrl = 'http://example.org/image/large.jpg';
+      const wrapper = factory();
+      wrapper.setData({
+        media: [
+          {
+            thumbnails: {
+              large: thumbnailUrl
+            }
+          }
+        ]
+      });
+      wrapper.vm.head = page.head;
+
+      const headMeta = wrapper.vm.head().meta;
+
+      headMeta.find(meta => meta.property === 'og:image').content.should.eq(thumbnailUrl);
+    });
+  });
+});


### PR DESCRIPTION
Also introduces unit tests for Nuxt page views. We have in the past relied on e2e tests for these, but not everything is readily testable thus, and they contain plenty of logic that should be unit tested. While Vue Test Utils may not be aware of some of the Nuxt methods, it's straightforward enough to supply them onto the local Vue wrapper's VM once created.