### PR TITLE
chore: capture errors to APM & retry CTF requests

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -77,6 +77,9 @@ export default {
         frameworkVersion: nuxtPkg.version,
         ignoreUrls: [
           /^\/(_nuxt|__webpack_hmr)\//
+        ],
+        ignoreUserAgents: [
+          'kube-probe/'
         ]
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6876,11 +6876,22 @@
       }
     },
     "axios-retry": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.1.9.tgz",
-      "integrity": "sha512-NFCoNIHq8lYkJa6ku4m+V1837TP6lCa7n79Iuf8/AqATAHYB0ISaAS1eyIenDOfHOLtym34W65Sjke2xjg2fsA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.4.tgz",
+      "integrity": "sha512-Co3UXiv4npi6lM963mfnuH90/YFLKWWDmoBYfxkHT5xtkSSWNqK9zdG3fw5/CP/dsoKB5aMMJCsgab+tp1OxLQ==",
       "requires": {
-        "is-retry-allowed": "^1.1.0"
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz",
+          "integrity": "sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "babel-loader": {
@@ -15764,9 +15775,9 @@
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
     },
     "is-retry-allowed": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg=="
     },
     "is-ssh": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@vue-a11y/announcer": "^2.1.0",
     "autosuggest-highlight": "^3.1.1",
     "axios": "^0.21.1",
+    "axios-retry": "^3.2.4",
     "bootstrap": "^4.6.0",
     "bootstrap-vue": "^2.21.2",
     "cookie-universal-nuxt": "^2.0.18",

--- a/src/plugins/europeana/annotation.js
+++ b/src/plugins/europeana/annotation.js
@@ -23,7 +23,7 @@ export default (context = {}) => {
       })
         .then(response => response.data.items ? response.data.items : [])
         .catch(error => {
-          throw apiError(error);
+          throw apiError(error, context);
         });
     }
   };

--- a/src/plugins/europeana/entity-management.js
+++ b/src/plugins/europeana/entity-management.js
@@ -27,7 +27,9 @@ export default (context = {}) => {
       const params = { ...defaults, ...options };
       return $axios.get(getEntityUrl(type, id).replace('.json', ''), { params })
         .then(response => response.data)
-        .catch(error => apiError(error));
+        .catch(error => {
+          throw apiError(error, context);
+        });
     },
 
     /**
@@ -40,7 +42,7 @@ export default (context = {}) => {
       return $axios.put(`/concept/base/${id}`, body)
         .then(response => response.data)
         .catch(error => {
-          throw apiError(error);
+          throw apiError(error, context);
         });
     }
 

--- a/src/plugins/europeana/entity.js
+++ b/src/plugins/europeana/entity.js
@@ -23,7 +23,7 @@ export default (context = {}) => {
           entity: response.data
         }))
         .catch(error => {
-          throw apiError(error);
+          throw apiError(error, context);
         });
     },
 
@@ -49,7 +49,7 @@ export default (context = {}) => {
       })
         .then(response => response.data.items ? response.data.items : [])
         .catch(error => {
-          throw apiError(error);
+          throw apiError(error, context);
         });
     },
 
@@ -111,7 +111,7 @@ export default (context = {}) => {
           };
         })
         .catch((error) => {
-          throw apiError(error);
+          throw apiError(error, context);
         });
     }
   };

--- a/src/plugins/europeana/record.js
+++ b/src/plugins/europeana/record.js
@@ -140,7 +140,7 @@ export default (context = {}) => {
     $axios,
 
     search(params, options = {}) {
-      return search($axios, params, options);
+      return search(context)($axios, params, options);
     },
 
     /**
@@ -330,7 +330,7 @@ export default (context = {}) => {
             options.fromTranslationError = true;
             return this.getRecord(europeanaId, options);
           }
-          throw apiError(error);
+          throw apiError(error, context);
         });
     },
 

--- a/src/plugins/europeana/search.js
+++ b/src/plugins/europeana/search.js
@@ -90,7 +90,7 @@ export function rangeFromQueryParam(paramValue) {
  * @param {string} options.url override the API URL
  * @return {{results: Object[], totalResults: number, facets: FacetSet, error: string}} search results for display
  */
-export default function search($axios, params, options = {}) {
+export default (context) => ($axios, params, options = {}) => {
   const maxResults = 1000;
   const perPage = params.rows === undefined ? 24 : Number(params.rows);
   const page = params.page || 1;
@@ -127,9 +127,9 @@ export default function search($axios, params, options = {}) {
       lastAvailablePage: start + perPage > maxResults
     }))
     .catch((error) => {
-      throw apiError(error);
+      throw apiError(error, context);
     });
-}
+};
 
 const reduceFieldsForItem = (item, options = {}) => {
   // Pick fields we need for search result display. See components/item/ItemPreviewCard.vue

--- a/src/plugins/europeana/set.js
+++ b/src/plugins/europeana/set.js
@@ -17,7 +17,7 @@ export default (context = {}) => {
       return $axios.get('/search', { params: { ...$axios.defaults.params, ...params } })
         .then(response => response)
         .catch(error => {
-          throw apiError(error);
+          throw apiError(error, context);
         });
     },
 
@@ -30,7 +30,7 @@ export default (context = {}) => {
       return this.search({ query: `creator:${creator} type:BookmarkFolder` })
         .then(response => response.data.items ? response.data.items[0] : null)
         .catch(error => {
-          throw apiError(error);
+          throw apiError(error, context);
         });
     },
 
@@ -52,7 +52,7 @@ export default (context = {}) => {
           return response.data;
         })
         .catch(error => {
-          throw apiError(error);
+          throw apiError(error, context);
         });
     },
 
@@ -82,7 +82,7 @@ export default (context = {}) => {
       )
         .then(response => response.data)
         .catch(error => {
-          throw apiError(error);
+          throw apiError(error, context);
         });
     },
 
@@ -99,7 +99,7 @@ export default (context = {}) => {
       )
         .then(response => response.data)
         .catch(error => {
-          throw apiError(error);
+          throw apiError(error, context);
         });
     },
 
@@ -114,7 +114,7 @@ export default (context = {}) => {
       )
         .then(response => response.data)
         .catch(error => {
-          throw apiError(error);
+          throw apiError(error, context);
         });
     },
 
@@ -132,7 +132,7 @@ export default (context = {}) => {
       return apiCall(`/${setIdFromUri(setId)}${itemId}${pinPos}`)
         .then(response => response.data)
         .catch(error => {
-          throw apiError(error);
+          throw apiError(error, context);
         });
     },
 

--- a/src/plugins/europeana/utils.js
+++ b/src/plugins/europeana/utils.js
@@ -51,7 +51,11 @@ const axiosInstanceOptions = ({ id, baseURL }, { store, $config }) => {
 };
 
 // TODO: extend to be more verbose in development environments, e.g. with stack trace
-export function apiError(error) {
+export function apiError(error, context) {
+  if (context?.$apm?.captureError) {
+    context?.$apm.captureError(error);
+  }
+
   let statusCode = 500;
   let message = error.message;
 

--- a/tests/unit/plugins/europeana/search.spec.js
+++ b/tests/unit/plugins/europeana/search.spec.js
@@ -16,7 +16,7 @@ describe('plugins/europeana/search', () => {
     nock.cleanAll();
   });
 
-  describe('search()', () => {
+  describe('search()()', () => {
     describe('API request', () => {
       it('requests 24 results by default', async() => {
         baseRequest
@@ -25,7 +25,7 @@ describe('plugins/europeana/search', () => {
           })
           .reply(200, defaultResponse);
 
-        await search($axios, { query: 'anything' });
+        await search()($axios, { query: 'anything' });
 
         nock.isDone().should.be.true;
       });
@@ -37,7 +37,7 @@ describe('plugins/europeana/search', () => {
           })
           .reply(200, defaultResponse);
 
-        await search($axios, { query: 'anything', rows: 9 });
+        await search()($axios, { query: 'anything', rows: 9 });
 
         nock.isDone().should.be.true;
       });
@@ -49,7 +49,7 @@ describe('plugins/europeana/search', () => {
           })
           .reply(200, defaultResponse);
 
-        await search($axios, { page: 2, query: 'anything' });
+        await search()($axios, { page: 2, query: 'anything' });
 
         nock.isDone().should.be.true;
       });
@@ -61,7 +61,7 @@ describe('plugins/europeana/search', () => {
           })
           .reply(200, defaultResponse);
 
-        await search($axios, { page: 42, query: 'anything' });
+        await search()($axios, { page: 42, query: 'anything' });
 
         nock.isDone().should.be.true;
       });
@@ -73,7 +73,7 @@ describe('plugins/europeana/search', () => {
           })
           .reply(200, defaultResponse);
 
-        await search($axios, { query: 'anything' });
+        await search()($axios, { query: 'anything' });
 
         nock.isDone().should.be.true;
       });
@@ -85,7 +85,7 @@ describe('plugins/europeana/search', () => {
           })
           .reply(200, defaultResponse);
 
-        await search($axios, { query: 'anything', facet: 'LANGUAGE' });
+        await search()($axios, { query: 'anything', facet: 'LANGUAGE' });
 
         nock.isDone().should.be.true;
       });
@@ -97,7 +97,7 @@ describe('plugins/europeana/search', () => {
           })
           .reply(200, defaultResponse);
 
-        await search($axios, { query: 'anything', facet: 'COUNTRY,REUSABILITY' });
+        await search()($axios, { query: 'anything', facet: 'COUNTRY,REUSABILITY' });
 
         nock.isDone().should.be.true;
       });
@@ -109,7 +109,7 @@ describe('plugins/europeana/search', () => {
           })
           .reply(200, defaultResponse);
 
-        await search($axios, { query: '' });
+        await search()($axios, { query: '' });
 
         nock.isDone().should.be.true;
       });
@@ -121,7 +121,7 @@ describe('plugins/europeana/search', () => {
           })
           .reply(200, defaultResponse);
 
-        await search($axios, { query: 'anything', reusability: 'open' });
+        await search()($axios, { query: 'anything', reusability: 'open' });
 
         nock.isDone().should.be.true;
       });
@@ -136,7 +136,7 @@ describe('plugins/europeana/search', () => {
             })
             .reply(200, defaultResponse);
 
-          await search($axios, { query: 'flor' }, { locale });
+          await search()($axios, { query: 'flor' }, { locale });
 
           nock.isDone().should.be.true;
         });
@@ -149,7 +149,7 @@ describe('plugins/europeana/search', () => {
             })
             .reply(200, defaultResponse);
 
-          await search($axios, { query: 'flor' });
+          await search()($axios, { query: 'flor' });
 
           nock.isDone().should.be.true;
         });
@@ -164,7 +164,7 @@ describe('plugins/europeana/search', () => {
             })
             .reply(200, defaultResponse);
 
-          await search($axios, { query: 'flor' }, { locale });
+          await search()($axios, { query: 'flor' }, { locale });
 
           nock.isDone().should.be.true;
         });
@@ -178,7 +178,7 @@ describe('plugins/europeana/search', () => {
             })
             .reply(200, defaultResponse);
 
-          await search($axios, { query: 'dress (red OR blue)' });
+          await search()($axios, { query: 'dress (red OR blue)' });
 
           nock.isDone().should.be.true;
         });
@@ -190,7 +190,7 @@ describe('plugins/europeana/search', () => {
             })
             .reply(200, defaultResponse);
 
-          await search($axios, { query: 'dress (red OR blue)' }, { escape: true });
+          await search()($axios, { query: 'dress (red OR blue)' }, { escape: true });
 
           nock.isDone().should.be.true;
         });
@@ -210,7 +210,7 @@ describe('plugins/europeana/search', () => {
 
           let error;
           try {
-            await search($axios, { query: 'NOT ' });
+            await search()($axios, { query: 'NOT ' });
           } catch (e) {
             error = e;
           }
@@ -222,7 +222,7 @@ describe('plugins/europeana/search', () => {
 
       context('with `items`', () => {
         function searchResponse(options = {}) {
-          return search($axios, { query: 'painting' }, options);
+          return search()($axios, { query: 'painting' }, options);
         }
 
         describe('.items', () => {
@@ -333,7 +333,7 @@ describe('plugins/europeana/search', () => {
 
           context('when page is at the API limit', () => {
             function searchResponse() {
-              return search($axios, { query: 'painting', page: 42 });
+              return search()($axios, { query: 'painting', page: 42 });
             }
 
             it('is `true`', async() => {


### PR DESCRIPTION
* Start capturing errors from various API requests to Elastic APM
* Use [axios-retry](https://www.npmjs.com/package/axios-retry) to retry failed Contentful GraphQL requests (3 times by default)
* Instruct Elastic APM to ignore Kubernetes health check user agent