### PR TITLE
Link plugin to detect when to use href, when to use router to

### DIFF
--- a/components/generic/RelatedChip.vue
+++ b/components/generic/RelatedChip.vue
@@ -1,7 +1,7 @@
 <template>
   <b-badge
-    :to="bbadgeTo"
-    :href="bbadgeHref"
+    :to="$link.to(linkTo)"
+    :href="$link.href(linkTo)"
     pill
     variant="light"
     class="mt-1 mr-2 font-weight-normal bg-white"
@@ -46,16 +46,6 @@
     },
 
     computed: {
-      bbadgeTo() {
-        return this.bbadgeHref ? null : this.linkTo;
-      },
-      bbadgeHref() {
-        if ((typeof this.linkTo === 'string') && this.linkTo.includes('://')) {
-          return this.linkTo;
-        } else {
-          return null;
-        }
-      },
       localisedTitle() {
         if (typeof this.title === 'string') return {
           values: [this.title],

--- a/components/generic/SmartLink.vue
+++ b/components/generic/SmartLink.vue
@@ -23,6 +23,8 @@
 </template>
 
 <script>
+  // TODO: refactor to use $link.to and $link.href
+
   export default {
     props: {
       destination: {
@@ -34,6 +36,7 @@
         type: String,
         default: ''
       },
+
       hideExternalIcon: {
         type: Boolean,
         default: false

--- a/components/search/SearchQueryOptions.vue
+++ b/components/search/SearchQueryOptions.vue
@@ -9,7 +9,8 @@
     <b-list-group-item
       v-for="(option, index) in value"
       :key="index"
-      :to="option.link"
+      :to="$link.to(option.link.path, option.link.query)"
+      :href="$link.href(option.link.path, option.link.query)"
       :data-qa="option.qa"
       role="option"
       :aria-selected="index === focus"

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -98,6 +98,7 @@ module.exports = {
     '~/plugins/apis',
     '~/plugins/vue',
     '~/plugins/i18n.js',
+    '~/plugins/link',
     '~/plugins/page',
     '~/plugins/vue-filters',
     '~/plugins/vue-directives'

--- a/plugins/link.js
+++ b/plugins/link.js
@@ -1,0 +1,12 @@
+const plugin = {
+  to(route) {
+    return this.href(route) === null ? route : null;
+  },
+  href(route) {
+    return (typeof route === 'string' && route.includes('://')) ? route : null;
+  }
+};
+
+export default (context, inject) => {
+  inject('link', plugin);
+};

--- a/plugins/link.js
+++ b/plugins/link.js
@@ -1,9 +1,23 @@
 const plugin = {
-  to(route) {
-    return this.href(route) === null ? route : null;
+  to(path, query = {}) {
+    if (path.includes('://')) {
+      return null;
+    } else {
+      return {
+        path,
+        query
+      };
+    }
   },
-  href(route) {
-    return (typeof route === 'string' && route.includes('://')) ? route : null;
+
+  href(path, query = {}) {
+    if (path.includes('://')) {
+      const url = new URL(path);
+      url.search = new URLSearchParams(query).toString();
+      return url.toString();
+    } else {
+      return null;
+    }
   }
 };
 

--- a/tests/unit/components/generic/RelatedChip.spec.js
+++ b/tests/unit/components/generic/RelatedChip.spec.js
@@ -16,12 +16,22 @@ const factory = (mocks = {}) => shallowMount(RelatedChip, {
 
 describe('components/generic/RelatedChip', () => {
   it('renders a related collection chip', () => {
-    const wrapper = factory();
+    const wrapper = factory({
+      $link: {
+        to: route => route,
+        href: () => null
+      }
+    });
     wrapper.findAll('[data-qa="Art related chip"]').length.should.eq(1);
   });
 
   it('has a collection title, lang and link', () => {
-    const wrapper = factory();
+    const wrapper = factory({
+      $link: {
+        to: route => route,
+        href: () => null
+      }
+    });
     wrapper.setProps({
       linkTo: '/collections/topic/190-art',
       title: 'Art'
@@ -34,7 +44,13 @@ describe('components/generic/RelatedChip', () => {
   });
 
   it('translates lang maps for title', () => {
-    const wrapper = factory({ $i18n: { locale: 'de' } });
+    const wrapper = factory({
+      $link: {
+        to: route => route,
+        href: () => null
+      },
+      $i18n: { locale: 'de' }
+    });
 
     wrapper.setProps({
       linkTo: '/collections/topic/33-costume',
@@ -49,7 +65,12 @@ describe('components/generic/RelatedChip', () => {
 
   context('when linkTo is a URL with scheme', () => {
     it('is linked to, not routed to', () => {
-      const wrapper = factory();
+      const wrapper = factory({
+        $link: {
+          href: route => route,
+          to: () => null
+        }
+      });
       wrapper.setProps({
         linkTo: 'https://www.example.org/collections/topic/190-art',
         title: 'Art'

--- a/tests/unit/components/generic/RelatedCollections.spec.js
+++ b/tests/unit/components/generic/RelatedCollections.spec.js
@@ -22,7 +22,11 @@ const factory = (options = {}) => {
         $i18n: { locale: 'en' },
         $t: () => {},
         $fetch: () => {},
-        $path
+        $path,
+        $link: {
+          to: route => route,
+          href: () => null
+        }
       }, ...(options.mocks || {})
     },
     store: options.store || store()

--- a/tests/unit/components/search/SearchQueryOptions.spec.js
+++ b/tests/unit/components/search/SearchQueryOptions.spec.js
@@ -30,6 +30,10 @@ const factory = (options = {}) => {
         $t: () => {},
         $path: (opts) => {
           return router.resolve(opts).route.fullPath;
+        },
+        $link: {
+          to: (route, query) => route.toString() + '?' + new URLSearchParams(query).toString(),
+          href: () => null
         }
       }, ...(options.mocks || {})
     }

--- a/tests/unit/plugins/link.spec.js
+++ b/tests/unit/plugins/link.spec.js
@@ -8,56 +8,43 @@ linkPluginModule(
 
 describe('link plugin', () => {
   describe('to()', () => {
-    it('returns null for string including "://"', () => {
-      const route = 'http://example.org/about';
+    it('returns null for path including "://"', () => {
+      const path = 'http://example.org/about';
+      const query = { query: 'art' };
 
-      const to = linkPlugin.to(route);
+      const to = linkPlugin.to(path, query);
 
       (to === null).should.be.true;
     });
 
-    it('returns route for object', () => {
-      const route = {
-        path: '/about'
-      };
+    it('returns route object for path without "://"', () => {
+      const path = '/about';
+      const query = { query: 'art' };
 
-      const to = linkPlugin.to(route);
+      const to = linkPlugin.to(path, query);
 
-      to.should.eql(route);
-    });
-
-    it('returns route for string without "://"', () => {
-      const route = '/about';
-
-      const to = linkPlugin.to(route);
-
-      to.should.eql(route);
+      to.should.eql({
+        path,
+        query
+      });
     });
   });
 
   describe('href()', () => {
-    it('returns route for string including "://"', () => {
-      const route = 'http://example.org/about';
+    it('returns URL for path including "://"', () => {
+      const path = 'http://example.org/about';
+      const query = { query: 'art' };
 
-      const href = linkPlugin.href(route);
+      const href = linkPlugin.href(path, query);
 
-      href.should.eql(route);
+      href.should.eql('http://example.org/about?query=art');
     });
 
-    it('returns null for object', () => {
-      const route = {
-        path: '/about'
-      };
+    it('returns null for path without "://"', () => {
+      const path = '/about';
+      const query = { query: 'art' };
 
-      const href = linkPlugin.href(route);
-
-      (href === null).should.be.true;
-    });
-
-    it('returns null for string without "://"', () => {
-      const route = '/about';
-
-      const href = linkPlugin.href(route);
+      const href = linkPlugin.href(path, query);
 
       (href === null).should.be.true;
     });

--- a/tests/unit/plugins/link.spec.js
+++ b/tests/unit/plugins/link.spec.js
@@ -1,0 +1,65 @@
+import linkPluginModule from '../../../plugins/link';
+
+let linkPlugin;
+linkPluginModule(
+  {},
+  (name, plugin) => linkPlugin = plugin
+);
+
+describe('link plugin', () => {
+  describe('to()', () => {
+    it('returns null for string including "://"', () => {
+      const route = 'http://example.org/about';
+
+      const to = linkPlugin.to(route);
+
+      (to === null).should.be.true;
+    });
+
+    it('returns route for object', () => {
+      const route = {
+        path: '/about'
+      };
+
+      const to = linkPlugin.to(route);
+
+      to.should.eql(route);
+    });
+
+    it('returns route for string without "://"', () => {
+      const route = '/about';
+
+      const to = linkPlugin.to(route);
+
+      to.should.eql(route);
+    });
+  });
+
+  describe('href()', () => {
+    it('returns route for string including "://"', () => {
+      const route = 'http://example.org/about';
+
+      const href = linkPlugin.href(route);
+
+      href.should.eql(route);
+    });
+
+    it('returns null for object', () => {
+      const route = {
+        path: '/about'
+      };
+
+      const href = linkPlugin.href(route);
+
+      (href === null).should.be.true;
+    });
+
+    it('returns null for string without "://"', () => {
+      const route = '/about';
+
+      const href = linkPlugin.href(route);
+
+      (href === null).should.be.true;
+    });
+  });
+});


### PR DESCRIPTION
Introduces a link plugin, and injects it onto the Nuxt context / Vue instance as `$link`, with two methods:
* `$link.to(path, query = {})`: returns null if the path is an absolute URL, i.e. contains "://", otherwise returns an object with path and query properties for routing with
* `$link.href(path, query = {})`: returns a URL including the query if the path is an absolute URL, otherwise null

These can be used in tandem on component props where only one or the other is wanted, owing to only one ever having a non-null return value, e.g.
```vue
<b-link
  :to="$link.to(path)"
  :href="$link.href(path)"
/>
```