### PR TITLE
Fetch creations with standard profile

### DIFF
--- a/src/components/account/UserSets.vue
+++ b/src/components/account/UserSets.vue
@@ -18,7 +18,7 @@
             :key="set.id"
             :sub-title="setSubTitle(set)"
             :title="set.title"
-            :image-url="$apis.set.getSetThumbnail(set)"
+            :image-url="$store.getters['set/creationPreview'](set.id)"
             :texts="[set.description]"
             :url="{ name: 'set-all', params: { pathMatch: setPathMatch(set) } }"
             data-qa="user set"

--- a/src/components/set/AddItemToSetButton.vue
+++ b/src/components/set/AddItemToSetButton.vue
@@ -4,6 +4,7 @@
     :style="style"
     :variant="variant"
     class="btn-collection w-100 text-left d-flex justify-content-between align-items-center"
+    :data-qa="`toggle item button`"
     @click="$emit('toggle')"
   >
     <span>{{ displayField('title') }} ({{ set.visibility }}) - {{ $tc('items.itemCount', set.total || 0) }}</span>

--- a/src/components/set/AddItemToSetButton.vue
+++ b/src/components/set/AddItemToSetButton.vue
@@ -15,6 +15,8 @@
 </template>
 
 <script>
+  import { langMapValueForLocale } from '@/plugins/europeana/utils';
+
   export default {
     name: 'AddItemToSetButton',
 
@@ -55,15 +57,8 @@
     },
 
     methods: {
-      // TODO: use lang map l10n function
       displayField(field) {
-        if (!this.set[field]) {
-          return '';
-        } else if (this.set[field][this.$i18n.locale]) {
-          return this.set[field][this.$i18n.locale];
-        } else {
-          return this.set[field].en;
-        }
+        return langMapValueForLocale(this.set[field], this.$i18n.locale).values[0];
       }
     }
   };

--- a/src/components/set/AddItemToSetButton.vue
+++ b/src/components/set/AddItemToSetButton.vue
@@ -1,0 +1,91 @@
+<template>
+  <b-button
+    :disabled="disabled"
+    :style="style"
+    :variant="variant"
+    class="btn-collection w-100 text-left d-flex justify-content-between align-items-center"
+    @click="$emit('toggle')"
+  >
+    <span>{{ displayField('title') }} ({{ set.visibility }}) - {{ $tc('items.itemCount', set.total || 0) }}</span>
+    <span
+      v-if="checked"
+      class="icon-check_circle d-inline-flex"
+    />
+  </b-button>
+</template>
+
+<script>
+  export default {
+    name: 'AddItemToSetButton',
+
+    props: {
+      set: {
+        type: Object,
+        required: true
+      },
+      img: {
+        type: String,
+        default: null
+      },
+      added: {
+        type: Boolean,
+        default: false
+      },
+      checked: {
+        type: Boolean,
+        default: false
+      },
+      disabled: {
+        type: Boolean,
+        default: false
+      }
+    },
+
+    computed: {
+      style() {
+        if (!this.added && this.img) {
+          return { 'background-image': `url("${this.img}")` };
+        }
+        return null;
+      },
+
+      variant() {
+        return this.added ? 'success' : 'overlay';
+      }
+    },
+
+    methods: {
+      // TODO: use lang map l10n function
+      displayField(field) {
+        if (!this.set[field]) {
+          return '';
+        } else if (this.set[field][this.$i18n.locale]) {
+          return this.set[field][this.$i18n.locale];
+        } else {
+          return this.set[field].en;
+        }
+      }
+    }
+  };
+</script>
+
+<style lang="scss" scoped>
+  @import '@/assets/scss/variables.scss';
+
+  .btn-collection {
+    border: 0;
+    font-size: 1rem;
+    font-weight: 500;
+    margin-bottom: 0.5rem;
+    padding: 1rem;
+    position: relative;
+    text-transform: none;
+    span {
+      position: relative;
+      z-index: 10;
+      &.icon-check_circle {
+        font-size: $font-size-large;
+      }
+    }
+  }
+</style>

--- a/src/components/set/AddItemToSetModal.vue
+++ b/src/components/set/AddItemToSetModal.vue
@@ -87,11 +87,7 @@
       // Array of IDs of sets containing the item
       collectionsWithItem() {
         return this.collections
-          .filter(collection => (
-            (collection.items || [])
-            .map(item => item.replace(`${EUROPEANA_DATA_URL}/item`, ''))
-            .includes(this.itemId)
-          ))
+          .filter(collection => (collection.items || []).includes(`${EUROPEANA_DATA_URL}/item${this.itemId}`))
           .map(collection => collection.id);
       }
     },
@@ -125,7 +121,6 @@
       },
 
       addItem(setId) {
-        // TODO: error handling
         this.$store.dispatch('set/addItem', { setId, itemId: this.itemId });
       },
 

--- a/src/components/set/AddItemToSetModal.vue
+++ b/src/components/set/AddItemToSetModal.vue
@@ -42,6 +42,8 @@
 </template>
 
 <script>
+  import { BASE_URL as EUROPEANA_DATA_URL } from '@/plugins/europeana/data';
+
   import AddItemToSetButton from './AddItemToSetButton';
 
   export default {
@@ -85,7 +87,11 @@
       // Array of IDs of sets containing the item
       collectionsWithItem() {
         return this.collections
-          .filter(collection => (collection.items || []).some(item => item.id === this.itemId))
+          .filter(collection => (
+            (collection.items || [])
+            .map(item => item.replace(`${EUROPEANA_DATA_URL}/item`, ''))
+            .includes(this.itemId)
+          ))
           .map(collection => collection.id);
       }
     },

--- a/src/components/set/AddItemToSetModal.vue
+++ b/src/components/set/AddItemToSetModal.vue
@@ -17,22 +17,17 @@
       {{ $t('set.actions.createNew') }}
     </b-button>
     <div class="collections">
-      <b-button
+      <AddItemToSetButton
         v-for="(collection, index) in collections"
         :key="index"
+        :set="collection"
+        :img="collectionPreview(collection.id)"
         :disabled="!fetched"
-        :style="!added.includes(collection.id) && buttonBackground($apis.set.getSetThumbnail(collection))"
-        :variant="added.includes(collection.id) ? 'success' : 'overlay'"
-        class="btn-collection w-100 text-left d-flex justify-content-between align-items-center"
+        :added="added.includes(collection.id)"
+        :checked="collectionsWithItem.includes(collection.id)"
         :data-qa="`toggle item button ${index}`"
-        @click="toggleItem(collection.id)"
-      >
-        <span>{{ displayField(collection, 'title') }} ({{ collection.visibility }}) - {{ $tc('items.itemCount', collection.total || 0) }}</span>
-        <span
-          v-if="collectionsWithItem.includes(collection.id)"
-          class="icon-check_circle d-inline-flex"
-        />
-      </b-button>
+        @toggle="toggleItem(collection.id)"
+      />
     </div>
     <div class="modal-footer">
       <b-button
@@ -47,8 +42,14 @@
 </template>
 
 <script>
+  import AddItemToSetButton from './AddItemToSetButton';
+
   export default {
     name: 'AddItemToSetModal',
+
+    components: {
+      AddItemToSetButton
+    },
 
     props: {
       itemId: {
@@ -113,14 +114,8 @@
         });
       },
 
-      toggleItem(setId) {
-        if (this.collectionsWithItem.includes(setId)) {
-          this.added = this.added.filter(id => id !== setId);
-          this.removeItem(setId);
-        } else {
-          this.added.push(setId);
-          this.addItem(setId);
-        }
+      collectionPreview(setId) {
+        return this.$store.getters['set/creationPreview'](setId);
       },
 
       addItem(setId) {
@@ -132,44 +127,20 @@
         this.$store.dispatch('set/removeItem', { setId, itemId: this.itemId });
       },
 
-      // TODO: use lang map l10n function
-      displayField(set, field) {
-        if (!set[field]) {
-          return '';
-        } else if (set[field][this.$i18n.locale]) {
-          return set[field][this.$i18n.locale];
+      toggleItem(setId) {
+        if (this.collectionsWithItem.includes(setId)) {
+          this.added = this.added.filter(id => id !== setId);
+          this.removeItem(setId);
         } else {
-          return set[field]['en'];
+          this.added.push(setId);
+          this.addItem(setId);
         }
-      },
-
-      buttonBackground(img) {
-        return img ? { 'background-image': `url("${img}")` } : null;
       }
     }
   };
 </script>
 
 <style lang="scss" scoped>
-  @import '@/assets/scss/variables.scss';
-
-  .btn-collection {
-    border: 0;
-    font-size: 1rem;
-    font-weight: 500;
-    margin-bottom: 0.5rem;
-    padding: 1rem;
-    position: relative;
-    text-transform: none;
-    span {
-      position: relative;
-      z-index: 10;
-      &.icon-check_circle {
-        font-size: $font-size-large;
-      }
-    }
-  }
-
   .collections {
     max-height: calc(100vh - 474px);
     overflow: auto;

--- a/src/store/set.js
+++ b/src/store/set.js
@@ -159,7 +159,7 @@ export default {
     refreshCreation({ state, commit, dispatch }, setId) {
       const setToReplaceIndex = state.creations.findIndex(set => set.id === setId);
       if (setToReplaceIndex === -1) {
-        return;
+        return Promise.resolve();
       }
 
       return this.$apis.set.getSet(setId, {

--- a/tests/unit/components/account/UserSets.spec.js
+++ b/tests/unit/components/account/UserSets.spec.js
@@ -41,7 +41,12 @@ const factory = (propsData) => mount(UserSets, {
     $t: (key) => key,
     $tc: (key) => key,
     $path: () => 'localizedPath',
-    $i18n: { locale: 'en' }
+    $i18n: { locale: 'en' },
+    $store: {
+      getters: {
+        'set/creationPreview': (id) => id
+      }
+    }
   }
 });
 

--- a/tests/unit/components/set/AddItemToSetButton.spec.js
+++ b/tests/unit/components/set/AddItemToSetButton.spec.js
@@ -1,0 +1,44 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import BootstrapVue from 'bootstrap-vue';
+import AddItemToSetButton from '@/components/set/AddItemToSetButton';
+
+const localVue = createLocalVue();
+localVue.use(BootstrapVue);
+
+const collection =
+  {
+    id: '001',
+    items: ['http://data.europeana.eu/item/000/aaa'],
+    title: 'Test collection',
+    total: 1,
+    visibility: 'public'
+  };
+
+const factory = (propsData = {}) => shallowMount(AddItemToSetButton, {
+  localVue,
+  propsData: {
+    ...propsData
+  },
+  mocks: {
+    $tc: () => {},
+    $i18n: {}
+  }
+});
+
+describe('components/set/AddItemToSetButton', () => {
+  it('emits the toggle event', async() => {
+    const wrapper = factory({ set: collection });
+
+    await wrapper.find('[data-qa="toggle item button"]').trigger('click');
+
+    wrapper.emitted('toggle').length.should.equal(1);
+  });
+
+  context('when an item is not yet added it', () => {
+    it('contains a background image of the first item in the set', () => {
+      const wrapper = factory({ set: collection, img: 'https://www.example.org/image' });
+
+      wrapper.find('[data-qa="toggle item button"]').attributes('style').should.equal('background-image: url(https://www.example.org/image);');
+    });
+  });
+});

--- a/tests/unit/components/set/AddItemToSetModal.spec.js
+++ b/tests/unit/components/set/AddItemToSetModal.spec.js
@@ -9,11 +9,13 @@ localVue.use(BootstrapVue);
 const storeDispatch = sinon.stub().resolves({});
 
 const sets = [
-  { id: '001',
-    items: [{ id: '/000/aaa' }],
+  {
+    id: '001',
+    items: ['http://data.europeana.eu/item/000/aaa'],
     title: 'Test collection',
     total: 1,
-    visibility: 'public' }
+    visibility: 'public'
+  }
 ];
 
 const factory = (propsData = {}) => mount(AddItemToSetModal, {
@@ -33,8 +35,10 @@ const factory = (propsData = {}) => mount(AddItemToSetModal, {
     },
     $store: {
       dispatch: storeDispatch,
-      state:
-        { set: { creations: sets } }
+      state: { set: { creations: sets } },
+      getters: {
+        'set/creationPreview': (id) => id
+      }
     }
   }
 });
@@ -69,11 +73,13 @@ describe('components/set/AddItemToSetModal', () => {
 
       storeDispatch.should.have.been.calledWith('set/addItem', { setId: '001', itemId: '/123/abc' });
     });
+
     it('removes item from gallery when item already added', async() => {
       const wrapper = factory({ itemId: '/000/aaa', modalId: 'add-item-to-set-modal-/000/aaa' });
       await wrapper.setData({ fetched: true });
 
       await wrapper.find('[data-qa="toggle item button 0"]').trigger('click');
+      // await wrapper.find('[data-qa="toggle item button 0"]').vm.$emit('toggle');
 
       storeDispatch.should.have.been.calledWith('set/removeItem', { setId: '001', itemId: '/000/aaa' });
     });

--- a/tests/unit/components/set/AddItemToSetModal.spec.js
+++ b/tests/unit/components/set/AddItemToSetModal.spec.js
@@ -64,7 +64,7 @@ describe('components/set/AddItemToSetModal', () => {
     });
   });
 
-  describe('toggle item button', () => {
+  describe('AddItemToSetButton', () => {
     it('adds item to gallery when item is not yet added', async() => {
       const wrapper = factory({ itemId: '/123/abc', modalId: 'add-item-to-set-modal-/123/abc' });
       await wrapper.setData({ fetched: true });
@@ -79,7 +79,6 @@ describe('components/set/AddItemToSetModal', () => {
       await wrapper.setData({ fetched: true });
 
       await wrapper.find('[data-qa="toggle item button 0"]').trigger('click');
-      // await wrapper.find('[data-qa="toggle item button 0"]').vm.$emit('toggle');
 
       storeDispatch.should.have.been.calledWith('set/removeItem', { setId: '001', itemId: '/000/aaa' });
     });

--- a/tests/unit/store/set.spec.js
+++ b/tests/unit/store/set.spec.js
@@ -272,21 +272,46 @@ describe('store/set', () => {
     });
 
     describe('fetchCreations()', () => {
-      it('fetches creations via $apis.set, then commits with "setCreations"', async() => {
+      it('fetches creations via $apis.set', async() => {
         const searchResponse = { data: { items: ['1', '2'] } };
         store.actions.$auth.user = { sub: userId };
         store.actions.$apis.set.search = sinon.stub().resolves(searchResponse);
 
-        await store.actions.fetchCreations({ commit });
+        await store.actions.fetchCreations({ commit, dispatch });
 
         store.actions.$apis.set.search.should.have.been.calledWith({
           query: `creator:${userId}`,
-          profile: 'itemDescriptions',
+          profile: 'standard',
           pageSize: 100,
           qf: 'type:Collection'
         });
+      });
+
+      it('removes data.europeana.eu/item prefix from set IDs');
+
+      it('commits creations with "setCreations"', async() => {
+        const searchResponse = { data: { items: ['1', '2'] } };
+        store.actions.$auth.user = { sub: userId };
+        store.actions.$apis.set.search = sinon.stub().resolves(searchResponse);
+
+        await store.actions.fetchCreations({ commit, dispatch });
+
         commit.should.have.been.calledWith('setCreations', ['1', '2']);
       });
+
+      it('triggers fetching of creation previews', async() => {
+        const searchResponse = { data: { items: ['1', '2'] } };
+        store.actions.$auth.user = { sub: userId };
+        store.actions.$apis.set.search = sinon.stub().resolves(searchResponse);
+
+        await store.actions.fetchCreations({ commit, dispatch });
+
+        dispatch.should.have.been.calledWith('fetchCreationPreviews');
+      });
+    });
+
+    describe('fetchCreationPreviews()', () => {
+      it('fetches first items for each creation via $apis.record');
     });
 
     describe('fetchCurations()', () => {

--- a/tests/unit/store/set.spec.js
+++ b/tests/unit/store/set.spec.js
@@ -254,17 +254,17 @@ describe('store/set', () => {
         });
       });
 
-      context('when creation is not stored', () => {
+      context('when creation is stored', () => {
         it('fetches it via $apis.set with itemDescriptions, then commits with "setCreations"', async() => {
           const oldCreation = { id: setId, title: { en: 'Old title' } };
           const newCreation = { id: setId, title: { en: 'New title' } };
           const state = { creations: [oldCreation] };
           store.actions.$apis.set.getSet = sinon.stub().resolves(newCreation);
 
-          await store.actions.refreshCreation({ commit, state }, setId);
+          await store.actions.refreshCreation({ commit, state, dispatch }, setId);
 
           store.actions.$apis.set.getSet.should.have.been.calledWith(setId, {
-            profile: 'itemDescriptions'
+            profile: 'standard'
           });
           commit.should.have.been.calledWith('setCreations', [newCreation]);
         });
@@ -286,8 +286,6 @@ describe('store/set', () => {
           qf: 'type:Collection'
         });
       });
-
-      it('removes data.europeana.eu/item prefix from set IDs');
 
       it('commits creations with "setCreations"', async() => {
         const searchResponse = { data: { items: ['1', '2'] } };
@@ -312,6 +310,8 @@ describe('store/set', () => {
 
     describe('fetchCreationPreviews()', () => {
       it('fetches first items for each creation via $apis.record');
+
+      it('commits edm:preview of items with "setCreationPreviews"');
     });
 
     describe('fetchCurations()', () => {

--- a/tests/unit/store/set.spec.js
+++ b/tests/unit/store/set.spec.js
@@ -255,7 +255,7 @@ describe('store/set', () => {
       });
 
       context('when creation is stored', () => {
-        it('fetches it via $apis.set with itemDescriptions, then commits with "setCreations"', async() => {
+        it('fetches it via $apis.set, then commits with "setCreations"', async() => {
           const oldCreation = { id: setId, title: { en: 'Old title' } };
           const newCreation = { id: setId, title: { en: 'New title' } };
           const state = { creations: [oldCreation] };


### PR DESCRIPTION
Then fetch edm:previews for sets from Record API with minimal profile, and store in a new state property.

Why? Because the itemDescriptions profile becomes very slow as the user's number of sets and/or the number of items in sets increases, greatly impairing the UX of the add to gallery feature, and the only reason we request it is to get an edm:preview for the sets from one of the items in that set.

These changes greatly improve the time-to-interaction of the modal for adding items to galleries, e.g. from ~ 1 second to ~ 125 ms with 8 sets, some being empty and only one having 40-50 items.

However... one drawback of this approach is that the preview for a set will only ever consider the first item in the set, i.e. it won't go looking over all items in the set until it finds an edm:preview.

TODO:
* Any additional unit tests needed?