### PR TITLE
chore: publish to NPM & warm up jsdelivr.net CDN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,10 @@ PORTAL_BASE_URL=https://www.europeana.eu
 # Base URL from which to serve client assets (JS, CSS, fonts, imgs), e.g. from a CDN
 # NUXT_BUILD_PUBLIC_PATH=
 
+# Load portal client assets from jsdelivr.net. Requires prior publishing of package
+# version to NPM. Takes precedence over NUXT_BUILD_PUBLIC_PATH.
+# ENABLE_JSDELIVR_BUILD_PUBLIC_PATH=0
+
 # Europeana API keys
 # EUROPEANA_ANNOTATION_API_KEY="YOUR_API_KEY"
 # EUROPEANA_RECORD_API_KEY="YOUR_API_KEY"

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -31,14 +31,34 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        name: Build and push
+        name: Build and push to DockerHub
+        id: build-push
         uses: docker/build-push-action@v2
         with:
           context: .
-          pull: true
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+      -
+        name: Publish to NPM
+        if: startsWith( github.event.ref, 'refs/tags/v' )
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+        run: |
+          docker run \
+            --rm \
+            --env NODE_AUTH_TOKEN=${NODE_AUTH_TOKEN} \
+            --mount type=bind,source=$(pwd)/.github/workflows/support/docker-images/.npmrc,target=/root/.npmrc \
+            --entrypoint npm ${{ steps.build-push.outputs.digest }} \
+            publish --access public
+      -
+        name: Warm up jsDelivr
+        if: startsWith( github.event.ref, 'refs/tags/v' )
+        run: |
+          docker run \
+            --rm \
+            --mount type=bind,source=$(pwd)/.github/workflows/support/docker-images/warm-up-jsdelivr.sh,target=/root/warm-up-jsdelivr.sh \
+            --entrypoint /root/warm-up-jsdelivr.sh ${{ steps.build-push.outputs.digest }}
 
   nginx:
     runs-on: ubuntu-latest
@@ -46,6 +66,9 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       -
         name: Docker meta
         id: meta
@@ -67,7 +90,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./tests/e2e/docker/nginx
-          pull: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -78,6 +102,9 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       -
         name: Docker meta
         id: meta
@@ -99,7 +126,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./tests/e2e/docker/nightwatch-base
-          pull: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/support/docker-images/.npmrc
+++ b/.github/workflows/support/docker-images/.npmrc
@@ -1,0 +1,3 @@
+//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
+registry=https://registry.npmjs.org/
+always-auth=true

--- a/.github/workflows/support/docker-images/warm-up-jsdelivr.sh
+++ b/.github/workflows/support/docker-images/warm-up-jsdelivr.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+version=$(npm view @europeana/portal version)
+
+for file in $(find .nuxt/dist/client -type f | sort); do
+  url="https://cdn.jsdelivr.net/npm/@europeana/portal@${version}/${file}"
+  echo ${url}
+  wget -q ${url}
+done

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -16,6 +16,14 @@ import { parseQuery, stringifyQuery } from './src/plugins/vue-router.cjs';
 
 const featureIsEnabled = (value) => Boolean(Number(value));
 
+const buildPublicPath = () => {
+  if (featureIsEnabled(process.env.ENABLE_JSDELIVR_BUILD_PUBLIC_PATH)) {
+    return `https://cdn.jsdelivr.net/npm/${pkg.name}@${pkg.version}/.nuxt/dist/client`;
+  } else {
+    return process.env.NUXT_BUILD_PUBLIC_PATH;
+  }
+};
+
 export default {
   /*
   ** Runtime config
@@ -378,7 +386,7 @@ export default {
       }
     },
 
-    publicPath: process.env.NUXT_BUILD_PUBLIC_PATH
+    publicPath: buildPublicPath()
   },
 
   /*


### PR DESCRIPTION
* After building versioned Docker images, publish the app package to NPM
* After publishing the app package to NPM, warm up the jsdelivr.net cache for client bundle files for that version
* Add a feature toggle to support loading all client bundle files from jsdelivr.net instead of having Nuxt serve them

Example of a successful Actions run: https://github.com/europeana/portal.js/actions/runs/1421046089
Resulting in NPM package: https://www.npmjs.com/package/@europeana/portal/v/1.53.1-npm-publish.12
And jsdelivr.net CDN: https://cdn.jsdelivr.net/npm/@europeana/portal@1.53.1-npm-publish.12/