### PR TITLE
perf: reduce and freeze search response items

### DIFF
--- a/src/plugins/europeana/utils.js
+++ b/src/plugins/europeana/utils.js
@@ -297,9 +297,12 @@ export const isLangMap = (value) => {
   });
 };
 
-export const reduceLangMapsForLocale = (value, locale) => {
+export const reduceLangMapsForLocale = (value, locale, options = {}) => {
+  const defaults = { freeze: true };
+  options = { ...defaults, ...options };
+
   if (Array.isArray(value)) {
-    return value.map(val => reduceLangMapsForLocale(val, locale));
+    return value.map(val => reduceLangMapsForLocale(val, locale, options));
   } else if (typeof value === 'object') {
     if (isLangMap(value)) {
       const selectedLocale = selectLocaleForLangMap(value, locale);
@@ -310,12 +313,12 @@ export const reduceLangMapsForLocale = (value, locale) => {
       if (selectedLocale !== 'def' && Array.isArray(value.def)) {
         langMap.def = value.def
           .filter(def => def.about)
-          .map(entity => reduceLangMapsForLocale(entity, locale));
+          .map(entity => reduceLangMapsForLocale(entity, locale, options));
       }
-      return Object.freeze(langMap);
+      return options.freeze ? Object.freeze(langMap) : langMap;
     } else {
       return Object.keys(value).reduce((memo, key) => {
-        memo[key] = reduceLangMapsForLocale(value[key], locale);
+        memo[key] = reduceLangMapsForLocale(value[key], locale, options);
         return memo;
       }, {});
     }

--- a/tests/unit/plugins/europeana/search.spec.js
+++ b/tests/unit/plugins/europeana/search.spec.js
@@ -221,47 +221,108 @@ describe('plugins/europeana/search', () => {
       });
 
       context('with `items`', () => {
-        function searchResponse() {
-          return search($axios, { query: 'painting' });
+        function searchResponse(options = {}) {
+          return search($axios, { query: 'painting' }, options);
         }
 
-        const apiResponse = {
-          success: true,
-          items: [
-            {
-              id: '/123/abc',
-              type: 'IMAGE',
-              dcTitleLangAware: {
-                en: ['A painting']
-              },
-              dcDescriptionLangAware: {
-                en: ['More information about this painting']
-              },
-              dcCreatorLangAware: {
-                en: ['An artist']
-              },
-              dataProvider: ['Europeana Foundation']
-            }
-          ],
-          itemsCount: 1,
-          totalResults: 2
-        };
+        describe('.items', () => {
+          describe('are reduced to data needed for display', () => {
+            const bloatedResponse = {
+              success: true,
+              items: [
+                {
+                  id: '/123/abc',
+                  type: 'IMAGE',
+                  dataProvider: ['Europeana Foundation'],
+                  title: ['A painting', 'Een schilderij'],
+                  dcTitleLangAware: {
+                    en: ['A painting'],
+                    nl: ['Een schilderij']
+                  },
+                  dcDescription: ['More information about this painting. More information about this painting. More information about this painting. More information about this painting. More information about this painting. More information about this painting. More information about this painting.'],
+                  dcDescriptionLangAware: {
+                    en: ['More information about this painting. More information about this painting. More information about this painting. More information about this painting. More information about this painting. More information about this painting. More information about this painting.']
+                  },
+                  dcCreatorLangAware: {
+                    en: ['An artist']
+                  },
+                  edmPreview: ['https://example.org/thumbnail/123/abc.jpeg']
+                }
+              ],
+              itemsCount: 1,
+              totalResults: 2
+            };
 
-        beforeEach('stub API response', () => {
-          baseRequest
-            .query(true)
-            .reply(200, apiResponse);
-        });
+            beforeEach('stub API response', () => {
+              baseRequest
+                .query(true)
+                .reply(200, bloatedResponse);
+            });
 
-        it('includes all API response data', async() => {
-          const response = await searchResponse();
+            it('preserves required non-LangMap fields', async() => {
+              const response = await searchResponse({ locale: 'en' });
+              const item = response.items[0];
 
-          for (const key in apiResponse) {
-            response[key].should.deep.eql(apiResponse[key]);
-          }
+              item.id.should.eq('/123/abc');
+              item.type.should.eq('IMAGE');
+              item.dataProvider.should.eql(['Europeana Foundation']);
+              item.edmPreview.should.eql(['https://example.org/thumbnail/123/abc.jpeg']);
+            });
+
+            it('removes irrelevant LangMap locales', async() => {
+              const response = await searchResponse({ locale: 'en' });
+              const item = response.items[0];
+
+              item.dcTitleLangAware.should.eql({ en: ['A painting'] });
+              item.dcCreatorLangAware.should.eql({ en: ['An artist'] });
+            });
+
+            it('truncates long LangMap values', async() => {
+              const response = await searchResponse({ locale: 'en' });
+              const item = response.items[0];
+
+              item.dcDescriptionLangAware.should.eql({ en: ['More information about this painting. More information about this painting. More information about this painting. More information about this painting. More information about this painting. More information about this painting. More information about this …'] });
+            });
+
+            it('removes irrelevant fields', async() => {
+              const response = await searchResponse({ locale: 'en' });
+              const item = response.items[0];
+
+              (item.title === undefined).should.be.true;
+              (item.dcDescription === undefined).should.be.true;
+            });
+          });
         });
 
         describe('.lastAvailablePage', () => {
+          const apiResponse = {
+            success: true,
+            items: [
+              {
+                id: '/123/abc',
+                type: 'IMAGE',
+                dcTitleLangAware: {
+                  en: ['A painting']
+                },
+                dcDescriptionLangAware: {
+                  en: ['More information about this painting']
+                },
+                dcCreatorLangAware: {
+                  en: ['An artist']
+                },
+                dataProvider: ['Europeana Foundation']
+              }
+            ],
+            itemsCount: 1,
+            totalResults: 2
+          };
+
+          beforeEach('stub API response', () => {
+            baseRequest
+              .query(true)
+              .reply(200, apiResponse);
+          });
+
           context('when page is not at the API limit', () => {
             it('is `false`', async() => {
               const response = await searchResponse();


### PR DESCRIPTION
Reductions:
* Pick fields we need for search result display
* Reduce lang maps to values needed for user's locale
* Truncate lang map values