### PR TITLE
feat: add config setting for locales to translate search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -147,3 +147,7 @@ ENABLE_LINKS_TO_CLASSIC=1
 
 # Entity management API URL
 # EUROPEANA_ENTITY_MANAGEMENT_API_URL=https://entity-management-acceptance.eanadev.org/entity
+
+# Comma-separated list of two-letter language codes for which to enable search
+# translation.
+# APP_SEARCH_TRANSLATE_LOCALES=es,de

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -35,6 +35,9 @@ export default {
       internalLinkDomain: process.env.INTERNAL_LINK_DOMAIN,
       schemaOrgDatasetId: process.env.SCHEMA_ORG_DATASET_ID,
       siteName: APP_SITE_NAME,
+      search: {
+        translateLocales: (process.env.APP_SEARCH_TRANSLATE_LOCALES || '').split(',')
+      },
       features: {
         abTests: featureIsEnabled(process.env.ENABLE_AB_TESTS),
         jiraServiceDeskFeedbackForm: featureIsEnabled(process.env.ENABLE_JIRA_SERVICE_DESK_FEEDBACK_FORM),

--- a/src/plugins/europeana/search.js
+++ b/src/plugins/europeana/search.js
@@ -101,17 +101,21 @@ export default (context) => ($axios, params, options = {}) => {
   const searchParams = {
     ...$axios.defaults.params,
     facet: params.facet,
-    profile: params.profile,
+    profile: params.profile || '',
     qf: addContentTierFilter(params.qf),
     query: options.escape ? escapeLuceneSpecials(query) : query,
     reusability: params.reusability,
     rows,
     start
   };
-  const targetLocale = 'en';
-  if (options.locale && options.locale !== targetLocale) {
-    searchParams['q.source'] = options.locale;
-    searchParams['q.target'] = targetLocale;
+
+  if (context?.$config?.app?.search?.translateLocales?.includes(options.locale)) {
+    const targetLocale = 'en';
+    if (options.locale && (options.locale !== targetLocale)) {
+      searchParams.profile = `${searchParams.profile},translate`;
+      searchParams['q.source'] = options.locale;
+      searchParams['q.target'] = targetLocale;
+    }
   }
 
   return $axios.get(`${options.url || ''}/search.json`, {

--- a/tests/unit/plugins/europeana/search.spec.js
+++ b/tests/unit/plugins/europeana/search.spec.js
@@ -127,7 +127,9 @@ describe('plugins/europeana/search', () => {
       });
 
       describe('multilingual queries', () => {
-        it('passes API i18n params if locale option given', async() => {
+        const context = { $config: { app: { search: { translateLocales: ['es'] } } } };
+
+        it('passes API i18n params if configured and locale option given', async() => {
           const locale = 'es';
 
           baseRequest
@@ -136,7 +138,7 @@ describe('plugins/europeana/search', () => {
             })
             .reply(200, defaultResponse);
 
-          await search()($axios, { query: 'flor' }, { locale });
+          await search(context)($axios, { query: 'flor' }, { locale });
 
           nock.isDone().should.be.true;
         });
@@ -149,7 +151,7 @@ describe('plugins/europeana/search', () => {
             })
             .reply(200, defaultResponse);
 
-          await search()($axios, { query: 'flor' });
+          await search(context)($axios, { query: 'flor' });
 
           nock.isDone().should.be.true;
         });
@@ -164,7 +166,7 @@ describe('plugins/europeana/search', () => {
             })
             .reply(200, defaultResponse);
 
-          await search()($axios, { query: 'flor' }, { locale });
+          await search(context)($axios, { query: 'flor' }, { locale });
 
           nock.isDone().should.be.true;
         });


### PR DESCRIPTION
Enabled by env var:
```
APP_SEARCH_TRANSLATE_LOCALES=es
```