### PR TITLE
refactor: request single facets when needed

### DIFF
--- a/src/components/generic/PaginationNav.vue
+++ b/src/components/generic/PaginationNav.vue
@@ -37,10 +37,6 @@
         type: Number,
         default: 0
       },
-      value: {
-        type: Number,
-        default: 1
-      },
       scrollToId: {
         type: String,
         default: 'main'
@@ -50,24 +46,10 @@
         default: null
       }
     },
-    data() {
-      return {
-        currentPage: this.value
-      };
-    },
     computed: {
       totalPages() {
         const atLeastOne = Math.max(this.totalResults, 1);
         return Math.ceil(Math.min(atLeastOne, this.maxResults || atLeastOne) / this.perPage);
-      }
-    },
-    watch: {
-      value: {
-        immediate: true,
-        handler(val) {
-          // Without this, using the browser back button will not update the highlighted pagination
-          this.currentPage = val;
-        }
       }
     },
     methods: {

--- a/src/components/generic/PaginationNav.vue
+++ b/src/components/generic/PaginationNav.vue
@@ -1,7 +1,6 @@
 <template>
   <b-pagination-nav
     v-if="totalResults > perPage"
-    v-model="currentPage"
     :limit="limit"
     :hide-ellipsis="hideEllipsis"
     :number-of-pages="totalPages"
@@ -10,6 +9,7 @@
     size="sm"
     align="center"
     data-qa="pagination navigation"
+    @input="changePaginationNav"
   />
 </template>
 
@@ -41,6 +41,10 @@
         type: Number,
         default: 1
       },
+      scrollToId: {
+        type: String,
+        default: 'main'
+      },
       maxResults: {
         type: Number,
         default: null
@@ -67,6 +71,9 @@
       }
     },
     methods: {
+      changePaginationNav() {
+        this.$scrollTo(`#${this.scrollToId}`);
+      },
       linkGen(page) {
         return {
           ...this.$route,

--- a/src/components/generic/PaginationNav.vue
+++ b/src/components/generic/PaginationNav.vue
@@ -10,7 +10,6 @@
     size="sm"
     align="center"
     data-qa="pagination navigation"
-    @input="changePaginationNav"
   />
 </template>
 
@@ -42,10 +41,6 @@
         type: Number,
         default: 1
       },
-      scrollToId: {
-        type: String,
-        default: '__nuxt'
-      },
       maxResults: {
         type: Number,
         default: null
@@ -72,9 +67,6 @@
       }
     },
     methods: {
-      changePaginationNav() {
-        this.$scrollTo(`#${this.scrollToId}`);
-      },
       linkGen(page) {
         return {
           ...this.$route,

--- a/src/components/search/SearchInterface.vue
+++ b/src/components/search/SearchInterface.vue
@@ -114,7 +114,6 @@
           <b-col>
             <client-only>
               <PaginationNav
-                v-model="page"
                 :total-results="totalResults"
                 :per-page="perPage"
                 :max-results="1000"

--- a/src/components/search/SearchInterface.vue
+++ b/src/components/search/SearchInterface.vue
@@ -177,7 +177,7 @@
     async fetch() {
       this.viewFromRouteQuery();
 
-      await this.$store.dispatch('search/activate');
+      this.$store.dispatch('search/activate');
       this.$store.commit('search/set', ['userParams', this.$route.query]);
 
       // TODO: refactor not to need overrides once ENABLE_SIDE_FILTERS is always-on
@@ -331,6 +331,9 @@
     },
     mounted() {
       this.showContentTierToast();
+    },
+    destroyed() {
+      this.$store.dispatch('search/deactivate');
     },
     methods: {
       viewFromRouteQuery() {

--- a/src/components/search/SearchInterface.vue
+++ b/src/components/search/SearchInterface.vue
@@ -182,8 +182,11 @@
       // TODO: refactor not to need overrides once ENABLE_SIDE_FILTERS is always-on
       await this.$store.dispatch('search/run', { skipFacets: this.sideFiltersEnabled });
 
-      if (this.$store.state.search.error && process.server) {
-        this.$nuxt.context.res.statusCode = this.$store.state.search.errorStatusCode;
+      if (this.$store.state.search.error) {
+        if (process.server) {
+          this.$nuxt.context.res.statusCode = this.$store.state.search.errorStatusCode;
+        }
+        throw this.$store.state.search.error;
       }
     },
     data() {

--- a/src/components/search/SearchInterface.vue
+++ b/src/components/search/SearchInterface.vue
@@ -180,6 +180,7 @@
       await this.$store.dispatch('search/activate');
       this.$store.commit('search/set', ['userParams', this.$route.query]);
 
+      // TODO: refactor not to need overrides once ENABLE_SIDE_FILTERS is always-on
       await this.$store.dispatch('search/run', { skipFacets: this.sideFiltersEnabled });
 
       if (this.$store.state.search.error && process.server) {

--- a/src/components/search/SearchInterface.vue
+++ b/src/components/search/SearchInterface.vue
@@ -7,7 +7,7 @@
     </b-row>
   </b-container>
   <b-container v-else-if="$fetchState.error">
-    <b-row class="flex-md-row py-4">
+    <b-row class="flex-md-row">
       <b-col cols="12">
         <AlertMessage
           :error="$fetchState.error.message"

--- a/src/components/search/SearchInterface.vue
+++ b/src/components/search/SearchInterface.vue
@@ -10,7 +10,7 @@
     <b-row class="flex-md-row">
       <b-col cols="12">
         <AlertMessage
-          :error="$fetchState.error.message"
+          :error="errorMessage"
         />
       </b-col>
     </b-row>
@@ -233,17 +233,17 @@
         return Number(this.$route.query.page || 1);
       },
       errorMessage() {
-        if (!this.error) {
+        if (!this.$fetchState.error?.message) {
           return null;
         }
 
-        const paginationError = this.error.match(/It is not possible to paginate beyond the first (\d+)/);
+        const paginationError = this.$fetchState.error.message.match(/It is not possible to paginate beyond the first (\d+)/);
         if (paginationError !== null) {
           const localisedPaginationLimit = this.$options.filters.localise(Number(paginationError[1]));
           return this.$t('messages.paginationLimitExceeded', { limit: localisedPaginationLimit });
         }
 
-        return this.error;
+        return this.$fetchState.error.message;
       },
       hasAnyResults() {
         return this.totalResults > 0;

--- a/src/components/search/SideFacetDropdown.vue
+++ b/src/components/search/SideFacetDropdown.vue
@@ -124,12 +124,16 @@
     },
 
     async fetch() {
+      // Always fetch the contentTier facet, which the toast advising of the
+      // filtering of low-tier items needs
       if (this.shown || (this.name === 'contentTier')) {
         const facets = await this.$store.dispatch('search/queryFacets', { facet: this.name });
         this.fields = (facets || [])[0]?.fields || [];
         this.fetched = true;
       }
     },
+
+    fetchOnServer: false,
 
     data() {
       return {

--- a/src/components/search/SideFacetDropdown.vue
+++ b/src/components/search/SideFacetDropdown.vue
@@ -91,12 +91,6 @@
         required: true
       },
 
-      // fields: {
-      //   type: Array,
-      //   required: false,
-      //   default: () => []
-      // },
-
       selected: {
         type: [Array, String],
         default: () => []
@@ -118,7 +112,7 @@
 
     computed: {
       fields() {
-        return this.$store.state.search.facets.find(facet => facet.name === this.name)?.fields || [];
+        return this.$store.state.search?.facets?.find(facet => facet.name === this.name)?.fields || [];
       },
 
       sortedOptions() {

--- a/src/components/search/SideFacetDropdown.vue
+++ b/src/components/search/SideFacetDropdown.vue
@@ -180,7 +180,6 @@
       },
 
       showDropdown() {
-        console.log('showDropdown', this.name);
         this.$store.dispatch('search/queryFacets', { facet: this.name });
       },
 

--- a/src/components/search/SideFacetDropdown.vue
+++ b/src/components/search/SideFacetDropdown.vue
@@ -124,7 +124,7 @@
     },
 
     async fetch() {
-      if (this.shown) {
+      if (this.shown || (this.name === 'contentTier')) {
         const facets = await this.$store.dispatch('search/queryFacets', { facet: this.name });
         this.fields = (facets || [])[0]?.fields || [];
         this.fetched = true;

--- a/src/components/search/SideFacetDropdown.vue
+++ b/src/components/search/SideFacetDropdown.vue
@@ -10,7 +10,8 @@
       class="facet-dropdown side-facet"
       :data-type="type"
       data-qa="search facet"
-      @hidden="cancelHandler"
+      @hidden="cancelDropdown"
+      @show="showDropdown"
     >
       <template v-slot:button-content>
         <span
@@ -90,11 +91,11 @@
         required: true
       },
 
-      fields: {
-        type: Array,
-        required: false,
-        default: () => []
-      },
+      // fields: {
+      //   type: Array,
+      //   required: false,
+      //   default: () => []
+      // },
 
       selected: {
         type: [Array, String],
@@ -116,6 +117,10 @@
     },
 
     computed: {
+      fields() {
+        return this.$store.state.search.facets.find(facet => facet.name === this.name)?.fields || [];
+      },
+
       sortedOptions() {
         if (this.isRadio) {
           return this.fields;
@@ -180,7 +185,12 @@
         });
       },
 
-      cancelHandler() {
+      showDropdown() {
+        console.log('showDropdown', this.name);
+        this.$store.dispatch('search/queryFacets', { facet: this.name });
+      },
+
+      cancelDropdown() {
         this.init();
       },
 

--- a/src/components/search/SideFilters.vue
+++ b/src/components/search/SideFilters.vue
@@ -28,12 +28,11 @@
           <client-only>
             <div class="position-relative">
               <SideFacetDropdown
-                v-for="facet in orderedFacets"
-                :key="facet.name"
-                :name="facet.name"
-                :fields="facet.fields"
-                :type="facetDropdownType(facet.name)"
-                :selected="filters[facet.name]"
+                v-for="facetName in facetNames"
+                :key="facetName"
+                :name="facetName"
+                :type="facetDropdownType(facetName)"
+                :selected="filters[facetName]"
                 role="search"
                 @changed="changeFacet"
               />
@@ -50,7 +49,6 @@
 
   import isEqual from 'lodash/isEqual';
   import { mapState, mapGetters } from 'vuex';
-  import { thematicCollections } from '@/plugins/europeana/search';
   import { queryUpdatesForFilters } from '../../store/search';
   import SideFacetDropdown from './SideFacetDropdown';
 
@@ -71,7 +69,6 @@
     },
     data() {
       return {
-        coreFacetNames: ['collection', 'TYPE', 'COUNTRY', 'REUSABILITY'],
         PROXY_DCTERMS_ISSUED: 'proxy_dcterms_issued'
       };
     },
@@ -106,31 +103,6 @@
 
         // This is a workaround
         return Number(this.$route.query.page || 1);
-      },
-      /**
-       * Sort the facets for display
-       * Facets are returned in the hard-coded preferred order from the search
-       * plugin, followed by all others in the order the API returned them.
-       * @return {Object[]} ordered facets
-       * TODO: does this belong in its own component?
-       */
-      orderedFacets() {
-        const unordered = this.facets.slice();
-        let ordered = [];
-
-        for (const facetName of this.facetNames) {
-          const index = unordered.findIndex((f) => {
-            return f.name === facetName;
-          });
-          if (index !== -1) {
-            ordered = ordered.concat(unordered.splice(index, 1));
-          }
-        }
-
-        if (this.$store.state.search.collectionFacetEnabled) {
-          ordered.unshift({ name: 'collection', fields: thematicCollections });
-        }
-        return ordered.concat(unordered);
       }
     },
     created() {

--- a/src/components/search/SideFilters.vue
+++ b/src/components/search/SideFilters.vue
@@ -25,19 +25,17 @@
         <b-col
           data-qa="search filters"
         >
-          <client-only>
-            <div class="position-relative">
-              <SideFacetDropdown
-                v-for="facetName in facetNames"
-                :key="facetName"
-                :name="facetName"
-                :type="facetDropdownType(facetName)"
-                :selected="filters[facetName]"
-                role="search"
-                @changed="changeFacet"
-              />
-            </div>
-          </client-only>
+          <div class="position-relative">
+            <SideFacetDropdown
+              v-for="facetName in facetNames"
+              :key="facetName"
+              :name="facetName"
+              :type="facetDropdownType(facetName)"
+              :selected="filters[facetName]"
+              role="search"
+              @changed="changeFacet"
+            />
+          </div>
         </b-col>
       </b-row>
     </b-container>
@@ -45,8 +43,6 @@
 </template>
 
 <script>
-  import ClientOnly from 'vue-client-only';
-
   import isEqual from 'lodash/isEqual';
   import { mapState, mapGetters } from 'vuex';
   import { queryUpdatesForFilters } from '../../store/search';
@@ -56,7 +52,6 @@
     name: 'SideFilters',
 
     components: {
-      ClientOnly,
       SideFacetDropdown
     },
     props: {

--- a/src/pages/blog/index.vue
+++ b/src/pages/blog/index.vue
@@ -84,12 +84,6 @@
       };
     },
 
-    watch: {
-      '$route.query.page'() {
-        this.$scrollTo('#main');
-      }
-    },
-
     methods: {
       imageUrl(post) {
         return post.primaryImageOfPage?.image?.url || null;

--- a/src/pages/blog/index.vue
+++ b/src/pages/blog/index.vue
@@ -28,7 +28,6 @@
     <b-row>
       <b-col>
         <PaginationNav
-          v-model="page"
           :limit="perPage"
           :total-results="total"
           :per-page="perPage"

--- a/src/pages/blog/index.vue
+++ b/src/pages/blog/index.vue
@@ -84,6 +84,12 @@
       };
     },
 
+    watch: {
+      '$route.query.page'() {
+        this.$scrollTo('#main');
+      }
+    },
+
     methods: {
       imageUrl(post) {
         return post.primaryImageOfPage?.image?.url || null;

--- a/src/pages/collections/_type/_.vue
+++ b/src/pages/collections/_type/_.vue
@@ -326,6 +326,11 @@
         return this.$config.app.features.sideFilters;
       }
     },
+    watch: {
+      '$route.query.page'() {
+        this.$scrollTo('#main');
+      }
+    },
     mounted() {
       this.$store.commit('search/setCollectionLabel', this.title.values[0]);
       this.$store.commit('search/set', ['overrideParams', this.searchOverrides]);
@@ -391,8 +396,7 @@
       this.$store.commit('entity/setId', null); // needed to re-enable auto-suggest in header
       this.$store.commit('entity/setEntity', null); // needed for best bets handling
       next();
-    },
-    watchQuery: ['api', 'reusability', 'query', 'qf', 'page']
+    }
   };
 </script>
 

--- a/src/pages/collections/_type/_.vue
+++ b/src/pages/collections/_type/_.vue
@@ -75,7 +75,10 @@
               :show-pins="userIsEditor && userIsSetsEditor"
             />
           </b-col>
-          <SideFilters v-if="sideFiltersEnabled" />
+          <SideFilters
+            v-if="sideFiltersEnabled"
+            :route="route"
+          />
         </b-row>
         <b-row>
           <b-col>

--- a/src/pages/collections/_type/_.vue
+++ b/src/pages/collections/_type/_.vue
@@ -326,11 +326,6 @@
         return this.$config.app.features.sideFilters;
       }
     },
-    watch: {
-      '$route.query.page'() {
-        this.$scrollTo('#main');
-      }
-    },
     mounted() {
       this.$store.commit('search/setCollectionLabel', this.title.values[0]);
       this.$store.commit('search/set', ['overrideParams', this.searchOverrides]);

--- a/src/pages/collections/_type/_.vue
+++ b/src/pages/collections/_type/_.vue
@@ -392,7 +392,6 @@
       if (to.matched[0].path !== `/${this.$i18n.locale}/search`) {
         this.$store.commit('search/setShowSearchBar', false);
       }
-      await this.$store.dispatch('search/deactivate');
       this.$store.commit('entity/setId', null); // needed to re-enable auto-suggest in header
       this.$store.commit('entity/setEntity', null); // needed for best bets handling
       next();

--- a/src/pages/collections/persons.vue
+++ b/src/pages/collections/persons.vue
@@ -24,7 +24,6 @@
     <b-row>
       <b-col>
         <PaginationNav
-          v-model="page"
           :limit="perPage"
           :total-results="total"
           :per-page="perPage"

--- a/src/pages/collections/persons.vue
+++ b/src/pages/collections/persons.vue
@@ -88,11 +88,6 @@
         };
       }
     },
-    watch: {
-      '$route.query.page'() {
-        this.$scrollTo('#main');
-      }
-    },
     methods: {
       entityRoute(entity) {
         return {

--- a/src/pages/collections/persons.vue
+++ b/src/pages/collections/persons.vue
@@ -88,6 +88,11 @@
         };
       }
     },
+    watch: {
+      '$route.query.page'() {
+        this.$scrollTo('#main');
+      }
+    },
     methods: {
       entityRoute(entity) {
         return {

--- a/src/pages/exhibitions/index.vue
+++ b/src/pages/exhibitions/index.vue
@@ -31,7 +31,6 @@
     <b-row>
       <b-col>
         <PaginationNav
-          v-model="page"
           :limit="perPage"
           :total-results="total"
           :per-page="perPage"

--- a/src/pages/exhibitions/index.vue
+++ b/src/pages/exhibitions/index.vue
@@ -86,6 +86,11 @@
         page: null
       };
     },
+    watch: {
+      '$route.query.page'() {
+        this.$scrollTo('#main');
+      }
+    },
     methods: {
       imageUrl(image) {
         return image?.image?.url;

--- a/src/pages/exhibitions/index.vue
+++ b/src/pages/exhibitions/index.vue
@@ -86,11 +86,6 @@
         page: null
       };
     },
-    watch: {
-      '$route.query.page'() {
-        this.$scrollTo('#main');
-      }
-    },
     methods: {
       imageUrl(image) {
         return image?.image?.url;

--- a/src/pages/galleries/index.vue
+++ b/src/pages/galleries/index.vue
@@ -26,7 +26,6 @@
     <b-row>
       <b-col>
         <PaginationNav
-          v-model="page"
           :limit="perPage"
           :total-results="total"
           :per-page="perPage"

--- a/src/pages/galleries/index.vue
+++ b/src/pages/galleries/index.vue
@@ -78,11 +78,6 @@
         page: null
       };
     },
-    watch: {
-      '$route.query.page'() {
-        this.$scrollTo('#main');
-      }
-    },
     methods: {
       imageUrl(data) {
         return (data.encoding ? data.encoding.edmPreview : data.thumbnailUrl) + '&size=w400';

--- a/src/pages/galleries/index.vue
+++ b/src/pages/galleries/index.vue
@@ -78,6 +78,11 @@
         page: null
       };
     },
+    watch: {
+      '$route.query.page'() {
+        this.$scrollTo('#main');
+      }
+    },
     methods: {
       imageUrl(data) {
         return (data.encoding ? data.encoding.edmPreview : data.thumbnailUrl) + '&size=w400';

--- a/src/pages/search/index.vue
+++ b/src/pages/search/index.vue
@@ -52,29 +52,20 @@
 </template>
 
 <script>
-  import SearchInterface from '../../components/search/SearchInterface';
-  import legacyUrl from '../../plugins/europeana/legacy-search';
-  import NotificationBanner from '../../components/generic/NotificationBanner';
+  import SearchInterface from '@/components/search/SearchInterface';
+  import legacyUrl from '@/plugins/europeana/legacy-search';
+  import NotificationBanner from '@/components/generic/NotificationBanner';
 
   export default {
     components: {
       SearchInterface,
       NotificationBanner,
-      RelatedSection: () => import('../../components/search/RelatedSection'),
-      SideFilters: () => import('../../components/search/SideFilters')
+      RelatedSection: () => import('@/components/search/RelatedSection'),
+      SideFilters: () => import('@/components/search/SideFilters')
     },
 
     middleware: 'sanitisePageQuery',
 
-    async fetch({ store, query, res, $apis }) {
-      await store.dispatch('search/activate');
-      store.commit('search/set', ['userParams', query]);
-
-      await store.dispatch('search/run', $apis.record.search);
-      if (store.state.search.error && typeof res !== 'undefined') {
-        res.statusCode = store.state.search.errorStatusCode;
-      }
-    },
     computed: {
       notificationUrl() {
         return legacyUrl(this.$route.query, this.$i18n.locale) +
@@ -106,9 +97,7 @@
       this.$store.commit('search/setShowSearchBar', false);
       await this.$store.dispatch('search/deactivate');
       next();
-    },
-
-    watchQuery: ['api', 'reusability', 'query', 'qf', 'page']
+    }
   };
 </script>
 

--- a/src/pages/search/index.vue
+++ b/src/pages/search/index.vue
@@ -87,12 +87,6 @@
       }
     },
 
-    watch: {
-      '$route.query.page'() {
-        this.$scrollTo('#main');
-      }
-    },
-
     mounted() {
       this.$store.commit('search/enableCollectionFacet');
     },

--- a/src/pages/search/index.vue
+++ b/src/pages/search/index.vue
@@ -40,6 +40,7 @@
             class="mb-4"
           />
           <SearchInterface
+            id="search-interface"
             :per-row="4"
           />
         </b-col>
@@ -79,6 +80,12 @@
       },
       sideFiltersEnabled() {
         return this.$config.app.features.sideFilters;
+      }
+    },
+
+    watch: {
+      '$route.query.page'() {
+        this.$scrollTo('#main');
       }
     },
 

--- a/src/pages/search/index.vue
+++ b/src/pages/search/index.vue
@@ -67,6 +67,10 @@
 
     middleware: 'sanitisePageQuery',
 
+    fetch() {
+      this.$store.commit('search/set', ['overrideParams', {}]);
+    },
+
     computed: {
       notificationUrl() {
         return legacyUrl(this.$route.query, this.$i18n.locale) +
@@ -102,7 +106,6 @@
     async beforeRouteLeave(to, from, next) {
       // Leaving the search page closes the search bar. Reevaluate when autosuggestions go straight to entity pages.
       this.$store.commit('search/setShowSearchBar', false);
-      await this.$store.dispatch('search/deactivate');
       next();
     }
   };

--- a/src/store/entity.js
+++ b/src/store/entity.js
@@ -1,5 +1,3 @@
-import { getEntityQuery } from '../plugins/europeana/entity';
-
 export default {
   state: () => ({
     curatedEntities: null,
@@ -81,42 +79,6 @@ export default {
   },
 
   actions: {
-    async searchForRecords({ getters, dispatch, commit, state }, query) {
-      if (!state.entity) {
-        return;
-      }
-
-      await dispatch('search/activate', null, { root: true });
-
-      const userParams = Object.assign({}, query);
-
-      const entityUri = state.id;
-
-      const overrideParams = {
-        qf: [],
-        rows: state.recordsPerPage
-      };
-
-      const curatedEntity = getters.curatedEntity(entityUri);
-      if (curatedEntity && curatedEntity.genre) {
-        overrideParams.qf.push(`collection:${curatedEntity.genre}`);
-      } else {
-        const entityQuery = getEntityQuery(entityUri);
-        overrideParams.qf.push(entityQuery);
-
-        if (!userParams.query) {
-          const englishPrefLabel = getters.englishPrefLabel;
-          if (englishPrefLabel) {
-            overrideParams.query = englishPrefLabel;
-          }
-        }
-      }
-
-      commit('search/set', ['userParams', userParams], { root: true });
-      commit('search/set', ['overrideParams', overrideParams], { root: true });
-
-      await dispatch('search/run', {}, { root: true });
-    },
     getFeatured({ commit, state, dispatch }) {
       const searchParams = {
         query: 'type:EntityBestItemsSet',

--- a/src/store/search.js
+++ b/src/store/search.js
@@ -404,6 +404,8 @@ export default {
             commit(`collections/${collection}/set`, ['facets', state.facets], { root: true });
             commit('set', ['facets', rootGetters[`collections/${collection}/facets`]]);
           }
+
+          return response.facets;
         })
         .catch(async(error) => {
           await dispatch('updateForFailure', error);

--- a/src/store/search.js
+++ b/src/store/search.js
@@ -290,19 +290,8 @@ export default {
       commit('setActive', true);
     },
 
-    async deactivate({ commit, dispatch }) {
+    deactivate({ commit }) {
       commit('setActive', false);
-      await dispatch('reset');
-    },
-
-    reset({ commit }) {
-      commit('set', ['userParams', {}]);
-      commit('set', ['overrideParams', {}]);
-      commit('set', ['apiParams', {}]);
-      commit('set', ['apiOptions', {}]);
-      commit('set', ['previousApiParams', null]);
-      commit('set', ['previousApiOptions', null]);
-      commit('setCollectionLabel', null);
     },
 
     // TODO: replace with a getter?
@@ -384,10 +373,6 @@ export default {
 
     // TODO: refactor not to need overrides once ENABLE_SIDE_FILTERS is always-on
     queryFacets({ commit, getters, rootState, rootGetters, dispatch, state }, overrides = {}) {
-      if (!state.active) {
-        return Promise.resolve();
-      }
-
       const paramsForFacets = {
         ...state.apiParams,
         rows: 0,

--- a/src/store/search.js
+++ b/src/store/search.js
@@ -357,12 +357,12 @@ export default {
     /**
      * Run a Record API search and store the results
      */
-    async run({ dispatch, getters }) {
+    async run({ dispatch, getters }, options = {}) {
       await dispatch('deriveApiSettings');
 
       return Promise.all([
-        getters.itemUpdateNeeded ? dispatch('queryItems') : () => null,
-        getters.facetUpdateNeeded ? dispatch('queryFacets') : () => null
+        getters.itemUpdateNeeded ? dispatch('queryItems') : Promise.resolve(),
+        (!options.skipFacets && getters.facetUpdateNeeded) ? dispatch('queryFacets') : Promise.resolve()
       ]);
     },
 
@@ -381,7 +381,7 @@ export default {
         });
     },
 
-    queryFacets({ commit, getters, rootState, rootGetters, dispatch, state }) {
+    queryFacets({ commit, getters, rootState, rootGetters, dispatch, state }, overrides = {}) {
       if (!state.active) {
         return Promise.resolve();
       }
@@ -389,7 +389,8 @@ export default {
       const paramsForFacets = {
         ...state.apiParams,
         rows: 0,
-        profile: 'facets'
+        profile: 'facets',
+        ...overrides
       };
 
       return this.$apis.record.search(paramsForFacets, { ...getters.searchOptions, locale: this.$i18n.locale })

--- a/src/store/search.js
+++ b/src/store/search.js
@@ -357,6 +357,7 @@ export default {
     /**
      * Run a Record API search and store the results
      */
+    // TODO: refactor not to need options once ENABLE_SIDE_FILTERS is always-on
     async run({ dispatch, getters }, options = {}) {
       await dispatch('deriveApiSettings');
 
@@ -381,6 +382,7 @@ export default {
         });
     },
 
+    // TODO: refactor not to need overrides once ENABLE_SIDE_FILTERS is always-on
     queryFacets({ commit, getters, rootState, rootGetters, dispatch, state }, overrides = {}) {
       if (!state.active) {
         return Promise.resolve();

--- a/tests/e2e/features/search/querying.feature
+++ b/tests/e2e/features/search/querying.feature
@@ -9,8 +9,8 @@ Feature: Search querying
     And I press the ENTER key
     And I see a `search query` with the text "paris"
     Then I see "paris" in the `search box`
-    And I should see 24 `item preview`s
     And I see the `total results`
+    And I should see 24 `item preview`s
     And I am on an accessible page
 
   Scenario: Search non existing Europeana content

--- a/tests/unit/components/search/SearchInterface.spec.js
+++ b/tests/unit/components/search/SearchInterface.spec.js
@@ -36,6 +36,7 @@ const factory = (options = {}) => {
     $path: () => '/',
     $goto: () => null,
     $config: { app: { features: { sideFilters: false } } },
+    $fetchState: {},
     ...options.mocks
   };
   const store = new Vuex.Store({

--- a/tests/unit/components/search/SearchInterface.spec.js
+++ b/tests/unit/components/search/SearchInterface.spec.js
@@ -36,7 +36,7 @@ const factory = (options = {}) => {
     $path: () => '/',
     $goto: () => null,
     $config: { app: { features: { sideFilters: false } } },
-    $fetchState: {},
+    $fetchState: options.fetchState || {},
     ...options.mocks
   };
   const store = new Vuex.Store({
@@ -109,8 +109,10 @@ describe('components/search/SearchInterface', () => {
       context('when there was a pagination error', () => {
         it('returns a user-friendly error message', async() => {
           const wrapper = factory({
-            storeState: {
-              error: 'Sorry! It is not possible to paginate beyond the first 5000 search results.'
+            fetchState: {
+              error: {
+                message: 'Sorry! It is not possible to paginate beyond the first 5000 search results.'
+              }
             }
           });
 

--- a/tests/unit/components/search/SideFacetDropdown.spec.js
+++ b/tests/unit/components/search/SideFacetDropdown.spec.js
@@ -90,6 +90,22 @@ describe('components/search/SideFacetDropdown', () => {
 
         storeDispatchStub.should.not.have.been.calledWith('search/queryFacets', { facet: 'COUNTRY' });
       });
+
+      context('and facet name is "contentTier"', () => {
+        it('does not fetch facet', async() => {
+          const wrapper = factory();
+          await wrapper.setProps({
+            name: 'contentTier'
+          });
+          await wrapper.setData({
+            shown: false
+          });
+
+          await wrapper.vm.fetch();
+
+          storeDispatchStub.should.have.been.calledWith('search/queryFacets', { facet: 'contentTier' });
+        });
+      });
     });
   });
 

--- a/tests/unit/components/search/SideFacetDropdown.spec.js
+++ b/tests/unit/components/search/SideFacetDropdown.spec.js
@@ -105,14 +105,26 @@ describe('components/search/SideFacetDropdown', () => {
     });
   });
 
-  describe('applySelection', () => {
-    it('emits `updated` event', async() => {
-      const wrapper = factory();
+  describe('methods', () => {
+    describe('showDropdown', () => {
+      it('requests single facet from API', () => {
+        const wrapper = factory();
 
-      wrapper.vm.$refs.dropdown.hide = sinon.spy();
+        wrapper.vm.showDropdown();
 
-      wrapper.vm.applySelection();
-      wrapper.emitted()['changed'].length.should.equal(1);
+        wrapper.vm.$store.dispatch.should.have.been.calledWith('search/queryFacets', { facet: 'COUNTRY' });
+      });
+    });
+
+    describe('applySelection', () => {
+      it('emits `updated` event', async() => {
+        const wrapper = factory();
+
+        wrapper.vm.$refs.dropdown.hide = sinon.spy();
+
+        wrapper.vm.applySelection();
+        wrapper.emitted()['changed'].length.should.equal(1);
+      });
     });
   });
 });

--- a/tests/unit/components/search/SideFacetDropdown.spec.js
+++ b/tests/unit/components/search/SideFacetDropdown.spec.js
@@ -30,13 +30,19 @@ const factory = () => shallowMount(SideFacetDropdown, {
     $t: (key) => key,
     $tFacetName: (key) => key,
     $store: {
-      dispatch: sinon.stub()
+      dispatch: sinon.stub(),
+      state: {
+        search: {
+          facets: [
+            { name: 'COUNTRY', fields: countryFields }
+          ]
+        }
+      }
     }
   },
   stubs: ['b-button', 'b-form-checkbox', 'b-dropdown', 'b-dropdown-form'],
   propsData: {
     type: 'checkbox',
-    fields: countryFields,
     name: 'COUNTRY'
   }
 });

--- a/tests/unit/components/search/SideFilters.spec.js
+++ b/tests/unit/components/search/SideFilters.spec.js
@@ -72,43 +72,6 @@ const factory = (options = {}) => {
 };
 
 describe('components/search/SideFilters', () => {
-  describe('computed properties', () => {
-    describe('orderedFacets', () => {
-      const wrapper = factory({
-        storeState: {
-          facets: [
-            { name: 'COUNTRY' },
-            { name: 'RIGHTS' },
-            { name: 'CONTRIBUTOR' },
-            { name: 'DATA_PROVIDER' },
-            { name: 'PROVIDER' },
-            { name: 'LANGUAGE' },
-            { name: 'REUSABILITY' },
-            { name: 'TYPE' }
-          ]
-        }
-      });
-
-      it('injects collection first', () => {
-        wrapper.vm.orderedFacets[0].name.should.eq('collection');
-      });
-
-      it('follows with ordered default facets from search plugin', () => {
-        wrapper.vm.orderedFacets[1].name.should.eq('TYPE');
-        wrapper.vm.orderedFacets[2].name.should.eq('REUSABILITY');
-        wrapper.vm.orderedFacets[3].name.should.eq('COUNTRY');
-        wrapper.vm.orderedFacets[4].name.should.eq('LANGUAGE');
-        wrapper.vm.orderedFacets[5].name.should.eq('PROVIDER');
-        wrapper.vm.orderedFacets[6].name.should.eq('DATA_PROVIDER');
-      });
-
-      it('ends with any other facets in their original order', () => {
-        wrapper.vm.orderedFacets[7].name.should.eq('RIGHTS');
-        wrapper.vm.orderedFacets[8].name.should.eq('CONTRIBUTOR');
-      });
-    });
-  });
-
   describe('methods', () => {
     describe('changeFacet', () => {
       const facetName = 'TYPE';

--- a/tests/unit/pages/collections/type/_.spec.js
+++ b/tests/unit/pages/collections/type/_.spec.js
@@ -25,6 +25,9 @@ const store = (entityExample = {}) => {
       },
       auth: {}
     },
+    getters: {
+      'entity/curatedEntity': () => () => null
+    },
     mutations: {
       'search/setCollectionLabel': () => null
     },

--- a/tests/unit/pages/collections/type/_.spec.js
+++ b/tests/unit/pages/collections/type/_.spec.js
@@ -10,16 +10,20 @@ const localVue = createLocalVue();
 localVue.use(BootstrapVue);
 localVue.use(Vuex);
 
-const organisationEntity =
-{ entity: { logo: { id: 'http://commons.wikimedia.org/wiki/Special:FilePath/Albertina%20Logo.svg' },
-  description: { en: 'example of an organisation description' },
-  homepage: 'https://www.example-organisation.eu' },
-type: 'organisation' };
+const organisationEntity = {
+  entity: {
+    id: 'http://data.europeana.eu/organization/01234567890',
+    logo: { id: 'http://commons.wikimedia.org/wiki/Special:FilePath/Albertina%20Logo.svg' },
+    description: { en: 'example of an organisation description' },
+    homepage: 'https://www.example-organisation.eu'
+  },
+  type: 'organisation'
+};
 
-const store = (entityExample = {}) => {
+const store = (entity = {}) => {
   return new Vuex.Store({
     state: {
-      entity: { entity: entityExample },
+      entity: { entity },
       i18n: {
         locale: 'en'
       },
@@ -29,6 +33,7 @@ const store = (entityExample = {}) => {
       'entity/curatedEntity': () => () => null
     },
     mutations: {
+      'search/set': () => null,
       'search/setCollectionLabel': () => null
     },
     actions: {

--- a/tests/unit/store/search.spec.js
+++ b/tests/unit/store/search.spec.js
@@ -498,6 +498,14 @@ describe('store/search', () => {
         dispatch.should.have.been.calledWith('queryItems');
         dispatch.should.not.have.been.calledWith('queryFacets');
       });
+
+      it('omits query for facets if explicitly skipped', async() => {
+        const dispatch = sinon.spy();
+
+        await store.actions.run({ dispatch, getters: { facetUpdateNeeded: true } }, { skipFacets: true });
+
+        dispatch.should.not.have.been.calledWith('queryFacets');
+      });
     });
 
     describe('queryItems', () => {

--- a/tests/unit/utils.js
+++ b/tests/unit/utils.js
@@ -8,6 +8,7 @@ const NUXT_METHODS = [
 const injectNuxtMethods = (wrapper, pageOrComponent) => {
   for (const method of NUXT_METHODS) {
     wrapper.vm[method] = pageOrComponent[method];
+    wrapper.vm['$fetch'] = pageOrComponent.fetch;
   }
   return wrapper;
 };


### PR DESCRIPTION
When side filters are enabled for search, only retrieve facets one-at-a-time and when they are needed, i.e. when the user shows that facet's dropdown, and unless they have previously been retrieved and would not have changed since.

Also:
* Fix the side filters on the search within a collection, which were instead running a full site search
* The contentTier filter must always be fetched (client-side) because it's needed for displaying the toast
* Move the responsibility for triggering the Record API search and facet requests from page views into the search interface component
* Make the search interface component use the newer-style Nuxt `fetch` with the loading indicator
* Remove use of `v-model` from PaginationNav.vue component, leaving Bootstrap Vue's Pagination Nav to deduce the page from the URL/route
* Improve smoothness of transitions between search and non-search pages by removing search store reset
* Improve initial rendering of side facet dropdowns by not wrapping in `client-only`