### PR TITLE
fix: prevent hydration error on hit highlights

### DIFF
--- a/src/components/generic/ContentCard.vue
+++ b/src/components/generic/ContentCard.vue
@@ -63,30 +63,32 @@
         >
           {{ $d(new Date(datetime), 'short') }}
         </time>
-        <template v-if="hitsText">
-          <b-card-text
-            text-tag="div"
-            data-qa="highlighted search term"
-          >
-            <p>{{ hitsText.prefix }}<strong class="has-text-highlight">{{ hitsText.exact }}</strong>{{ hitsText.suffix }}</p>
-          </b-card-text>
-        </template>
+        <b-card-text
+          v-if="hitsText"
+          text-tag="div"
+          data-qa="highlighted search term"
+        >
+          <p>
+            {{ hitsText.prefix }}
+            <strong class="has-text-highlight">
+              {{ hitsText.exact }}
+            </strong>
+            {{ hitsText.suffix }}
+          </p>
+        </b-card-text>
         <template v-if="displayTexts.length > 0">
-          <template
+          <b-card-text
             v-for="(text, index) in displayTexts"
+            :key="index"
+            :lang="text.code"
+            text-tag="div"
           >
-            <b-card-text
-              :key="index"
-              :lang="text.code"
-              text-tag="div"
-            >
-              <!-- eslint-disable vue/no-v-html -->
-              <p
-                v-html="cardText(text.values)"
-              />
-              <!-- eslint-enable vue/no-v-html -->
-            </b-card-text>
-          </template>
+            <!-- eslint-disable vue/no-v-html -->
+            <p
+              v-html="cardText(text.values)"
+            />
+            <!-- eslint-enable vue/no-v-html -->
+          </b-card-text>
         </template>
       </b-card-body>
     </SmartLink>

--- a/tests/unit/components/generic/ContentCard.spec.js
+++ b/tests/unit/components/generic/ContentCard.spec.js
@@ -145,7 +145,7 @@ describe('components/generic/ContentCard', () => {
       }
     });
 
-    const description =  wrapper.find('[data-qa="highlighted search term"] p');
-    description.html().should.contain('<p>The quick brown <strong class="has-text-highlight">fox</strong> jumps over the lazy dog</p>');
+    const description =  wrapper.find('[data-qa="highlighted search term"] strong');
+    description.text().should.eq('fox');
   });
 });


### PR DESCRIPTION
The fix is the change to move each part of the hit highlight templating (p and strong tags; prefix, suffix and exact texts) onto its own line. The other changes are just to remove some superfluous uses of the Vue template element.