### PR TITLE
refactor: request individual facets up front

### DIFF
--- a/src/components/search/SideFacetDropdown.vue
+++ b/src/components/search/SideFacetDropdown.vue
@@ -133,7 +133,7 @@
       if (this.staticFields) {
         this.fields = this.staticFields;
         this.fetched = true;
-        return;
+        return Promise.resolve();
       }
 
       return this.$store.dispatch('search/queryFacets', { facet: this.name })

--- a/src/components/search/SideFilters.vue
+++ b/src/components/search/SideFilters.vue
@@ -26,16 +26,18 @@
           data-qa="search filters"
         >
           <div class="position-relative">
-            <SideFacetDropdown
-              v-for="facet in filterableFacets"
-              :key="facet.name"
-              :name="facet.name"
-              :type="facetDropdownType(facet.name)"
-              :selected="filters[facet.name]"
-              :static-fields="facet.staticFields"
-              role="search"
-              @changed="changeFacet"
-            />
+            <client-only>
+              <SideFacetDropdown
+                v-for="facet in filterableFacets"
+                :key="facet.name"
+                :name="facet.name"
+                :type="facetDropdownType(facet.name)"
+                :selected="filters[facet.name]"
+                :static-fields="facet.staticFields"
+                role="search"
+                @changed="changeFacet"
+              />
+            </client-only>
           </div>
         </b-col>
       </b-row>
@@ -44,6 +46,7 @@
 </template>
 
 <script>
+  import ClientOnly from 'vue-client-only';
   import { thematicCollections } from '@/plugins/europeana/search';
   import isEqual from 'lodash/isEqual';
   import { mapState, mapGetters } from 'vuex';
@@ -54,6 +57,7 @@
     name: 'SideFilters',
 
     components: {
+      ClientOnly,
       SideFacetDropdown
     },
     props: {

--- a/tests/unit/components/search/SideFacetDropdown.spec.js
+++ b/tests/unit/components/search/SideFacetDropdown.spec.js
@@ -54,11 +54,11 @@ describe('components/search/SideFacetDropdown', () => {
   });
 
   describe('fetch', () => {
-    context('if dropdown is shown', () => {
+    context('if fields are not static', () => {
       it('fetches facet', async() => {
         const wrapper = factory();
         await wrapper.setData({
-          shown: true
+          staticFields: null
         });
 
         await wrapper.vm.fetch();
@@ -79,32 +79,29 @@ describe('components/search/SideFacetDropdown', () => {
       });
     });
 
-    context('if dropdown is not shown', () => {
+    context('if fields are static', () => {
       it('does not fetch facet', async() => {
         const wrapper = factory();
-        await wrapper.setData({
-          shown: false
+        await wrapper.setProps({
+          name: 'collection',
+          staticFields: []
         });
 
         await wrapper.vm.fetch();
 
-        storeDispatchStub.should.not.have.been.calledWith('search/queryFacets', { facet: 'COUNTRY' });
+        storeDispatchStub.should.not.have.been.calledWith('search/queryFacets', { facet: 'collection' });
       });
 
-      context('and facet name is "contentTier"', () => {
-        it('does not fetch facet', async() => {
-          const wrapper = factory();
-          await wrapper.setProps({
-            name: 'contentTier'
-          });
-          await wrapper.setData({
-            shown: false
-          });
-
-          await wrapper.vm.fetch();
-
-          storeDispatchStub.should.have.been.calledWith('search/queryFacets', { facet: 'contentTier' });
+      it('marks facet as fetched', async() => {
+        const wrapper = factory();
+        await wrapper.setProps({
+          name: 'collection',
+          staticFields: []
         });
+
+        await wrapper.vm.fetch();
+
+        wrapper.vm.fetched.should.be.true;
       });
     });
   });


### PR DESCRIPTION
* Keep the facet API requests isolated to a single facet at a time...
* ...but don't wait for user interaction, i.e. request them all in advance, in multiple API requests
* Only render the filter dropdowns client-side, to get a speedy initial server response time
* Once a facet API response is received, if a facet has no available fields, remove it from display
* When URL query parameters change that may affect the facets, immediately re-request all of them