### PR TITLE
Retry request without auth when token refresh request fails

### DIFF
--- a/src/plugins/europeana/auth.js
+++ b/src/plugins/europeana/auth.js
@@ -1,6 +1,14 @@
 // @see https://github.com/nuxt-community/auth-module/blob/v4.9.1/lib/schemes/oauth2.js#L157-L201
 const refreshAccessToken = async({ $auth, $axios, redirect, route }, requestConfig) => {
-  const refreshAccessTokenResponse = await $auth.request(refreshAccessTokenRequestOptions($auth));
+  let refreshAccessTokenResponse;
+  try {
+    refreshAccessTokenResponse = await $auth.request(refreshAccessTokenRequestOptions($auth));
+  } catch {
+    // Refresh token is no longer valid; clear tokens and try again
+    $auth.logout();
+    delete requestConfig.headers['Authorization'];
+    return $axios.request(requestConfig);
+  }
 
   if (!updateAccessToken($auth, requestConfig, refreshAccessTokenResponse)) {
     // No new access token; redirect to login URL
@@ -84,7 +92,7 @@ export const keycloakResponseErrorHandler = (context, error) => {
 };
 
 const keycloakUnauthorizedResponseErrorHandler = ({ $auth, $axios, redirect, route }, error) => {
-  if ($auth.loggedIn && $auth.getRefreshToken($auth.strategy.name)) {
+  if ($auth.getRefreshToken($auth.strategy.name)) {
     // User has previously logged in, and we have a refresh token, e.g.
     // access token has expired
     return refreshAccessToken({ $auth, $axios, redirect, route }, error.config);

--- a/src/plugins/europeana/set.js
+++ b/src/plugins/europeana/set.js
@@ -14,7 +14,7 @@ export default (context = {}) => {
     $axios,
 
     search(params) {
-      return $axios.get('/search', { params })
+      return $axios.get('/search', { params: { ...$axios.defaults.params, ...params } })
         .then(response => response)
         .catch(error => {
           throw apiError(error);
@@ -45,7 +45,7 @@ export default (context = {}) => {
       const defaults = {
         profile: 'standard'
       };
-      const params = { ...defaults, ...options };
+      const params = { ...$axios.defaults.params, ...defaults, ...options };
 
       return $axios.get(`/${setIdFromUri(id)}`, { params })
         .then(response => {

--- a/tests/unit/plugins/europeana/set.spec.js
+++ b/tests/unit/plugins/europeana/set.spec.js
@@ -2,7 +2,7 @@ import nock from 'nock';
 
 import set, { BASE_URL } from '@/plugins/europeana/set';
 
-const axios = require('axios');
+const $config = { europeana: { apis: { set: { key: 'apikey' } } } };
 
 const setId = '1234';
 const itemId = '/123/abc';
@@ -59,25 +59,37 @@ describe('describe./@/plugins/europeana/set', () => {
   });
 
   describe('getSet()', () => {
-    it('get the set data', async() => {
+    it('gets the set data', async() => {
       const setId = '1';
-      const profile = 'standard';
       nock(BASE_URL)
-        .get(`/${setId}?profile=standard`)
+        .get(`/${setId}`)
+        .query(true)
         .reply(200, setsResponse[0]);
 
-      const response =  await set(axios).getSet(setId, { profile });
+      const response = await set({ $config }).getSet(setId);
       response.items.should.deep.equal(['item-1', 'item-2']);
+    });
+
+    it('includes the axios default params', async() => {
+      const setId = '1';
+      nock(BASE_URL)
+        .get(`/${setId}`)
+        .query(query => query.wskey === 'apikey')
+        .reply(200);
+
+      await set({ $config }).getSet(setId);
+      nock.isDone().should.be.true;
     });
   });
 
   describe('getLikes()', () => {
     it('get the likes set ID', async() => {
       nock(BASE_URL)
-        .get('/search?query=creator:auth-user-sub+type:BookmarkFolder')
+        .get('/search')
+        .query(query => query.query === 'creator:auth-user-sub type:BookmarkFolder')
         .reply(200, searchResponse);
 
-      const response = await set(axios).getLikes('auth-user-sub');
+      const response = await set({ $config }).getLikes('auth-user-sub');
       response.should.eq('http://data.europeana.eu/set/163');
     });
   });
@@ -86,9 +98,10 @@ describe('describe./@/plugins/europeana/set', () => {
     it('creates a likes set', async() => {
       nock(BASE_URL)
         .post('/')
+        .query(true)
         .reply(200, likesResponse);
 
-      const response = await set(axios).createLikes();
+      const response = await set({ $config }).createLikes();
       response.id.should.eq('http://data.europeana.eu/set/1234');
     });
   });
@@ -97,17 +110,21 @@ describe('describe./@/plugins/europeana/set', () => {
     it('adds item to set', async() => {
       nock(BASE_URL)
         .put(`/${setId}${itemId}`)
+        .query(true)
         .reply(200, likesResponse);
-      const response =  await set(axios).modifyItems('add', setId, itemId);
+      const response =  await set({ $config }).modifyItems('add', setId, itemId);
       response.id.should.eq('http://data.europeana.eu/set/1234');
     });
   });
 
   describe('deleteSet()', () => {
     it('deletes item from set', async() => {
-      nock(BASE_URL).delete(`/${setId}`).reply(204);
+      nock(BASE_URL)
+        .delete(`/${setId}`)
+        .query(true)
+        .reply(204);
 
-      await set(axios).deleteSet(setId);
+      await set({ $config }).deleteSet(setId);
       nock.isDone().should.be.true;
     });
   });


### PR DESCRIPTION
To handle the situation where a request with authorization fails because the tokens are invalid, but the request may not need authorization anyway, e.g. when viewing a public set. Removes the tokens and retries the request. If it does not require authorization, it will then succeed; if it does require authorization, then it will receive the relevant error message.

Also addresses an issue with difference in behaviour between dev/production builds when requesting a public set without any authorization, where dev builds were redirecting to login instead of displaying the set.