### PR TITLE
chore: group Elastic APM transactions by Vue route

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -74,7 +74,9 @@ export default {
         serviceVersion: pkg.version,
         frameworkName: 'Nuxt',
         frameworkVersion: nuxtPkg.version,
-        usePathAsTransactionName: true
+        ignoreUrls: [
+          /^\/_nuxt\//
+        ]
       }
     },
     europeana: {

--- a/src/modules/elastic-apm/index.js
+++ b/src/modules/elastic-apm/index.js
@@ -5,10 +5,12 @@ import path from 'path';
 const MODULE_NAME = 'elastic-apm';
 
 export default function() {
-  this.addPlugin({
-    src: path.resolve(__dirname, 'plugin.js'),
-    fileName: path.join(MODULE_NAME, 'plugin.js')
-  });
+  for (const filename of ['plugin.js', 'plugin.server.js']) {
+    this.addPlugin({
+      src: path.resolve(__dirname, filename),
+      fileName: path.join(MODULE_NAME, filename)
+    });
+  }
 
   this.nuxt.hook('ready', async(nuxt) => {
     const runtimeConfig = defu(nuxt.options.privateRuntimeConfig, nuxt.options.publicRuntimeConfig);

--- a/src/modules/elastic-apm/plugin.server.js
+++ b/src/modules/elastic-apm/plugin.server.js
@@ -1,0 +1,26 @@
+import apm from 'elastic-apm-node';
+
+// Server-side plugin to set the transaction name based on the Vue route.
+export default ({ route, req }) => {
+  if (!apm.isStarted())  {
+    return;
+  }
+
+  // Path deduction logic courtesy of @elastic/apm-rum-core package's src/route-hooks.js
+  const matched = route.matched || [];
+  let path = route.path;
+
+  /**
+   * Get the last matched route record which acts as stack when
+   * route changes are pushed and popped out of the stack
+   *
+   * Also account for the slug pattern on the routes, to.path always
+   * resolves the current slug param, but we need need to
+   * use the slug pattern for the transaction name
+   */
+  if (matched.length > 0) {
+    path = matched[matched.length - 1].path || path;
+  }
+
+  apm.setTransactionName(`${req.method} ${path}`);
+};

--- a/src/modules/elastic-apm/plugin.server.js
+++ b/src/modules/elastic-apm/plugin.server.js
@@ -6,7 +6,7 @@ export default ({ route, req }) => {
     return;
   }
 
-  // Path deduction logic courtesy of @elastic/apm-rum-core package's src/route-hooks.js
+  // Path deduction logic courtesy of `@elastic/apm-rum-vue` package's `src/route-hooks.js`
   const matched = route.matched || [];
   let path = route.path;
 


### PR DESCRIPTION
We recently enabled `usePathAsTransactionName` in the Elastic APM config (in nuxt.config.js) to alleviate all SSR transactions being recorded as "unknown route". This results in the full URL being recorded instead, which is better than nothing, but better would be for those to be grouped by the underlying route handler, i.e. the Nuxt page.

This PR achieves that by:
* Add a server-side plugin to the elastic-apm module to set the APM transaction name for Nuxt SSRs based on the current Vue route, reusing the logic from `@elastic/apm-rum-vue`
* Tweak API server middleware Express app to include `/_api/` prefix in transaction names
* Adjust Elastic APM agent config to not set transaction name by full URL (so any unmatched will again be registered as "unknown route"), and to ignore any `/_nuxt/*` URLs (for serving of static assets), which should leave very few recorded as "unknown route"