### PR TITLE
refactor: load Klaro CSS from unpkg

### DIFF
--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -47,11 +47,9 @@
   import { BBreadcrumb } from 'bootstrap-vue';
   import ClientOnly from 'vue-client-only';
   import PageHeader from '../components/PageHeader';
-  import klaroConfig from '../plugins/klaro-config';
+  import klaroConfig, { version as klaroVersion } from '../plugins/klaro-config';
   import { version as bootstrapVersion } from 'bootstrap/package.json';
   import { version as bootstrapVueVersion } from 'bootstrap-vue/package.json';
-
-  const klaroVersion = '0.7.18';
 
   export default {
     components: {
@@ -177,7 +175,7 @@
           { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,700italic,400,600,700&subset=latin,greek,cyrillic&display=swap',
             body: true },
           { rel: 'stylesheet', href: `https://unpkg.com/bootstrap@${bootstrapVersion}/dist/css/bootstrap.min.css` },
-          { rel: 'stylesheet', href: `https://cdn.kiprotect.com/klaro/v${klaroVersion}/klaro.min.css` },
+          { rel: 'stylesheet', href: `https://unpkg.com/klaro@${klaroVersion}/dist/klaro.min.css` },
           { rel: 'stylesheet', href: `https://unpkg.com/bootstrap-vue@${bootstrapVueVersion}/dist/bootstrap-vue.min.css` },
           { hreflang: 'x-default', rel: 'alternate', href: this.canonicalUrlWithoutLocale },
           ...i18nHead.link

--- a/src/plugins/klaro-config.js
+++ b/src/plugins/klaro-config.js
@@ -1,3 +1,5 @@
+export const version = '0.7.18';
+
 export default ($i18n, $initHotjar, $matomo) => {
   // TODO: uncomment when we have translations
   // const locale = $i18n.locale;


### PR DESCRIPTION
Because:
1. Other linked assets are loaded from there, including the Klaro JS, i.e. for consistency
2. unpkg.com sets much longer max-age in cache-control than cdn.kiprotect.com