### PR TITLE
DRY SSOT for navigation links

### DIFF
--- a/src/components/PageHeader.vue
+++ b/src/components/PageHeader.vue
@@ -54,7 +54,6 @@
       >
         <PageNavigation
           class="d-none d-lg-flex"
-          :links="mainNavigation"
           data-qa="top navigation"
         />
         <b-button
@@ -99,7 +98,6 @@
             </SmartLink>
           </div>
           <PageNavigation
-            :links="sidebarNavigation"
             sidebar-nav
           />
           <div />
@@ -116,6 +114,8 @@
   import { mapState } from 'vuex';
 
   export default {
+    name: 'PageHeader',
+
     components: {
       SmartLink,
       SearchForm,
@@ -131,24 +131,7 @@
     computed: {
       ...mapState({
         showSearch: state => state.search.showSearchBar
-      }),
-      mainNavigation() {
-        return [
-          { url: '/', text: this.$t('header.navigation.home') },
-          { url: '/collections', text: this.$t('header.navigation.collections') },
-          { url: '/stories', text: this.$t('header.navigation.stories') }
-        ];
-      },
-      sidebarNavigation() {
-        return [
-          { url: '/', text: this.$t('header.navigation.home') },
-          { url: '/collections', text: this.$t('header.navigation.collections') },
-          { url: '/stories', text: this.$t('header.navigation.stories') },
-          { url: '/europeana-classroom', text: this.$t('header.navigation.europeanaClassroom') },
-          { url: '/about-us', text: this.$t('header.navigation.about') },
-          { url: '/help', text: this.$t('header.navigation.help') }
-        ];
-      }
+      })
     },
 
     methods: {

--- a/src/components/PageNavigation.vue
+++ b/src/components/PageNavigation.vue
@@ -41,7 +41,7 @@
         </li>
         <li
           v-for="item in authLinks"
-          :key="item.name"
+          :key="item.url"
           class="nav-item d-block"
           :class="sidebarNav ? 'sidebar-nav-item' : 'd-lg-none'"
         >
@@ -53,7 +53,7 @@
             :data-qa="item.dataQa"
             class="nav-link"
           >
-            <span :class="renderIcon(item.name)" />
+            <span :class="renderIcon(item.url)" />
             <span>
               {{ item.text }}
             </span>
@@ -87,6 +87,8 @@
   import keycloak from '../mixins/keycloak';
 
   export default {
+    name: 'PageNavigation',
+
     components: {
       SmartLink
     },
@@ -94,10 +96,6 @@
       keycloak
     ],
     props: {
-      links: {
-        type: Array,
-        default: () => []
-      },
       sidebarNav: {
         type: Boolean,
         default: false
@@ -106,15 +104,28 @@
     data() {
       return {
         authLinks: [
-          { to: this.$path({ name: 'account' }), text: this.$t('account.myProfile'), name: '/account', dataQa: 'likes and galleries button' },
-          { href: this.keycloakAccountUrl, text: this.$t('account.profileSettings'), name: '/account/settings', dataQa: 'account settings button' },
-          { divider: true, name: 'divider' },
-          { to: { name: 'account-logout' }, text: this.$t('account.linkLogout'), name: '/account/logout', dataQa: 'log out button' }
+          { to: this.$path({ name: 'account' }), text: this.$t('account.myProfile'), url: '/account', dataQa: 'likes and galleries button' },
+          { href: this.keycloakAccountUrl, text: this.$t('account.profileSettings'), url: '/account/settings', dataQa: 'account settings button' },
+          { divider: true },
+          { to: { name: 'account-logout' }, text: this.$t('account.linkLogout'), url: '/account/logout', dataQa: 'log out button' }
+        ],
+        mainNavigation: [
+          { url: '/', text: this.$t('header.navigation.home') },
+          { url: '/collections', text: this.$t('header.navigation.collections') },
+          { url: '/stories', text: this.$t('header.navigation.stories') }
+        ],
+        sidebarNavigation: [
+          { url: '/europeana-classroom', text: this.$t('header.navigation.europeanaClassroom') },
+          { url: '/about-us', text: this.$t('header.navigation.about') },
+          { url: '/help', text: this.$t('header.navigation.help') }
         ]
       };
     },
 
     computed: {
+      links() {
+        return this.mainNavigation.concat(this.sidebarNav ? this.sidebarNavigation : []);
+      },
       isAuthenticated() {
         return this.$store.state.auth.loggedIn;
       },
@@ -126,38 +137,26 @@
       window.addEventListener('storage', this.storageEvent);
     },
     methods: {
-      renderIcon(name) {
+      renderIcon(url) {
         let className = '';
-        switch (name) {
+        switch (url) {
+        case ('/collections'):
+        case ('/help'):
+        case ('/stories'):
+        case ('/account'):
+        case ('/account/login'):
+        case ('/account/logout'):
+        case ('/account/settings'):
+          className = `icon-${url.split('/').pop()}`;
+          break;
         case ('/'):
           className = 'icon-home';
-          break;
-        case ('/collections'):
-          className = 'icon-collections';
           break;
         case ('/europeana-classroom'):
           className = 'icon-school';
           break;
         case ('/about-us'):
           className = 'icon-info';
-          break;
-        case ('/help'):
-          className = 'icon-help';
-          break;
-        case ('/account'):
-          className = 'icon-account';
-          break;
-        case ('/account/login'):
-          className = 'icon-login';
-          break;
-        case ('/account/logout'):
-          className = 'icon-logout';
-          break;
-        case ('/account/settings'):
-          className = 'icon-settings';
-          break;
-        case ('/stories'):
-          className = 'icon-stories';
           break;
         default:
           className = 'icon-info blank';

--- a/tests/unit/components/PageNavigation.spec.js
+++ b/tests/unit/components/PageNavigation.spec.js
@@ -1,30 +1,15 @@
-import { createLocalVue, mount } from '@vue/test-utils';
-import Vuex from 'vuex';
+import { createLocalVue, shallowMount } from '@vue/test-utils';
 
 import BootstrapVue from 'bootstrap-vue';
 import PageNavigation from '../../../src/components/PageNavigation.vue';
 
 const localVue = createLocalVue();
-localVue.use(Vuex);
 localVue.use(BootstrapVue);
 
-const store = new Vuex.Store({
-  modules: {
-    i18n: {
-      state: {
-        locale: 'en'
-      }
-    },
-    auth: {
-      loggedIn: false
-    }
-  }
-});
-
-const factory = () => mount(PageNavigation, {
+const factory = () => shallowMount(PageNavigation, {
   localVue,
-  store,
   mocks: {
+    $store: { state: { auth: { loggedIn: false } } },
     $t: (key) => key,
     $path: code => window.location.href + code,
     $route: { fullPath: '/fr' },
@@ -37,6 +22,6 @@ describe('components/PageNavigation', () => {
     const wrapper = factory();
     const links = wrapper.find('[data-qa="main navigation"]');
 
-    links.contains('Our partners');
+    links.html().includes('header.navigation.collections').should.be.true;
   });
 });


### PR DESCRIPTION
Refactored:
1. Move declaration of navigation links from PageHeader into PageNavigation, the only place they are used
2. Reuse the main navigation links in the sidebar navigation instead of declaring them twice
3. Rename the `name` property of the auth links to `url` for consistency with main and sidebar links
4. Where possible, derive the icon for sidebar navigation links from the final component of the URL, e.g. `/collections` derived as `icon-collections`, `/account/logout` derived as `icon-logout`, but `/about-us` is an explicit exception as `icon-info`
5. Make the PageNavigation unit test do something, as it was not testing anything at all previously