### PR TITLE
Forked Optimize module for experiment runtime config

### DIFF
--- a/assets/scss/toast.scss
+++ b/assets/scss/toast.scss
@@ -4,4 +4,7 @@
     border: 0;
     color: $white;
   }
+  .toast-body {
+    padding: 1rem;
+  }
 }

--- a/components/authored/AuthoredHead.vue
+++ b/components/authored/AuthoredHead.vue
@@ -37,6 +37,7 @@
           :image-content-type="heroImage.contentType"
           :rights-statement="hero.license"
           :attribution="hero"
+          :alt="heroImageAlt"
           hero
         />
       </b-col>
@@ -78,6 +79,9 @@
     computed: {
       heroImage() {
         return this.hero ? this.hero.image : null;
+      },
+      heroImageAlt() {
+        return this.heroImage && this.heroImage.description ? this.heroImage.description : '';
       }
     }
   };

--- a/components/browse/BrowseContentCard.vue
+++ b/components/browse/BrowseContentCard.vue
@@ -5,6 +5,7 @@
     :url="destination"
     :image-url="imageUrl"
     :image-content-type="imageContentType"
+    :image-alt="imageAlt"
     :variant="cardVariant"
     :omit-all-uris="true"
     :image-optimisation-options="{ width: 510 }"
@@ -67,6 +68,9 @@
       },
       imageContentType() {
         return this.imageIsContentfulAsset ? this.cardFields.image.contentType : null;
+      },
+      imageAlt() {
+        return this.imageIsContentfulAsset && this.cardFields.image.description ? this.cardFields.image.description : '';
       },
       destination() {
         if (this.fields.url) {

--- a/components/browse/BrowseSections.vue
+++ b/components/browse/BrowseSections.vue
@@ -47,6 +47,7 @@
         :content-type="section.image.contentType"
         :width="section.image.width"
         :height="section.image.height"
+        :alt="section.image.description ? section.image.description : ''"
         :attribution="attributionFields(section)"
         :rights-statement="section.license"
       />

--- a/components/browse/LatestSection.vue
+++ b/components/browse/LatestSection.vue
@@ -20,6 +20,7 @@
           :image-url="cardData(card).imageUrl"
           :image-content-type="cardData(card).imageContentType"
           :image-optimisation-options="{ width: 510 }"
+          :image-alt="cardData(card).description"
         />
       </b-card-group>
       <b-button
@@ -112,6 +113,7 @@
 
         return {
           cardLink: { name, params: { [key]: card.identifier } },
+          description: card.description ? card.description : '',
           imageUrl,
           imageContentType
         };

--- a/components/generic/ContentCard.vue
+++ b/components/generic/ContentCard.vue
@@ -18,13 +18,13 @@
           :src="optimisedImageUrl"
           :blank-width="blankImageWidth"
           :blank-height="blankImageHeight"
-          alt=""
+          :alt="imageAlt"
           @error.native="imageNotFound"
         />
         <b-img
           v-else
           :src="optimisedImageUrl"
-          alt=""
+          :alt="imageAlt"
           @error="imageNotFound"
         />
       </div>
@@ -132,6 +132,10 @@
       imageContentType: {
         type: String,
         default: null
+      },
+      imageAlt: {
+        type: String,
+        default: ''
       },
       imageOptimisationOptions: {
         type: Object,

--- a/components/generic/ImageWithAttribution.vue
+++ b/components/generic/ImageWithAttribution.vue
@@ -15,6 +15,7 @@
           :src="src"
           :width="width"
           :height="height"
+          :alt="alt"
           :content-type="contentType"
           :max-width="1100"
           data-qa="image"
@@ -78,6 +79,10 @@
       height: {
         type: Number,
         default: 790
+      },
+      alt: {
+        type: String,
+        default: ''
       },
       name: {
         type: String,

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -13,6 +13,10 @@ EXPOSE ${PORT}
 
 WORKDIR /app
 
+# TODO: git is only needed to install NPM packages direct from GitHub. Remove
+#       when no longer needed.
+RUN apk add --no-cache git
+
 COPY . .
 
 RUN npm install && \

--- a/docker/stack/app/Dockerfile
+++ b/docker/stack/app/Dockerfile
@@ -15,6 +15,10 @@ EXPOSE ${PORT}
 
 WORKDIR /app
 
+# TODO: git is only needed to install NPM packages direct from GitHub. Remove
+#       when no longer needed.
+RUN apk add --no-cache git
+
 COPY package.json package-lock.json ./
 
 RUN npm install

--- a/experiments/hamburger-menu/index.js
+++ b/experiments/hamburger-menu/index.js
@@ -1,7 +1,7 @@
 export default {
   name: 'hamburger-menu',
-  experimentID: ({ $config }) => $config.app.experiments.hamburgerMenu,
-  isEligible: ({ $config }) => $config.app.experiments.hamburgerMenu,
+  experimentID: ({ $config }) => $config.googleOptimize.experiments.hamburgerMenu,
+  isEligible: ({ $config }) => $config.googleOptimize.experiments.hamburgerMenu,
   variants: [
     { component: 'A',
       weight: 50 },

--- a/experiments/hamburger-menu/index.js
+++ b/experiments/hamburger-menu/index.js
@@ -1,6 +1,7 @@
 export default {
   name: 'hamburger-menu',
-  experimentID: 'pcPZyo34Sxa3mayB2csGLA',
+  experimentID: ({ $config }) => $config.app.experiments.hamburgerMenu,
+  isEligible: ({ $config }) => $config.app.experiments.hamburgerMenu,
   variants: [
     { component: 'A',
       weight: 50 },

--- a/lang/bg.js
+++ b/lang/bg.js
@@ -3,7 +3,9 @@ export default {
     "likes": "Харесвания",
     "linkAccount": "Моят профил",
     "linkLogin": "Влизане",
+    "linkLoginJoin": "Вход/Регистрация",
     "linkLogout": "Излизане",
+    "myProfile": "Моят профил",
     "notifications": {
       "noCollections": {
         "private": "Все още не сте създали никакви лични галерии",

--- a/lang/cs.js
+++ b/lang/cs.js
@@ -3,7 +3,9 @@ export default {
     "likes": "Oblíbené",
     "linkAccount": "Můj účet",
     "linkLogin": "Přihlásit se",
+    "linkLoginJoin": "Přihlášení/Připojení",
     "linkLogout": "Odhlásit se",
+    "myProfile": "Můj profil",
     "notifications": {
       "noCollections": {
         "private": "Ještě jste nevytvořil/a žádné soukromé galerie.",

--- a/lang/da.js
+++ b/lang/da.js
@@ -3,7 +3,9 @@ export default {
     "likes": "Synes om'er",
     "linkAccount": "Min konto",
     "linkLogin": "Log ind",
+    "linkLoginJoin": "Login/Deltag",
     "linkLogout": "Log ud",
+    "myProfile": "Min profil",
     "notifications": {
       "noCollections": {
         "private": "Du har ikke oprettet nogen private gallerier endnu",

--- a/lang/de.js
+++ b/lang/de.js
@@ -3,7 +3,9 @@ export default {
     "likes": "Likes",
     "linkAccount": "Mein Konto",
     "linkLogin": "Anmelden",
+    "linkLoginJoin": "Anmelden/Beitreten",
     "linkLogout": "Abmelden",
+    "myProfile": "Mein Profil",
     "notifications": {
       "noCollections": {
         "private": "Sie haben bisher keine private Galerie erstellt",

--- a/lang/el.js
+++ b/lang/el.js
@@ -3,7 +3,9 @@ export default {
     "likes": "Like",
     "linkAccount": "Ο λογαριασμός μου",
     "linkLogin": "Σύνδεση",
+    "linkLoginJoin": "Εγγραφή/Σύνδεση",
     "linkLogout": "Αποσύνδεση",
+    "myProfile": "ΤΟ ΠΡΟΦΙΛ ΜΟΥ",
     "notifications": {
       "noCollections": {
         "private": "Δεν έχετε δημιουργήσει ιδιωτικές συλλογές",

--- a/lang/en.js
+++ b/lang/en.js
@@ -5,17 +5,18 @@ export default {
     "linkLogin": "Login",
     "linkLoginJoin": "Login/Join",
     "linkLogout": "Log out",
+    "myProfile": "My Profile",
     "notifications": {
       "noCollections": {
         "private": "You haven’t created any private galleries yet",
         "public": "You haven’t created any public galleries yet"
       },
-      "noLikedItems": "You haven’t liked any items yet"
+      "noLikedItems": "You haven’t liked any items yet",
+      "loggedIn": "You are now logged in. Welcome!",
+      "loggedOut": "You are now logged out."
     },
     "privateCollections": "Private Galleries",
     "profile": "My Likes & Galleries",
-    "profileSettings": "Profile settings",
-    "myProfile": "My Profile",
     "publicCollections": "Public Galleries",
     "settings": "Settings",
     "title": "My account"

--- a/lang/en.js
+++ b/lang/en.js
@@ -17,6 +17,7 @@ export default {
     },
     "privateCollections": "Private Galleries",
     "profile": "My Likes & Galleries",
+    "profileSettings": "Profile settings",
     "publicCollections": "Public Galleries",
     "settings": "Settings",
     "title": "My account"

--- a/lang/es.js
+++ b/lang/es.js
@@ -3,7 +3,9 @@ export default {
     "likes": "Me gusta",
     "linkAccount": "Mi cuenta",
     "linkLogin": "Iniciar sesión",
+    "linkLoginJoin": "Iniciar sesión/Unirse",
     "linkLogout": "Cerrar sesión",
+    "myProfile": "Mi perfil",
     "notifications": {
       "noCollections": {
         "private": "Aún no has creado ninguna galería privada",

--- a/lang/et.js
+++ b/lang/et.js
@@ -3,7 +3,9 @@ export default {
     "likes": "Meeldimised",
     "linkAccount": "Minu konto",
     "linkLogin": "Logi sisse",
+    "linkLoginJoin": "Logi sisse/Liitu",
     "linkLogout": "Logi välja",
+    "myProfile": "Minu profiil",
     "notifications": {
       "noCollections": {
         "private": "Te pole veel ühtegi privaatset galeriid loonud",

--- a/lang/eu.js
+++ b/lang/eu.js
@@ -3,7 +3,9 @@ export default {
     "likes": "Atsegin |",
     "linkAccount": "Nire kontua",
     "linkLogin": "Saioa hasi",
+    "linkLoginJoin": "Saioa hasi/Sartu",
     "linkLogout": "Saioa amaitu",
+    "myProfile": "Nire profila",
     "notifications": {
       "noCollections": {
         "private": "Oraindik ez duzu bilduma pribaturik sortu",

--- a/lang/fi.js
+++ b/lang/fi.js
@@ -3,7 +3,9 @@ export default {
     "likes": "Tykätyt",
     "linkAccount": "Oma tili",
     "linkLogin": "Kirjaudu sisään",
+    "linkLoginJoin": "Kirjaudu/Liity",
     "linkLogout": "Kirjaudu ulos",
+    "myProfile": "Profiilini",
     "notifications": {
       "noCollections": {
         "private": "Et ole luonut vielä yksityisiä gallerioita",

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -3,7 +3,9 @@ export default {
     "likes": "Mentions J’aime",
     "linkAccount": "Mon compte",
     "linkLogin": "Se connecter",
+    "linkLoginJoin": "Connexion/Rejoignez-nous",
     "linkLogout": "Déconnexion",
+    "myProfile": "Mon profil",
     "notifications": {
       "noCollections": {
         "private": "Vous n'avez pas encore créé de galeries privées",

--- a/lang/ga.js
+++ b/lang/ga.js
@@ -3,7 +3,9 @@ export default {
     "likes": "Toghanna",
     "linkAccount": "Mo Chuntas",
     "linkLogin": "Logáil isteach",
+    "linkLoginJoin": "Logáil Isteach",
     "linkLogout": "Logáil amach",
+    "myProfile": "Mo phróifíl",
     "notifications": {
       "noCollections": {
         "private": "Níor chruthaigh tú aon ghailearaithe príobháideacha fós",

--- a/lang/hr.js
+++ b/lang/hr.js
@@ -3,7 +3,9 @@ export default {
     "likes": "Sviđanja",
     "linkAccount": "Moj račun",
     "linkLogin": "Prijava",
+    "linkLoginJoin": "Prijavi se/Pridruži se",
     "linkLogout": "Odjava",
+    "myProfile": "Moj profil",
     "notifications": {
       "noCollections": {
         "private": "Još niste stvorili privatne galerije",

--- a/lang/hu.js
+++ b/lang/hu.js
@@ -3,7 +3,9 @@ export default {
     "likes": "Kedvelések",
     "linkAccount": "Fiókom",
     "linkLogin": "Bejelentkezés",
+    "linkLoginJoin": "Bejelentkezés/Csatlakozás",
     "linkLogout": "Bejelentkezés",
+    "myProfile": "A profilom",
     "notifications": {
       "noCollections": {
         "private": "Még nem hozott létre privát galériát",

--- a/lang/it.js
+++ b/lang/it.js
@@ -3,7 +3,9 @@ export default {
     "likes": "Mi piace",
     "linkAccount": "Il mio account",
     "linkLogin": "Accedi",
+    "linkLoginJoin": "Accedi/Iscriviti",
     "linkLogout": "Esci",
+    "myProfile": "Il mio profilo",
     "notifications": {
       "noCollections": {
         "private": "Non hai ancora creato gallerie private",

--- a/lang/lt.js
+++ b/lang/lt.js
@@ -3,7 +3,9 @@ export default {
     "likes": "Patinka",
     "linkAccount": "Mano paskyra",
     "linkLogin": "Prisijungti",
+    "linkLoginJoin": "Prisijungti/Prisijungti",
     "linkLogout": "Atsijungti",
+    "myProfile": "Mano profilis",
     "notifications": {
       "noCollections": {
         "private": "Kol kas nesukūrėte jokių privačių galerijų",

--- a/lang/lv.js
+++ b/lang/lv.js
@@ -3,7 +3,9 @@ export default {
     "likes": "Patīk",
     "linkAccount": "Mans konts",
     "linkLogin": "Pieteikties",
+    "linkLoginJoin": "Pieteikties/Pievienoties",
     "linkLogout": "Atteikties",
+    "myProfile": "Mans profils",
     "notifications": {
       "noCollections": {
         "private": "Vēl nav izveidota neviena privāta galerija",

--- a/lang/mt.js
+++ b/lang/mt.js
@@ -3,7 +3,9 @@ export default {
     "likes": "Likes",
     "linkAccount": "Il-Kont Tiegħi",
     "linkLogin": "Illoggja",
+    "linkLoginJoin": "Idħol/Ingħaqad",
     "linkLogout": "Oħroġ",
+    "myProfile": "Il-profil Tiegħi",
     "notifications": {
       "noCollections": {
         "private": "Għadek ma ħloqt l-ebda direttorju tar-ritratti privat s'issa",

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -3,7 +3,9 @@ export default {
     "likes": "Likes",
     "linkAccount": "Mijn account",
     "linkLogin": "Inloggen",
+    "linkLoginJoin": "Inloggen/Aanmelden",
     "linkLogout": "Uitloggen",
+    "myProfile": "Mijn profiel",
     "notifications": {
       "noCollections": {
         "private": "U hebt nog geen privé galerijen gemaakt",

--- a/lang/pl.js
+++ b/lang/pl.js
@@ -3,7 +3,9 @@ export default {
     "likes": "Polubienia",
     "linkAccount": "Moje konto",
     "linkLogin": "Zaloguj się",
+    "linkLoginJoin": "Zaloguj/Dołącz",
     "linkLogout": "Wyloguj",
+    "myProfile": "Mój profil",
     "notifications": {
       "noCollections": {
         "private": "Nie masz jeszcze prywatnych galerii",

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -3,7 +3,9 @@ export default {
     "likes": "Gostos",
     "linkAccount": "A minha conta",
     "linkLogin": "Inicie sessão",
+    "linkLoginJoin": "Entrar/Criar conta",
     "linkLogout": "Encerrar sessão",
+    "myProfile": "Meu perfil",
     "notifications": {
       "noCollections": {
         "private": "Ainda não criou nenhuma galeria privada",

--- a/lang/ro.js
+++ b/lang/ro.js
@@ -3,7 +3,9 @@ export default {
     "likes": "Aprecieri",
     "linkAccount": "Contul meu",
     "linkLogin": "Autentificare",
+    "linkLoginJoin": "Autentificare/Înscriere",
     "linkLogout": "Deconectare",
+    "myProfile": "Profilul meu",
     "notifications": {
       "noCollections": {
         "private": "Încă nu ai creat nicio galerie privată",

--- a/lang/sk.js
+++ b/lang/sk.js
@@ -3,7 +3,9 @@ export default {
     "likes": "Označenia Páči sa mi",
     "linkAccount": "Môj účet",
     "linkLogin": "Prihlásiť sa",
+    "linkLoginJoin": "Prihlásiť sa/Zaregistrovať sa",
     "linkLogout": "Odhlásiť sa",
+    "myProfile": "Môj profil",
     "notifications": {
       "noCollections": {
         "private": "Zatiaľ ste nevytvorili žiadne súkromné galérie",

--- a/lang/sl.js
+++ b/lang/sl.js
@@ -3,7 +3,9 @@ export default {
     "likes": "Všečki",
     "linkAccount": "Moj račun",
     "linkLogin": "Vpis",
+    "linkLoginJoin": "Prijava/Pridruži se",
     "linkLogout": "Izpis",
+    "myProfile": "Moj profil",
     "notifications": {
       "noCollections": {
         "private": "Niste še ustvarili nobene zasebne zbirke.",

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -3,7 +3,9 @@ export default {
     "likes": "Likes",
     "linkAccount": "Mitt konto",
     "linkLogin": "Logga in",
+    "linkLoginJoin": "Logga in/Gå med",
     "linkLogout": "Logga ut",
+    "myProfile": "Min profil",
     "notifications": {
       "noCollections": {
         "private": "Du har inte skapat något privat galleri ännu",

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -103,6 +103,30 @@
       }
     },
 
+    mounted() {
+      if (this.$auth.$storage.getUniversal('portalLoggingIn') && this.$auth.loggedIn) {
+        this.showToast(this.$t('account.notifications.loggedIn'));
+        this.$auth.$storage.removeUniversal('portalLoggingIn');
+      }
+      if (this.$auth.$storage.getUniversal('portalLoggingOut') && !this.$auth.loggedIn) {
+        this.showToast(this.$t('account.notifications.loggedOut'));
+        this.$auth.$storage.removeUniversal('portalLoggingOut');
+      }
+    },
+
+    methods: {
+      showToast(msg) {
+        this.$bvToast.toast(msg, {
+          toastClass: 'brand-toast',
+          toaster: 'b-toaster-bottom-left',
+          autoHideDelay: 5000,
+          isStatus: true,
+          noCloseButton: true,
+          solid: true
+        });
+      }
+    },
+
     head() {
       const i18nSeo = this.$nuxtI18nSeo();
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -69,8 +69,7 @@
       return {
         ...config,
         linkGroups: {},
-        enableAnnouncer: true,
-        variantB: false
+        enableAnnouncer: true
       };
     },
 
@@ -82,7 +81,12 @@
       ...mapGetters({
         canonicalUrl: 'http/canonicalUrl',
         canonicalUrlWithoutLocale: 'http/canonicalUrlWithoutLocale'
-      })
+      }),
+
+      variantB() {
+        return (this.$exp && this.$exp.name === 'hamburger-menu' && this.$exp.$activeVariants[0].component === 'B') ||
+          (this.$route.query.variant === 'B');
+      }
     },
 
     watch: {
@@ -96,12 +100,6 @@
             this.enableAnnouncer = true;
           }
         });
-      }
-    },
-
-    mounted() {
-      if (this.$exp && this.$exp.name === 'hamburger-menu' && this.$exp.$activeVariants[0].component === 'B') {
-        return this.variantB = true;
       }
     },
 

--- a/modules/contentful-graphql/queries/blog-foyer-page.graphql
+++ b/modules/contentful-graphql/queries/blog-foyer-page.graphql
@@ -13,6 +13,7 @@ query BlogFoyerPage(
       primaryImageOfPage {
         image {
           url
+          description
           contentType
         }
       }

--- a/modules/contentful-graphql/queries/blog-post-page.graphql
+++ b/modules/contentful-graphql/queries/blog-post-page.graphql
@@ -61,6 +61,7 @@ fragment imageWithAttributionFields on ImageWithAttribution {
   url
   image {
     url
+    description
     contentType
     width
     height

--- a/modules/contentful-graphql/queries/browse-static-page.graphql
+++ b/modules/contentful-graphql/queries/browse-static-page.graphql
@@ -25,6 +25,7 @@ query BrowseStaticPage(
       image {
         url
         contentType
+        description
       }
       # TODO: enforce this limit in CTF content model
       hasPartCollection(limit: 10) {
@@ -55,6 +56,7 @@ query BrowseStaticPage(
                   image {
                     url
                     contentType
+                    description
                   }
                 }
               }
@@ -85,6 +87,7 @@ query BrowseStaticPage(
       image {
         url
         contentType
+        description
       }
       hasPartCollection(limit: 40) {
         total
@@ -128,6 +131,7 @@ fragment imageWithAttributionFields on ImageWithAttribution {
   image {
     url
     contentType
+    description
     width
     height
   }

--- a/modules/contentful-graphql/queries/collection-page.graphql
+++ b/modules/contentful-graphql/queries/collection-page.graphql
@@ -13,6 +13,7 @@ query CollectionPage(
         url
         image {
           url
+          description
           contentType
         }
       }
@@ -55,6 +56,7 @@ query CollectionPage(
                   url
                   image {
                     url
+                    description
                     contentType
                   }
                 }

--- a/modules/contentful-graphql/queries/exhibition-chapter-page.graphql
+++ b/modules/contentful-graphql/queries/exhibition-chapter-page.graphql
@@ -66,6 +66,7 @@ fragment imageWithAttributionFields on ImageWithAttribution {
   url
   image {
     url
+    description
     contentType
     width
     height

--- a/modules/contentful-graphql/queries/exhibition-foyer-page.graphql
+++ b/modules/contentful-graphql/queries/exhibition-foyer-page.graphql
@@ -13,6 +13,7 @@ query ExhibitionFoyerPage(
       primaryImageOfPage {
         image {
           url
+          description
           contentType
         }
       }

--- a/modules/contentful-graphql/queries/exhibition-landing-page.graphql
+++ b/modules/contentful-graphql/queries/exhibition-landing-page.graphql
@@ -35,6 +35,7 @@ fragment imageWithAttributionFields on ImageWithAttribution {
   url
   image {
     url
+    description
     contentType
   }
 }

--- a/modules/contentful-graphql/queries/latest-card-groups.graphql
+++ b/modules/contentful-graphql/queries/latest-card-groups.graphql
@@ -39,6 +39,7 @@ query LatestCardGroups($preview: Boolean = false, $locale: String!, $limit: Int 
 fragment imageComparisonFields on ImageWithAttribution {
   image {
     url
+    description
     contentType
   }
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -91,7 +91,10 @@ module.exports = {
       id: process.env.GOOGLE_TAG_MANAGER_ID
     },
     googleOptimize: {
-      id: process.env.GOOGLE_OPTIMIZE_ID
+      id: process.env.GOOGLE_OPTIMIZE_ID,
+      experiments: {
+        hamburgerMenu: process.env.GOOGLE_OPTIMIZE_EXPERIMENT_ID_HAMBURGER_MENU
+      }
     },
     hotjar: {
       id: process.env.HOTJAR_ID,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@europeana/portal",
-  "version": "1.29.1",
+  "version": "1.31.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21306,19 +21306,11 @@
       }
     },
     "nuxt-google-optimize": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/nuxt-google-optimize/-/nuxt-google-optimize-0.5.4.tgz",
-      "integrity": "sha512-DSa5Y5isQI9mUikeqHbeqqzFDDIWhlilJAdVguvgt9GRU7mZgPlC7w0eL5DYd8Z7SEjzT3B4dLUmdtC7eGutQw==",
+      "version": "github:europeana/nuxt-google-optimize#a53b4f2bb129f6b90bacd1550b49ee280b45bbcb",
+      "from": "github:europeana/nuxt-google-optimize#evaluated-experiment-IDs",
       "requires": {
-        "cookie": "^0.3.1",
+        "cookie": "^0.4.0",
         "weighted-random": "^0.1.0"
-      },
-      "dependencies": {
-        "cookie": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
-        }
       }
     },
     "nuxt-i18n": {

--- a/package.json
+++ b/package.json
@@ -1,16 +1,17 @@
 {
   "name": "@europeana/portal",
-  "version": "1.29.1",
+  "version": "1.31.0",
   "description": "Europeana Portal",
   "contributors": [
     "Richard Doe <richard.doe@europeana.eu>",
     "Lutz Biedinger <lutz.biedinger@europeana.eu>",
-    "Mirjam Verloop <mirjam.verloop@europeana.eu>"
+    "Mirjam Verloop <mirjam.verloop@europeana.eu>",
+    "Leonie Peters <leonie.peters@europeana.eu>",
+    "Alan Sutherland <alan.sutherland@europeana.eu>"
   ],
   "private": true,
   "keywords": [
-    "code4lib",
-    "incubator"
+    "code4lib"
   ],
   "license": "EUPL-1.2",
   "engines": {
@@ -19,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/europeana/incubator-portal-vue-nuxt.git"
+    "url": "https://github.com/europeana/portal.js.git"
   },
   "scripts": {
     "build": "nuxt build",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "marked": "^0.7.0",
     "morgan": "^1.9.1",
     "nuxt": "^2.14.12",
-    "nuxt-google-optimize": "^0.5.4",
+    "nuxt-google-optimize": "github:europeana/nuxt-google-optimize#evaluated-experiment-IDs",
     "nuxt-i18n": "^6.10.1",
     "qs": "^6.6.0",
     "swiper": "^6.1.2",

--- a/pages/account/login.vue
+++ b/pages/account/login.vue
@@ -7,6 +7,7 @@
     layout: 'minimal',
 
     created() {
+      this.$auth.$storage.setUniversal('portalLoggingIn', true);
       this.$auth.loginWith('keycloak');
     },
 

--- a/pages/account/logout.vue
+++ b/pages/account/logout.vue
@@ -6,6 +6,10 @@
   export default {
     layout: 'minimal',
 
+    created() {
+      this.$auth.$storage.setUniversal('portalLoggingOut', true);
+    },
+
     mounted() {
       this.$auth.logout();
       localStorage.setItem('logout-event', `logout-${Math.random()}`);

--- a/pages/blog/_.vue
+++ b/pages/blog/_.vue
@@ -91,7 +91,8 @@
           { hid: 'og:description', property: 'og:description', content: this.post.description }
         ] : [])
           .concat(this.post.primaryImageOfPage ? [
-            { hid: 'og:image', property: 'og:image', content: this.post.primaryImageOfPage.image.url }
+            { hid: 'og:image', property: 'og:image', content: this.post.primaryImageOfPage.image.url },
+            { hid: 'og:image:alt', property: 'og:image', content: this.post.primaryImageOfPage.image.description || '' }
           ] : [])
       };
     },

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -18,6 +18,7 @@
             :image-url="imageUrl(post)"
             :image-content-type="imageContentType(post)"
             :image-optimisation-options="{ width: 510 }"
+            :image-alt="imageAlt(post)"
             :texts="[post.description]"
             :show-subtitle="false"
           />
@@ -95,6 +96,12 @@
           return post.primaryImageOfPage.image.contentType;
         }
         return null;
+      },
+      imageAlt(post) {
+        if (post.primaryImageOfPage && post.primaryImageOfPage.image.description) {
+          return post.primaryImageOfPage.image.description;
+        }
+        return '';
       }
     },
 

--- a/pages/collections/_type/_.vue
+++ b/pages/collections/_type/_.vue
@@ -169,18 +169,6 @@
       editorialAttribution() {
         return this.page.primaryImageOfPage.url;
       },
-      // Depiction from the Contentful entry
-      editorialDepiction() {
-        try {
-          const image = this.page.primaryImageOfPage.image;
-          return this.$options.filters.optimisedImageUrl(image.url, image.contentType, { width: 510 });
-        } catch (error) {
-          if (error instanceof TypeError) {
-            return null;
-          }
-          throw error;
-        }
-      },
       // Description from the Contentful entry
       editorialDescription() {
         if (!this.hasEditorialDescription) return null;
@@ -273,9 +261,6 @@
           .concat(this.descriptionText ? [
             { hid: 'description', name: 'description', content: this.descriptionText },
             { hid: 'og:description', property: 'og:description', content: this.descriptionText }
-          ] : [])
-          .concat(this.depiction ? [
-            { hid: 'og:image', property: 'og:image', content: this.$options.filters.urlWithProtocol(this.depiction) }
           ] : [])
       };
     },

--- a/pages/exhibitions/_exhibition/_chapter.vue
+++ b/pages/exhibitions/_exhibition/_chapter.vue
@@ -178,6 +178,7 @@
           { hid: 'title', name: 'title', content: this.page.name },
           { hid: 'og:title', property: 'og:title', content: this.page.name },
           { hid: 'og:image', property: 'og:image', content: this.optimisedImageUrl },
+          { hid: 'og:image:alt', property: 'og:image', content: this.heroImage.description },
           { hid: 'og:type', property: 'og:type', content: 'article' }
         ]
           .concat(this.page.description ? [

--- a/pages/exhibitions/_exhibition/index.vue
+++ b/pages/exhibitions/_exhibition/index.vue
@@ -129,7 +129,8 @@
           { hid: 'description', name: 'description', content: this.description },
           { hid: 'og:description', property: 'og:description', content: this.description }
         ] : []).concat(this.heroImage ? [
-          { hid: 'og:image', property: 'og:image', content: this.optimisedImageUrl }
+          { hid: 'og:image', property: 'og:image', content: this.optimisedImageUrl },
+          { hid: 'og:image:alt', property: 'og:image', content: this.heroImage.description }
         ] : [])
       };
     }

--- a/pages/exhibitions/index.vue
+++ b/pages/exhibitions/index.vue
@@ -21,6 +21,7 @@
             :image-url="imageUrl(exhibition.primaryImageOfPage)"
             :image-content-type="imageContentType(exhibition.primaryImageOfPage)"
             :image-optimisation-options="{ width: 510 }"
+            :image-alt="imageAlt(exhibition.primaryImageOfPage)"
             :texts="[exhibition.description]"
             :show-subtitle="false"
           />
@@ -91,6 +92,9 @@
       },
       imageContentType(image) {
         if (image && image.image) return image.image.contentType;
+      },
+      imageAlt(image) {
+        if (image && image.image && image.image.description) return image.image.description;
       }
     },
     head() {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -94,13 +94,18 @@
           this.$store.state.i18n.locale
         }?utm_source=new-website&utm_medium=button`;
       },
-      optimisedImageUrl() {
+      socialMediaImage() {
         // use social media image if set in Contentful, otherwise use hero image
-        let img = this.image === null ? this.heroImage.image : this.image;
-        return this.$options.filters.optimisedImageUrl(img.url, img.contentType, {
+        return this.image === null ? this.heroImage.image : this.image;
+      },
+      socialMediaImageOptimisedUrl() {
+        return this.$options.filters.optimisedImageUrl(this.socialMediaImage.url, this.socialMediaImage.contentType, {
           width: 800,
           height: 800
         });
+      },
+      socialMediaImageAlt() {
+        return this.socialMediaImage.description ? this.socialMediaImage.description : '';
       },
       hero() {
         return this.primaryImageOfPage ? this.primaryImageOfPage : null;
@@ -108,7 +113,7 @@
       heroImage() {
         let heroImage = null;
 
-        if (this.hero && this.hero.image && this.hero.image.image) {
+        if (this.hero && this.hero.image) {
           heroImage = this.hero.image;
         }
 
@@ -127,7 +132,8 @@
           { hid: 'description', name: 'description', content: this.description },
           { hid: 'og:description', property: 'og:description', content: this.description }
         ] : []).concat(this.heroImage ? [
-          { hid: 'og:image', property: 'og:image', content: this.optimisedImageUrl }
+          { hid: 'og:image', property: 'og:image', content: this.socialMediaImageOptimisedUrl },
+          { hid: 'og:image:alt', property: 'og:image', content: this.socialMediaImageAlt }
         ] : [])
       };
     }

--- a/store/set.js
+++ b/store/set.js
@@ -54,21 +54,36 @@ export const actions = {
       .then(() => {
         return this.$apis.set.modifyItems('add', state.likesId, itemId)
           .then(commit('like', itemId));
+      })
+      .catch(() => {
+        return dispatch('fetchLikes');
       });
   },
-  unlike({ commit, state }, itemId) {
+  unlike({ dispatch, commit, state }, itemId) {
     return this.$apis.set.modifyItems('delete', state.likesId, itemId)
-      .then(commit('unlike', itemId));
+      .then(commit('unlike', itemId))
+      .then(() => {
+        return dispatch('fetchLikes');
+      })
+      .catch(() => {
+        return dispatch('fetchLikes');
+      });
   },
   addItem({ dispatch }, { setId, itemId }) {
     return this.$apis.set.modifyItems('add', setId, itemId)
       .then(() => {
+        dispatch('refreshCreation', setId);
+      })
+      .catch(() => {
         dispatch('refreshCreation', setId);
       });
   },
   removeItem({ dispatch }, { setId, itemId }) {
     return this.$apis.set.modifyItems('delete', setId, itemId)
       .then(() => {
+        dispatch('refreshCreation', setId);
+      })
+      .catch(() => {
         dispatch('refreshCreation', setId);
       });
   },

--- a/tests/features/ZZ-finally/memory-usage.feature
+++ b/tests/features/ZZ-finally/memory-usage.feature
@@ -1,4 +1,6 @@
 Feature: Memory budget
   Scenario: 50 MB
     Given I am on the `home page`
+    # Wait a bit to allow garbage collection, to prevent false positives for memory leaks
+    And I wait 5 seconds
     Then the memory used is less than 50 MB

--- a/tests/unit/components/entity/EntityDetails.spec.js
+++ b/tests/unit/components/entity/EntityDetails.spec.js
@@ -24,8 +24,7 @@ const factory = (propsData = {}) => mount(EntityDetails, {
 const entityDetails = {
   title: { values: ['Book'], code: 'en' },
   description: { values: ['Architecture is both the process and the product of planning, designing, and constructing buildings and other physical structures.'], code: 'en' },
-  attribution: 'http://www.europeana.eu/item/123/abc',
-  depiction: 'https://www.example.org/image.jpeg'
+  attribution: 'http://www.europeana.eu/item/123/abc'
 };
 
 describe('components/entity/EntityDetails', () => {

--- a/tests/unit/layouts/default.spec.js
+++ b/tests/unit/layouts/default.spec.js
@@ -1,6 +1,7 @@
 import { createLocalVue, shallowMount } from '@vue/test-utils';
 import BootstrapVue from 'bootstrap-vue';
 import Vuex from 'vuex';
+import sinon from 'sinon';
 
 import layout from '../../../layouts/default';
 
@@ -22,6 +23,11 @@ const factory = () => shallowMount(layout, {
   },
   mocks: {
     $t: key => key,
+    $auth: {
+      $storage: {
+        getUniversal: sinon.spy()
+      }
+    },
     $announcer: {
       setComplementRoute: () => {}
     },

--- a/tests/unit/layouts/default.spec.js
+++ b/tests/unit/layouts/default.spec.js
@@ -27,6 +27,9 @@ const factory = () => shallowMount(layout, {
     },
     $exp: {
       $variantIndexes: [0]
+    },
+    $route: {
+      query: {}
     }
   },
   stubs: {

--- a/tests/unit/pages/account/logout.spec.js
+++ b/tests/unit/pages/account/logout.spec.js
@@ -65,7 +65,8 @@ describe('pages/account/logout.vue', () => {
             loginWith: sinon.spy(),
             logout: sinon.spy(),
             $storage: {
-              getUniversal: sinon.stub().withArgs('redirect').returns('/about-us')
+              getUniversal: sinon.stub().withArgs('redirect').returns('/about-us'),
+              setUniversal: sinon.spy()
             },
             strategies: {
               keycloak: {


### PR DESCRIPTION
This extends the work from #976 to:
1. Use a [fork of the nuxt-google-optimize module](https://github.com/europeana/nuxt-google-optimize/tree/evaluated-experiment-IDs) that adds support for supplying experiment IDs from Nuxt runtime config
2. Temporarily adds git to the two app Docker images so that this fork may be installed from GitHub
3. For the hamburger menu experiment, the env var for the ID is `GOOGLE_OPTIMIZE_EXPERIMENT_ID_HAMBURGER_MENU`
4. Marks the experiment ineligible to be run if the ID is not present, for easy toggling on/off by runtime config
5. Permits also enabling use of the B variant of the hamburger menu when Optimize is not enabled by adding to any URL `?variant=B`; this is to facilitate development & testing