### PR TITLE
refactor: return single metadata fields object from record plugin

### DIFF
--- a/src/components/item/MetadataBox.vue
+++ b/src/components/item/MetadataBox.vue
@@ -90,6 +90,52 @@
 <script>
   import MetadataField from './MetadataField';
 
+  export default {
+    name: 'MetadataBox',
+
+    components: {
+      MetadataField,
+      MapEmbed: () => import('../geo/MapEmbed')
+    },
+
+    props: {
+      value: {
+        type: Object,
+        required: true
+      },
+      transcribingAnnotations: {
+        type: Array,
+        default: () => []
+      },
+      location: {
+        type: Object,
+        default: null
+      }
+    },
+
+    data() {
+      return {
+        CORE_FIELDS,
+        ALL_FIELDS,
+        showLocationMap: false
+      };
+    },
+
+    computed: {
+      mappableLocation() {
+        return this.location?.def?.find(loc => (
+          (typeof loc === 'object') && loc.latitude && loc.longitude
+        )) || null;
+      }
+    },
+
+    methods: {
+      clickLocationTab() {
+        this.showLocationMap = true;
+      }
+    }
+  };
+
   const CORE_FIELDS = [
     'edmDataProvider',
     'dcContributor',
@@ -145,50 +191,4 @@
     'timestampCreated',
     'timestampUpdate'
   ]);
-
-  export default {
-    name: 'MetadataBox',
-
-    components: {
-      MetadataField,
-      MapEmbed: () => import('../geo/MapEmbed')
-    },
-
-    props: {
-      value: {
-        type: Object,
-        required: true
-      },
-      transcribingAnnotations: {
-        type: Array,
-        default: () => []
-      },
-      location: {
-        type: Object,
-        default: null
-      }
-    },
-
-    data() {
-      return {
-        CORE_FIELDS,
-        ALL_FIELDS,
-        showLocationMap: false
-      };
-    },
-
-    computed: {
-      mappableLocation() {
-        return this.location?.def?.find(loc => (
-          (typeof loc === 'object') && loc.latitude && loc.longitude
-        )) || null;
-      }
-    },
-
-    methods: {
-      clickLocationTab() {
-        this.showLocationMap = true;
-      }
-    }
-  };
 </script>

--- a/src/components/item/MetadataBox.vue
+++ b/src/components/item/MetadataBox.vue
@@ -17,10 +17,10 @@
             data-qa="main metadata section"
           >
             <MetadataField
-              v-for="(value, name) in core"
+              v-for="name in CORE_FIELDS"
               :key="name"
               :name="name"
-              :field-data="value"
+              :field-data="value[name]"
             />
           </b-card-text>
         </b-tab>
@@ -32,10 +32,10 @@
             text-tag="div"
           >
             <MetadataField
-              v-for="(value, name) in all"
+              v-for="name in ALL_FIELDS"
               :key="name"
               :name="name"
-              :field-data="value"
+              :field-data="value[name]"
             />
           </b-card-text>
         </b-tab>
@@ -106,7 +106,6 @@
     'edmRights',
     'edmUgc',
     'dcRights',
-    'dcPublisher',
     'dctermsCreated',
     'dcDate',
     'dctermsIssued',
@@ -172,19 +171,13 @@
 
     data() {
       return {
+        CORE_FIELDS,
+        ALL_FIELDS,
         showLocationMap: false
       };
     },
 
     computed: {
-      core() {
-        return this.ordered(CORE_FIELDS);
-      },
-
-      all() {
-        return this.ordered(ALL_FIELDS);
-      },
-
       mappableLocation() {
         return this.location?.def?.find(loc => (
           (typeof loc === 'object') && loc.latitude && loc.longitude
@@ -193,16 +186,6 @@
     },
 
     methods: {
-      ordered(fields) {
-        const keys = Object.keys(this.value);
-        return fields.reduce((memo, field) => {
-          if (keys.includes(field)) {
-            memo[field] = this.value[field];
-          }
-          return memo;
-        }, {});
-      },
-
       clickLocationTab() {
         this.showLocationMap = true;
       }

--- a/src/components/item/MetadataBox.vue
+++ b/src/components/item/MetadataBox.vue
@@ -17,7 +17,7 @@
             data-qa="main metadata section"
           >
             <MetadataField
-              v-for="(value, name) in coreMetadata"
+              v-for="(value, name) in core"
               :key="name"
               :name="name"
               :field-data="value"
@@ -32,7 +32,7 @@
             text-tag="div"
           >
             <MetadataField
-              v-for="(value, name) in allMetadata"
+              v-for="(value, name) in all"
               :key="name"
               :name="name"
               :field-data="value"
@@ -90,6 +90,63 @@
 <script>
   import MetadataField from './MetadataField';
 
+  const CORE_FIELDS = [
+    'edmDataProvider',
+    'dcContributor',
+    'dcCreator',
+    'dcPublisher',
+    'dcSubject',
+    'dcType',
+    'dctermsMedium'
+  ];
+
+  const ALL_FIELDS = CORE_FIELDS.concat([
+    'edmProvider',
+    'edmIntermediateProvider',
+    'edmRights',
+    'edmUgc',
+    'dcRights',
+    'dcPublisher',
+    'dctermsCreated',
+    'dcDate',
+    'dctermsIssued',
+    'dctermsPublished',
+    'dctermsTemporal',
+    'dcCoverage',
+    'dctermsSpatial',
+    'edmCurrentLocation',
+    'dctermsProvenance',
+    'dcSource',
+    'dcIdentifier',
+    'dctermsExtent',
+    'dcDuration',
+    'dcMedium',
+    'dcFormat',
+    'dcLanguage',
+    'dctermsIsPartOf',
+    'dcRelation',
+    'dctermsReferences',
+    'dctermsHasPart',
+    'dctermsHasVersion',
+    'dctermsIsFormatOf',
+    'dctermsIsReferencedBy',
+    'dctermsIsReplacedBy',
+    'dctermsIsRequiredBy',
+    'edmHasMet',
+    'edmIncorporates',
+    'edmIsDerivativeOf',
+    'edmIsRepresentationOf',
+    'edmIsSimilarTo',
+    'edmIsSuccessorOf',
+    'edmRealizes',
+    'wasPresentAt',
+    'year',
+    'edmCountry',
+    'europeanaCollectionName',
+    'timestampCreated',
+    'timestampUpdate'
+  ]);
+
   export default {
     name: 'MetadataBox',
 
@@ -99,13 +156,9 @@
     },
 
     props: {
-      coreMetadata: {
+      value: {
         type: Object,
-        default: null
-      },
-      allMetadata: {
-        type: Object,
-        default: null
+        required: true
       },
       transcribingAnnotations: {
         type: Array,
@@ -124,6 +177,14 @@
     },
 
     computed: {
+      core() {
+        return this.ordered(CORE_FIELDS);
+      },
+
+      all() {
+        return this.ordered(ALL_FIELDS);
+      },
+
       mappableLocation() {
         return this.location?.def?.find(loc => (
           (typeof loc === 'object') && loc.latitude && loc.longitude
@@ -132,6 +193,16 @@
     },
 
     methods: {
+      ordered(fields) {
+        const keys = Object.keys(this.value);
+        return fields.reduce((memo, field) => {
+          if (keys.includes(field)) {
+            memo[field] = this.value[field];
+          }
+          return memo;
+        }, {});
+      },
+
       clickLocationTab() {
         this.showLocationMap = true;
       }

--- a/src/components/item/MetadataBox.vue
+++ b/src/components/item/MetadataBox.vue
@@ -21,7 +21,7 @@
               :key="name"
               :metadata-language="metadataLanguage"
               :name="name"
-              :field-data="value[name]"
+              :field-data="metadata[name]"
             />
           </b-card-text>
         </b-tab>
@@ -37,7 +37,7 @@
               :key="name"
               :metadata-language="metadataLanguage"
               :name="name"
-              :field-data="value[name]"
+              :field-data="metadata[name]"
             />
           </b-card-text>
         </b-tab>
@@ -101,7 +101,7 @@
     },
 
     props: {
-      value: {
+      metadata: {
         type: Object,
         required: true
       },

--- a/src/components/item/MetadataBox.vue
+++ b/src/components/item/MetadataBox.vue
@@ -195,6 +195,7 @@
     'edmCountry',
     'europeanaCollectionName',
     'timestampCreated',
-    'timestampUpdate'
+    'timestampUpdate',
+    'keywords'
   ]);
 </script>

--- a/src/pages/item/_.vue
+++ b/src/pages/item/_.vue
@@ -193,7 +193,7 @@
         }, {});
       },
       fieldsAndKeywords() {
-        return { ...this.metadata, ...{ keywords: this.keywords } };
+        return { ...this.metadata, keywords: this.keywords };
       },
       locationData() {
         return this.metadata.dctermsSpatial;

--- a/src/pages/item/_.vue
+++ b/src/pages/item/_.vue
@@ -68,7 +68,7 @@
             class="col-lg-10"
           >
             <MetadataBox
-              v-model="fieldsAndKeywords"
+              :metadata="fieldsAndKeywords"
               :location="locationData"
               :metadata-language="metadataLanguage"
               :transcribing-annotations="transcribingAnnotations || []"

--- a/src/pages/item/_.vue
+++ b/src/pages/item/_.vue
@@ -68,8 +68,7 @@
             class="col-lg-10"
           >
             <MetadataBox
-              :all-metadata="allMetaData"
-              :core-metadata="coreFields"
+              v-model="fieldsAndKeywords"
               :location="locationData"
               :transcribing-annotations="transcribingAnnotations || []"
             />
@@ -162,13 +161,12 @@
         altTitle: null,
         cardGridClass: null,
         concepts: [],
-        coreFields: null,
         description: null,
         error: null,
-        fields: {},
         identifier: null,
         isShownAt: null,
         media: [],
+        metadata: {},
         organizations: [],
         timespans: [],
         title: null,
@@ -194,16 +192,13 @@
         }, {});
       },
       fieldsAndKeywords() {
-        return { ...this.fields, ...{ keywords: this.keywords } };
-      },
-      allMetaData() {
-        return { ...this.coreFields, ...this.fieldsAndKeywords };
+        return { ...this.metadata, ...{ keywords: this.keywords } };
       },
       locationData() {
-        return this.fields.dctermsSpatial;
+        return this.metadata.dctermsSpatial;
       },
       edmRights() {
-        return this.fields.edmRights?.def[0] || '';
+        return this.metadata.edmRights?.def[0] || '';
       },
       europeanaEntities() {
         return this.agents
@@ -220,10 +215,10 @@
       attributionFields() {
         return {
           title: langMapValueForLocale(this.title, this.metadataLanguage || this.$i18n.locale).values[0],
-          creator: langMapValueForLocale(this.coreFields.dcCreator, this.$i18n.locale).values[0],
-          year: langMapValueForLocale(this.fields.year, this.$i18n.locale).values[0],
-          provider: langMapValueForLocale(this.coreFields.edmDataProvider.value, this.$i18n.locale).values[0],
-          country: langMapValueForLocale(this.fields.edmCountry, this.$i18n.locale).values[0],
+          creator: langMapValueForLocale(this.metadata.dcCreator, this.$i18n.locale).values[0],
+          year: langMapValueForLocale(this.metadata.year, this.$i18n.locale).values[0],
+          provider: langMapValueForLocale(this.metadata.edmDataProvider?.value, this.$i18n.locale).values[0],
+          country: langMapValueForLocale(this.metadata.edmCountry, this.$i18n.locale).values[0],
           url: this.shareUrl
         };
       },
@@ -257,7 +252,7 @@
         return this.descriptionInCurrentLanguage.values[0] || '';
       },
       dataProvider() {
-        const edmDataProvider = langMapValueForLocale(this.coreFields.edmDataProvider, this.$i18n.locale);
+        const edmDataProvider = langMapValueForLocale(this.metadata.edmDataProvider, this.$i18n.locale);
 
         if (edmDataProvider.values[0].about) {
           return edmDataProvider.values[0];
@@ -339,10 +334,10 @@
         }
 
         const dataSimilarItems = {
-          dcSubject: this.getSimilarItemsData(this.coreFields.dcSubject),
+          dcSubject: this.getSimilarItemsData(this.metadata.dcSubject),
           dcType: this.getSimilarItemsData(this.title),
-          dcCreator: this.getSimilarItemsData(this.coreFields.dcCreator),
-          edmDataProvider: this.getSimilarItemsData(this.fields.edmDataProvider)
+          dcCreator: this.getSimilarItemsData(this.metadata.dcCreator),
+          edmDataProvider: this.getSimilarItemsData(this.metadata.edmDataProvider)
         };
 
         return this.$apis.record.search({
@@ -371,10 +366,10 @@
       },
       matomoOptions() {
         return {
-          dimension1: langMapValueForLocale(this.fields.edmCountry, 'en').values[0],
-          dimension2: langMapValueForLocale(this.coreFields.edmDataProvider.value, 'en').values[0],
-          dimension3: langMapValueForLocale(this.fields.edmProvider, 'en').values[0],
-          dimension4: langMapValueForLocale(this.fields.edmRights, 'en').values[0]
+          dimension1: langMapValueForLocale(this.metadata.edmCountry, 'en').values[0],
+          dimension2: langMapValueForLocale(this.metadata.edmDataProvider.value, 'en').values[0],
+          dimension3: langMapValueForLocale(this.metadata.edmProvider, 'en').values[0],
+          dimension4: langMapValueForLocale(this.metadata.edmRights, 'en').values[0]
         };
       }
     },

--- a/src/pages/item/_.vue
+++ b/src/pages/item/_.vue
@@ -341,7 +341,7 @@
           //       used instead.
           dcType: this.getSimilarItemsData(this.title),
           dcCreator: this.getSimilarItemsData(this.metadata.dcCreator),
-          edmDataProvider: this.getSimilarItemsData(this.metadata.edmDataProvider)
+          edmDataProvider: this.getSimilarItemsData(this.metadata.edmDataProvider.value)
         };
 
         return this.$apis.record.search({

--- a/src/plugins/europeana/record.js
+++ b/src/plugins/europeana/record.js
@@ -183,13 +183,15 @@ export default (context = {}) => {
       }
 
       const metadata = {
-        ...lookupEntities(merge.all(edm.proxies, edm.aggregations, edm.europeanaAggregation), entities),
+        ...lookupEntities(
+          merge.all(edm.proxies.concat(edm.aggregations[0]).concat(edm.europeanaAggregation)), entities
+        ),
         europeanaCollectionName: edm.europeanaCollectionName,
         timestampCreated: edm.timestamp_created,
         timestampUpdate: edm.timestamp_update
       };
       metadata.edmDataProvider = {
-        url: providerAggregation.edmIsShownAt, value: providerAggregation.edmDataProvider
+        url: providerAggregation.edmIsShownAt, value: metadata.edmDataProvider
       };
 
       const allMediaUris = this.aggregationMediaUris(providerAggregation).map(Object.freeze);

--- a/src/plugins/europeana/record.js
+++ b/src/plugins/europeana/record.js
@@ -1,4 +1,3 @@
-// import omitBy from 'lodash/omitBy';
 import pick from 'lodash/pick';
 import uniq from 'lodash/uniq';
 import merge from 'deepmerge';

--- a/src/plugins/europeana/record.js
+++ b/src/plugins/europeana/record.js
@@ -182,12 +182,15 @@ export default (context = {}) => {
         });
       }
 
-      const metadata = Object.freeze({
+      const metadata = {
         ...lookupEntities(merge.all(edm.proxies, edm.aggregations, edm.europeanaAggregation), entities),
         europeanaCollectionName: edm.europeanaCollectionName,
         timestampCreated: edm.timestamp_created,
         timestampUpdate: edm.timestamp_update
-      });
+      };
+      metadata.edmDataProvider = {
+        url: providerAggregation.edmIsShownAt, value: providerAggregation.edmDataProvider
+      };
 
       const allMediaUris = this.aggregationMediaUris(providerAggregation).map(Object.freeze);
       return {
@@ -197,7 +200,7 @@ export default (context = {}) => {
         identifier: edm.about,
         type: edm.type,
         isShownAt: providerAggregation.edmIsShownAt,
-        metadata,
+        metadata: Object.freeze(metadata),
         media: this.aggregationMedia(providerAggregation, allMediaUris, edm.type, edm.services),
         agents,
         concepts,

--- a/tests/unit/components/item/MetadataBox.spec.js
+++ b/tests/unit/components/item/MetadataBox.spec.js
@@ -37,7 +37,7 @@ describe('components/item/MetadataBox', () => {
 
       it('is rendered', () => {
         const wrapper = factory({
-          value: {},
+          metadata: {},
           location
         });
 
@@ -49,7 +49,7 @@ describe('components/item/MetadataBox', () => {
       context('and mappable location is present', () => {
         it('does not render map embed at first', () => {
           const wrapper = factory({
-            value: {},
+            metadata: {},
             location
           });
 
@@ -58,7 +58,7 @@ describe('components/item/MetadataBox', () => {
 
         it('renders map when location tab is clicked', async() => {
           const wrapper = factory({
-            value: {},
+            metadata: {},
             location
           });
 
@@ -72,7 +72,7 @@ describe('components/item/MetadataBox', () => {
     context('when location prop is absent', () => {
       it('is not rendered', () => {
         const wrapper = factory({
-          value: {},
+          metadata: {},
           location: null
         });
 
@@ -86,7 +86,7 @@ describe('components/item/MetadataBox', () => {
   describe('.mappableLocation', () => {
     it('uses the first location object having latitude and longitude', () => {
       const wrapper = factory({
-        value: {},
+        metadata: {},
         location: {
           def: [
             fixtures.locations.eastSussex,
@@ -102,7 +102,7 @@ describe('components/item/MetadataBox', () => {
 
     it('is `null` if no such location', () => {
       const wrapper = factory({
-        value: {},
+        metadata: {},
         location: {
           def: [
             fixtures.locations.eastSussex


### PR DESCRIPTION
**What?**

In the record plugin's parsing of Record API responses, stop differentiating and separating fields as core & extra. Instead, return all together as a single metadata object. Then, make the distinction only where it is needed, i.e. in the MetadataBox component.


**Why?**

* Separation of concerns: intermediate views such as the item page should not need to know whether title, description, etc will be in core or extra fields as that distinction is only relevant in the metadata box.
* Moves the field names for core and extra into the metadata box component where it is easier to locate and modify them (as it is the only component doing so would affect).
* Reduction in duplication of logic for entity lookups in the record plugin as it's only done once.
* Reduction in size of the record plugin, which is injected into the context of every request by the `apis` plugin, hence included in the app bundle loaded with any SSR.