### PR TITLE
Detect linkTo having scheme, and use href, not to

### DIFF
--- a/components/generic/RelatedChip.vue
+++ b/components/generic/RelatedChip.vue
@@ -1,6 +1,7 @@
 <template>
   <b-badge
-    :to="linkTo"
+    :to="bbadgeTo"
+    :href="bbadgeHref"
     pill
     variant="light"
     class="mt-1 mr-2 font-weight-normal bg-white"
@@ -26,10 +27,6 @@
     name: 'RelatedChip',
 
     props: {
-      to: {
-        type: String,
-        default: ''
-      },
       linkTo: {
         type: String,
         default: ''
@@ -49,6 +46,16 @@
     },
 
     computed: {
+      bbadgeTo() {
+        return this.bbadgeHref ? null : this.linkTo;
+      },
+      bbadgeHref() {
+        if ((typeof this.linkTo === 'string') && this.linkTo.includes('://')) {
+          return this.linkTo;
+        } else {
+          return null;
+        }
+      },
       localisedTitle() {
         if (typeof this.title === 'string') return {
           values: [this.title],

--- a/tests/unit/components/generic/RelatedChip.spec.js
+++ b/tests/unit/components/generic/RelatedChip.spec.js
@@ -30,6 +30,7 @@ describe('components/generic/RelatedChip', () => {
     const chip = wrapper.find('[data-qa="Art related chip"]');
     chip.text().should.eq('Art');
     chip.attributes().to.should.contain('190-art');
+    (chip.attributes().href === undefined).should.be.true;
   });
 
   it('translates lang maps for title', () => {
@@ -44,5 +45,19 @@ describe('components/generic/RelatedChip', () => {
 
     const chip = wrapper.find('[data-qa="Costume related chip"]');
     chip.text().should.eq('Costume');
+  });
+
+  context('when linkTo is a URL with scheme', () => {
+    it('is linked to, not routed to', () => {
+      const wrapper = factory();
+      wrapper.setProps({
+        linkTo: 'https://www.example.org/collections/topic/190-art',
+        title: 'Art'
+      });
+
+      const chip = wrapper.find('[data-qa="Art related chip"]');
+      chip.attributes().href.should.eq('https://www.example.org/collections/topic/190-art');
+      (chip.attributes().to === undefined).should.be.true;
+    });
   });
 });


### PR DESCRIPTION
To test this locally:
* Enable SSL negotiation with `ENABLE_SSL_NEGOTIATION=1`
* Ensure the SSL blacklist includes dataset 08711, e.g. with `SSL_DATASET_BLACKLIST=08711`
* Open http://localhost:3000/en/item/08711/item_150452, and observe that the "COLLECTIONS YOU MIGHT LIKE" link to Geology points correctly to https://localhost/en/collections/topic/152-geology (which may or may not then work, depending on whether you have SSL set up)