### PR TITLE
chore: optimize Nuxt build config and Bootstrap Vue plugin registration

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,5 +1,10 @@
 /* eslint-disable camelcase */
 
+/*
+** Nuxt config
+** Docs: https://nuxtjs.org/docs/configuration-glossary/
+*/
+
 const APP_SITE_NAME = 'Europeana';
 
 import pkg from './package.json';
@@ -208,10 +213,16 @@ export default {
     bootstrapVueCSS: false,
 
     // Tree shake plugins
+    //
+    // NOTE: do not register plugins globally (here) unless they are used widely;
+    //       import them locally into the views that need them instead. This
+    //       is to prevent large amounts of unused JS being sent upfront to clients.
+    //       As a general rule, only register globally if at least three views
+    //       use the plugin's components/directives. Also consider how often
+    //       those components are rendered based on placement in layout and
+    //       usage patterns by users, and the plugin's bundled size.
     componentPlugins: [
-      'AlertPlugin',
       'BadgePlugin',
-      'BreadcrumbPlugin',
       'ButtonPlugin',
       'CardPlugin',
       'DropdownPlugin',
@@ -227,16 +238,10 @@ export default {
       'LayoutPlugin',
       'LinkPlugin',
       'ListGroupPlugin',
-      'MediaPlugin',
       'ModalPlugin',
       'NavbarPlugin',
-      'NavPlugin',
-      'PaginationNavPlugin',
       'SidebarPlugin',
-      'TablePlugin',
-      'TabsPlugin',
-      'ToastPlugin',
-      'TooltipPlugin'
+      'ToastPlugin'
     ]
   },
 
@@ -362,7 +367,26 @@ export default {
   /*
   ** Build configuration
   */
-  build: {},
+  build: {
+    // Extract CSS to files instead of inlining to keep HTML page size down.
+    // This results in more network requests in total to render the full page,
+    // but a smaller HTML document, and a smaller total size of all requests.
+    // Lighthouse performance ratings favour this by a few percentage points.
+    extractCSS: true,
+
+    extend(config, { isClient }) {
+      // Extend webpack config only for client bundle
+      if (isClient) {
+        // Build source maps to aid debugging in production builds
+        config.devtool = 'source-map';
+      }
+    }
+  },
+
+  /*
+  ** Enable modern builds
+  */
+  modern: true,
 
   /*
   ** Render configuration

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -368,11 +368,9 @@ export default {
   ** Build configuration
   */
   build: {
-    // Extract CSS to files instead of inlining to keep HTML page size down.
-    // This results in more network requests in total to render the full page,
-    // but a smaller HTML document, and a smaller total size of all requests.
-    // Lighthouse performance ratings favour this by a few percentage points.
-    extractCSS: true,
+    // Do not enable extractCSS as it is unreliable.
+    // See: https://github.com/nuxt/nuxt.js/issues/4219
+    extractCSS: false,
 
     extend(config, { isClient }) {
       // Extend webpack config only for client bundle

--- a/src/components/generic/AlertMessage.vue
+++ b/src/components/generic/AlertMessage.vue
@@ -10,7 +10,12 @@
 </template>
 
 <script>
+  import { BAlert } from 'bootstrap-vue';
+
   export default {
+    components: {
+      BAlert
+    },
     props: {
       error: {
         type: String,

--- a/src/components/generic/ContentCard.vue
+++ b/src/components/generic/ContentCard.vue
@@ -95,6 +95,7 @@
 <script>
   import ClientOnly from 'vue-client-only';
   import SmartLink from './SmartLink';
+  import stripMarkdown from '@/mixins/stripMarkdown';
   import { langMapValueForLocale } from  '@/plugins/europeana/utils';
 
   export default {
@@ -104,6 +105,10 @@
       ClientOnly,
       SmartLink
     },
+
+    mixins: [
+      stripMarkdown
+    ],
 
     props: {
       title: {
@@ -273,7 +278,7 @@
           limited.push(this.$t('formatting.ellipsis'));
         }
         const joined = limited.join(this.$t('formatting.listSeperator') + ' ');
-        const stripped = this.$options.filters.stripMarkdown(joined);
+        const stripped = this.stripMarkdown(joined);
         return this.$options.filters.truncate(stripped, 255, this.$t('formatting.ellipsis'));
       },
 

--- a/src/components/generic/InfoMessage.vue
+++ b/src/components/generic/InfoMessage.vue
@@ -20,7 +20,12 @@
 </template>
 
 <script>
+  import { BAlert } from 'bootstrap-vue';
+
   export default {
+    components: {
+      BAlert
+    },
     props: {
       message: {
         type: String,

--- a/src/components/generic/PaginationNav.vue
+++ b/src/components/generic/PaginationNav.vue
@@ -15,7 +15,12 @@
 </template>
 
 <script>
+  import { BPaginationNav } from 'bootstrap-vue';
+
   export default {
+    components: {
+      BPaginationNav
+    },
     props: {
       perPage: {
         type: Number,

--- a/src/components/item/MetadataBox.vue
+++ b/src/components/item/MetadataBox.vue
@@ -88,13 +88,14 @@
 </template>
 
 <script>
-  import { BTabs } from 'bootstrap-vue';
+  import { BTab, BTabs } from 'bootstrap-vue';
   import MetadataField from './MetadataField';
 
   export default {
     name: 'MetadataBox',
 
     components: {
+      BTab,
       BTabs,
       MetadataField,
       MapEmbed: () => import('../geo/MapEmbed')

--- a/src/components/item/MetadataBox.vue
+++ b/src/components/item/MetadataBox.vue
@@ -88,12 +88,14 @@
 </template>
 
 <script>
+  import { BTabs } from 'bootstrap-vue';
   import MetadataField from './MetadataField';
 
   export default {
     name: 'MetadataBox',
 
     components: {
+      BTabs,
       MetadataField,
       MapEmbed: () => import('../geo/MapEmbed')
     },

--- a/src/components/item/SummaryInfo.vue
+++ b/src/components/item/SummaryInfo.vue
@@ -15,7 +15,7 @@
           {{ heading.value }}
           <button
             v-if="translatedItemsEnabled"
-            v-b-tooltip.bottomright="{ customClass: 'tooltip' }"
+            v-b-tooltip.bottomright
             :title="$t(`multilingual.${heading.translationSource || 'original'}`)"
             class="translation-source"
             :class="heading.translationSource || 'original'"
@@ -31,7 +31,7 @@
           {{ heading.value }}
           <button
             v-if="translatedItemsEnabled"
-            v-b-tooltip.bottomright="{ customClass: 'tooltip' }"
+            v-b-tooltip.bottomright
             :title="$t(`multilingual.${heading.translationSource || 'original'}`)"
             class="translation-source"
             :class="heading.translationSource || 'original'"
@@ -62,7 +62,7 @@
         <!-- eslint-disable vue/no-v-html -->
         <button
           v-if="translatedItemsEnabled && index === 0"
-          v-b-tooltip.bottomright="{ customClass: 'tooltip' }"
+          v-b-tooltip.bottomright
           :title="$t(`multilingual.${description.translationSource || 'original'}`)"
           class="translation-source"
           :class="description.translationSource || 'original'"
@@ -70,7 +70,7 @@
         />
         <button
           v-else-if="translatedItemsEnabled && showAll"
-          v-b-tooltip.bottomright="{ customClass: 'tooltip' }"
+          v-b-tooltip.bottomright
           :title="$t(`multilingual.${description.translationSource || 'original'}`)"
           class="translation-source"
           :class="description.translationSource || 'original'"

--- a/src/components/item/SummaryInfo.vue
+++ b/src/components/item/SummaryInfo.vue
@@ -94,10 +94,17 @@
 </template>
 
 <script>
+  import { VBTooltip, BTooltip } from 'bootstrap-vue';
+
   export default {
     name: 'SummaryInfo',
 
     components: {
+      BTooltip
+    },
+
+    directives: {
+      'b-tooltip': VBTooltip
     },
 
     props: {

--- a/src/components/item/SummaryInfo.vue
+++ b/src/components/item/SummaryInfo.vue
@@ -94,14 +94,10 @@
 </template>
 
 <script>
-  import { VBTooltip, BTooltip } from 'bootstrap-vue';
+  import { VBTooltip } from 'bootstrap-vue';
 
   export default {
     name: 'SummaryInfo',
-
-    components: {
-      BTooltip
-    },
 
     directives: {
       'b-tooltip': VBTooltip

--- a/src/components/search/ViewToggles.vue
+++ b/src/components/search/ViewToggles.vue
@@ -20,8 +20,13 @@
 </template>
 
 <script>
+  import { BNav } from 'bootstrap-vue';
+
   export default {
     name: 'ViewToggles',
+    components: {
+      BNav
+    },
     props: {
       value: {
         type: String,

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -44,6 +44,7 @@
 
 <script>
   import { mapGetters, mapState } from 'vuex';
+  import { BBreadcrumb } from 'bootstrap-vue';
   import ClientOnly from 'vue-client-only';
   import PageHeader from '../components/PageHeader';
   import klaroConfig from '../plugins/klaro-config';
@@ -54,6 +55,7 @@
 
   export default {
     components: {
+      BBreadcrumb,
       ClientOnly,
       PageHeader,
       PageFooter: () => import('../components/PageFooter'),

--- a/src/mixins/stripMarkdown.js
+++ b/src/mixins/stripMarkdown.js
@@ -1,0 +1,28 @@
+import marked from 'marked';
+
+const htmlRemovalPatternsFromTags = (tags) => {
+  return [/\n$/].concat(tags.map((tag) => new RegExp(`</?${tag}.*?>`, 'gi')));
+};
+
+export default {
+  methods: {
+    /**
+     * Strip markdown from text.
+     * This method FIRST converts markdown to HTML, then removes HTML tags.
+     * WARNING: This also means any HTML tags already present before will be stripped.
+     *
+     * As an optional parameter specific HTML tag names can be supplied. In which case,
+     * only these will be removed.
+     * @param {string} text String containing mark1down
+     * @param {string[]} tags the HTML tags to be removed.
+     * @return {String} text value with HTML breaks
+     */
+    stripMarkdown(text, tags = ['']) {
+      text = marked(text); // Marked adds newlines to the end of the string, and wraps it in a <p> tag.
+      for (const pattern of htmlRemovalPatternsFromTags(tags)) {
+        text = text.replace(pattern, '');
+      }
+      return text;
+    }
+  }
+};

--- a/src/pages/account/index.vue
+++ b/src/pages/account/index.vue
@@ -154,7 +154,7 @@
 </template>
 
 <script>
-  import { BTabs } from 'bootstrap-vue';
+  import { BTabs, BTab } from 'bootstrap-vue';
   import { mapState } from 'vuex';
 
   import keycloak from '../../mixins/keycloak';
@@ -168,6 +168,7 @@
 
     components: {
       BTabs,
+      BTab,
       ItemPreviewCardGroup,
       UserSets,
       AlertMessage,

--- a/src/pages/account/index.vue
+++ b/src/pages/account/index.vue
@@ -154,6 +154,7 @@
 </template>
 
 <script>
+  import { BTabs } from 'bootstrap-vue';
   import { mapState } from 'vuex';
 
   import keycloak from '../../mixins/keycloak';
@@ -166,6 +167,7 @@
     middleware: 'auth',
 
     components: {
+      BTabs,
       ItemPreviewCardGroup,
       UserSets,
       AlertMessage,

--- a/src/pages/collections/organisations.vue
+++ b/src/pages/collections/organisations.vue
@@ -12,12 +12,14 @@
 </template>
 
 <script>
+  import { BTable } from 'bootstrap-vue';
   import ContentHeader from '@/components/generic/ContentHeader';
   import ClientOnly from 'vue-client-only';
 
   export default {
     name: 'OrganisationsPage',
     components: {
+      BTable,
       ContentHeader,
       ClientOnly,
       OrganisationsTable: () => import('@/components/entity/OrganisationsTable')

--- a/src/pages/galleries/_.vue
+++ b/src/pages/galleries/_.vue
@@ -36,6 +36,7 @@
   import ContentHeader from '../../components/generic/ContentHeader';
 
   import marked from 'marked';
+  import stripMarkdown from '@/mixins/stripMarkdown';
 
   export default {
     name: 'ImageGallery',
@@ -43,6 +44,9 @@
       ContentHeader,
       ContentCard: () => import('../../components/generic/ContentCard')
     },
+    mixins: [
+      stripMarkdown
+    ],
     asyncData({ params, query, error, app }) {
       const variables = {
         identifier: params.pathMatch,
@@ -75,7 +79,7 @@
         return this.images.length === 0 ? null : this.imageUrl(this.images[0]);
       },
       description() {
-        return this.$options.filters.stripMarkdown(this.rawDescription);
+        return this.stripMarkdown(this.rawDescription);
       },
       htmlDescription() {
         return marked(this.rawDescription);

--- a/src/plugins/vue-filters.js
+++ b/src/plugins/vue-filters.js
@@ -3,8 +3,10 @@
  * @see {@link https://vuejs.org/v2/guide/filters.html}
  */
 
+// NOTE: use sparingly and avoid importing third-party libraries as these filters
+//       are registered globally. Consider the use of locally imported mixins instead.
+
 import Vue from 'vue';
-import marked from 'marked';
 
 Vue.filter('localise', val => {
   if (typeof val === 'undefined' || val === null) {
@@ -53,29 +55,6 @@ Vue.filter('optimisedImageUrl', (imageUrl, contentType, options = {}) => {
   }
 
   return imageUrl;
-});
-
-const htmlRemovalPatternsFromTags = (tags) => {
-  return [/\n$/].concat(tags.map((tag) => new RegExp(`</?${tag}.*?>`, 'gi')));
-};
-
-/**
- * Strip markdown from text.
- * This method FIRST converts markdown to HTML, then removes HTML tags.
- * WARNING: This also means any HTML tags already present before will be stripped.
- *
- * As an optional parameter specific HTML tag names can be supplied. In which case,
- * only these will be removed.
- * @param {string} text String containing mark1down
- * @param {string[]} tags the HTML tags to be removed.
- * @return {String} text value with HTML breaks
- */
-Vue.filter('stripMarkdown', (text, tags = ['']) => {
-  text = marked(text); // Marked adds newlines to the end of the string, and wraps it in a <p> tag.
-  for (const pattern of htmlRemovalPatternsFromTags(tags)) {
-    text = text.replace(pattern, '');
-  }
-  return text;
 });
 
 /**

--- a/tests/size/.size-limit.json
+++ b/tests/size/.size-limit.json
@@ -1,14 +1,23 @@
 [
   {
-    "name": "portal.js client (en)",
+    "name": "portal.js client",
     "running": false,
     "limit": "750 KB",
     "path": [
-      "../../.nuxt/dist/client/*.js"
+      "../../.nuxt/dist/client/*.js",
+      "!../../.nuxt/dist/client/*.modern.js"
     ]
   },
   {
-    "name": "portal.js server (en)",
+    "name": "portal.js modern",
+    "running": false,
+    "limit": "700 KB",
+    "path": [
+      "../../.nuxt/dist/client/*.modern.js"
+    ]
+  },
+  {
+    "name": "portal.js server",
     "running": false,
     "limit": "500 KB",
     "path": [

--- a/tests/size/.size-limit.json
+++ b/tests/size/.size-limit.json
@@ -11,7 +11,7 @@
   {
     "name": "portal.js modern",
     "running": false,
-    "limit": "700 KB",
+    "limit": "750 KB",
     "path": [
       "../../.nuxt/dist/client/*.modern.js"
     ]

--- a/tests/size/package.json
+++ b/tests/size/package.json
@@ -8,7 +8,7 @@
   "author": "",
   "license": "EUPL-1.2",
   "dependencies": {
-    "@size-limit/preset-app": "^4.6.0",
-    "size-limit": "^4.6.0"
+    "@size-limit/preset-app": "^5.0.5",
+    "size-limit": "^5.0.5"
   }
 }

--- a/tests/unit/mixins/stripMarkdown.spec.js
+++ b/tests/unit/mixins/stripMarkdown.spec.js
@@ -1,0 +1,76 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+// import sinon from 'sinon';
+
+import mixin from '@/mixins/stripMarkdown';
+
+const component = {
+  template: '<div/>',
+  mixins: [mixin]
+};
+
+const factory = () => shallowMount(component, {
+  localVue: createLocalVue()
+});
+
+describe('mixins/stripMarkdown', () => {
+  describe('methods', () => {
+    describe('stripMarkdown', () => {
+      context('when the text is plain', () => {
+        const textBefore = 'Contains only plain text.';
+
+        it('returns the text as is', () => {
+          const result = factory().vm.stripMarkdown(textBefore);
+          result.should.eq('Contains only plain text.');
+        });
+      });
+
+      context('when the text contains markdown', () => {
+        const textBefore = 'Contains _markdown_ with [a link](http://example.org)!';
+
+        it('returns the text as plain text', () => {
+          const result = factory().vm.stripMarkdown(textBefore);
+          result.should.eq('Contains markdown with a link!');
+        });
+      });
+
+      context('when the text contains html', () => {
+        const textBefore = '<p>Contains <em>HTML</em> with <a href="http://example.org">a link</a>!</p>';
+
+        it('returns the text as plain text', () => {
+          const result = factory().vm.stripMarkdown(textBefore);
+          result.should.eq('Contains HTML with a link!');
+        });
+      });
+
+      context('when passing in the a tag as an option to remove only links', () => {
+        const tags = ['a'];
+        context('when the text is plain', () => {
+          const textBefore = 'Contains only plain text.';
+
+          it('returns the text wrapped in a "<p>" tag ', () => {
+            const result = factory().vm.stripMarkdown(textBefore, tags);
+            result.should.eq('<p>Contains only plain text.</p>');
+          });
+        });
+
+        context('when the text contains markdown', () => {
+          const textBefore = 'Contains _markdown_ with [a link](http://example.org)!';
+
+          it('returns the text as plain text', () => {
+            const result = factory().vm.stripMarkdown(textBefore, tags);
+            result.should.eq('<p>Contains <em>markdown</em> with a link!</p>');
+          });
+        });
+
+        context('when the text contains html', () => {
+          const textBefore = '<p>Contains <em>HTML</em> with <a href="http://example.org">a link</a>!</p>';
+
+          it('returns the text as plain text', () => {
+            const result = factory().vm.stripMarkdown(textBefore, tags);
+            result.should.eq('<p>Contains <em>HTML</em> with a link!</p>');
+          });
+        });
+      });
+    });
+  });
+});

--- a/tests/unit/plugins/vue-filters.spec.js
+++ b/tests/unit/plugins/vue-filters.spec.js
@@ -59,67 +59,6 @@ describe('Vue filters', () => {
     });
   });
 
-  describe('stripMarkdown', () => {
-    const stripMarkdown = Vue.filter('stripMarkdown');
-
-    context('when the text is plain', () => {
-      const textBefore = 'Contains only plain text.';
-
-      it('returns the text as is', () => {
-        const result = stripMarkdown(textBefore);
-        result.should.eq('Contains only plain text.');
-      });
-    });
-
-    context('when the text contains markdown', () => {
-      const textBefore = 'Contains _markdown_ with [a link](http://example.org)!';
-
-      it('returns the text as plain text', () => {
-        const result = stripMarkdown(textBefore);
-        result.should.eq('Contains markdown with a link!');
-      });
-    });
-
-    context('when the text contains html', () => {
-      const textBefore = '<p>Contains <em>HTML</em> with <a href="http://example.org">a link</a>!</p>';
-
-      it('returns the text as plain text', () => {
-        const result = stripMarkdown(textBefore);
-        result.should.eq('Contains HTML with a link!');
-      });
-    });
-
-    context('when passing in the a tag as an option to remove only links', () => {
-      const tags = ['a'];
-      context('when the text is plain', () => {
-        const textBefore = 'Contains only plain text.';
-
-        it('returns the text wrapped in a "<p>" tag ', () => {
-          const result = stripMarkdown(textBefore, tags);
-          result.should.eq('<p>Contains only plain text.</p>');
-        });
-      });
-
-      context('when the text contains markdown', () => {
-        const textBefore = 'Contains _markdown_ with [a link](http://example.org)!';
-
-        it('returns the text as plain text', () => {
-          const result = stripMarkdown(textBefore, tags);
-          result.should.eq('<p>Contains <em>markdown</em> with a link!</p>');
-        });
-      });
-
-      context('when the text contains html', () => {
-        const textBefore = '<p>Contains <em>HTML</em> with <a href="http://example.org">a link</a>!</p>';
-
-        it('returns the text as plain text', () => {
-          const result = stripMarkdown(textBefore, tags);
-          result.should.eq('<p>Contains <em>HTML</em> with a link!</p>');
-        });
-      });
-    });
-  });
-
   describe('urlWithProtocol', () => {
     const urlWithProtocol = Vue.filter('urlWithProtocol');
 


### PR DESCRIPTION
Optimisations to Nuxt config:
1. Enable building source maps in webpack to facilitate debugging in production builds, for instance identifying the source line at which errors occurred, or showing the source module responsible for unused JS identified by Lighthouse performance reports.
2. ~~Enable extractCSS to prevent inlining CSS in HTML, reducing the size of the initial document transfer (by 57 kB/45% on the homepage), but increasing the number of network requests required. Lighthouse performance reports favour extracted CSS.~~ Disabled as it messes up some CSS. See: https://github.com/nuxt/nuxt.js/issues/4219
3. Enable "modern" builds to have Nuxt generate an additional client-side bundle using ECMAscript which will be served to modern browsers detected as supporting it. The modern bundle is 34 kB/5% smaller than the transpiled one for older browsers.
4. Reduce the number of globally registered Bootstrap Vue plugins, instead importing those only used occasionally in the views that need them.

This combination of optimisations has been tested with Lighthouse on the homepage, an item page, the collections hub page and the blog hub page, and result in performance score increases on all of 10-20 points (out of 100).


~~**FIXME:** there is one issue arising out of these changes, with the tooltips indicating metadata origin on the item page. When running in dev mode, these do not render properly at first, but making a change, any change, to `src/components/items/SummaryInfo.vue`, causing the hot reload, gets them rendering properly. This is not however an issue on production builds.~~