### PR TITLE
Disable compressor

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -350,6 +350,10 @@ module.exports = {
   ** Render configuration
    */
   render: {
+    // Disable compression: leave it to a gateway/reverse proxy like NGINX or
+    // Cloudflare.
+    compressor: false,
+
     static: {
       maxAge: '1d'
     }


### PR DESCRIPTION
Leave it to a gateway/reverse proxy like NGINX or Cloudflare.

**Benchmarks**

Setup: 
* API proxy cache deployed to Cloud Foundry with 1 day retention in memory, /en warmed up
* Portal deployed to Cloud Foundry, with NGINX gateway in front of it, and Cloudflare proxying enabled at FQDN www-test.europeana.eu
* Benchmark command: `ab -k -n 100 -c 10 -H "Accept-Encoding: gzip" "https://www-test.europeana.eu/en"`

Results:
* With compressor enabled on Nuxt:
  `Time per request:       395.785 [ms] (mean, across all concurrent requests)`
* With compressor disabled on Nuxt, responses are still gzipped, by Cloudflare:
  `Time per request:       307.560 [ms] (mean, across all concurrent requests)`