### PR TITLE
Graphql for exhibition & blog content warnings

### DIFF
--- a/src/modules/contentful-graphql/queries/blog-post-page.graphql
+++ b/src/modules/contentful-graphql/queries/blog-post-page.graphql
@@ -49,6 +49,10 @@ query BlogPostPage(
           url
         }
       }
+      contentWarning {
+        name
+        description
+      }
     }
   }
 }

--- a/src/modules/contentful-graphql/queries/exhibition-chapter-page.graphql
+++ b/src/modules/contentful-graphql/queries/exhibition-chapter-page.graphql
@@ -15,6 +15,10 @@ query ExhibitionChapterPage(
       name
       identifier
       credits
+      contentWarning {
+        name
+        description
+      }
       hasPartCollection(limit: 40) {
         items {
           name

--- a/src/modules/contentful-graphql/queries/exhibition-landing-page.graphql
+++ b/src/modules/contentful-graphql/queries/exhibition-landing-page.graphql
@@ -23,6 +23,10 @@ query ExhibitionLandingPage(
         }
       }
       credits
+      contentWarning {
+        name
+        description
+      }
     }
   }
 }

--- a/src/pages/exhibitions/_exhibition/_chapter.vue
+++ b/src/pages/exhibitions/_exhibition/_chapter.vue
@@ -128,6 +128,7 @@
             credits: exhibition.credits,
             exhibitionIdentifier: params.exhibition,
             exhibitionTitle: exhibition.name,
+            exhibitionContentWarning: exhibition.contentWarning,
             page: chapter
           };
         })


### PR DESCRIPTION
Also adds assignment in the asyncdata for exhibition chapters. 
The same has not been done on the blog and exhibition landing pages as there the whole graphql response is already available to the template.
Example:
`contentWarning.name` & `contentWarning.description` for exhibition landing pages.
or
`post.contentWarning.name` & `post.contentWarning.description` for blogs.
