### PR TITLE
chore: use distroless base image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
           tags: |
             type=ref,event=pr
       -
-        name: Build and load
+        name: Build and load app image
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -186,9 +186,17 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       -
+        name: Build and load size test image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./tests/size
+          load: true
+          tags: ${{ env.DOCKER_REPOSITORY }}-test-size
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      -
         name: Prepare resources for size tests
         run: |
-          docker pull europeana/portal.js-test-size
           docker run --name portal.js --rm -d ${{ env.DOCKER_REPOSITORY }}:${{ steps.meta.outputs.version }}
           docker cp portal.js:/app/.nuxt ./.nuxt
           docker stop portal.js
@@ -198,7 +206,7 @@ jobs:
           docker run \
             --mount type=bind,source="$(pwd)"/.nuxt,target=/app/.nuxt \
             --mount type=bind,source="$(pwd)"/tests/size/.size-limit.json,target=/app/.size-limit.json \
-            europeana/portal.js-test-size
+            ${{ env.DOCKER_REPOSITORY }}-test-size
 
   # Run e2e tests on pull requests
   test-e2e:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,39 +113,39 @@ jobs:
             --mount type=bind,source="$(pwd)"/.eslintrc.cjs,target=/app/.eslintrc.cjs \
             ${DOCKER_REPOSITORY}:${{ steps.meta.outputs.version }} npm run test:unit
 
-# Build and cache build stage.
-docker-build-stage:
-  runs-on: ubuntu-latest
-  needs: [docker-base-stage]
-  if: github.event_name == 'push' || github.event.pull_request.draft == false
-  steps:
-    -
-      name: Checkout
-      uses: actions/checkout@v2
-    -
-      name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    -
-      name: Docker meta
-      id: meta
-      uses: docker/metadata-action@v3
-      with:
-        images: ${{ env.DOCKER_REPOSITORY }}
-        tags: |
-          type=ref,event=pr,suffix=-build
-          type=ref,event=branch,suffix=-build
-          type=ref,event=tag,suffix=-build
-          type=semver,pattern={{version}},suffix=-build
-    -
-      name: Build and cache
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        pull: true
-        tags: ${{ steps.meta.outputs.tags }}
-        target: build
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+  # Build and cache build stage.
+  docker-build-stage:
+    runs-on: ubuntu-latest
+    needs: [docker-base-stage]
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.DOCKER_REPOSITORY }}
+          tags: |
+            type=ref,event=pr,suffix=-build
+            type=ref,event=branch,suffix=-build
+            type=ref,event=tag,suffix=-build
+            type=semver,pattern={{version}},suffix=-build
+      -
+        name: Build and cache
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          pull: true
+          tags: ${{ steps.meta.outputs.tags }}
+          target: build
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   # Build, and push to Docker Hub, full production Docker image for use throughout
   # other jobs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,7 +423,7 @@ jobs:
           npm publish --access public --dry-run ./tmp/app
       -
         name: Warm up jsDelivr
-        run: .github/workflows/support/docker-images/warm-up-jsdelivr.sh ./tmp/app/.nuxt/dist/client
+        run: .github/workflows/support/docker-images/warm-up-jsdelivr.sh ./tmp/app
 
   # Send a notification to Slack channel with details of new PR deployments
   notify:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,13 +374,11 @@ jobs:
   npm-publish:
     runs-on: ubuntu-latest
     needs: [docker-final-stage]
-    if: github.event_name == 'push' && startsWith( github.event.ref, 'refs/tags/v' )
+    # TODO: uncomment
+    # if: github.event_name == 'push' && startsWith( github.event.ref, 'refs/tags/v' )
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
     steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v2
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -402,14 +400,22 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       -
+        name: Prepare resources for publish
+        run: |
+          docker run --name portal.js --rm -d ${{ env.DOCKER_REPOSITORY }}:${{ steps.meta.outputs.version }}
+          docker cp portal.js:/app ./
+          docker stop portal.js
+      -
+        name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      -
         name: Publish to NPM
         run: |
-          docker run \
-            --rm \
-            --env NODE_AUTH_TOKEN=${NODE_AUTH_TOKEN} \
-            --mount type=bind,source=$(pwd)/.github/workflows/support/docker-images/.npmrc,target=/root/.npmrc \
-            --entrypoint npm ${{ env.DOCKER_REPOSITORY }}:${{ steps.meta.outputs.version }} \
-            publish --access public
+          cp .github/workflows/support/docker-images/.npmrc ~/
+          cd ./app
+          npm publish --access public --dry-run
       -
         name: Warm up jsDelivr
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,9 +420,7 @@ jobs:
         name: Publish to NPM
         run: |
           cp .github/workflows/support/docker-images/.npmrc ~/
-          cd ./tmp/app
-          npm publish --access public --dry-run
-          cd -
+          npm publish --access public --dry-run ./tmp/app
       -
         name: Warm up jsDelivr
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,6 +383,11 @@ jobs:
         name: Checkout
         uses: actions/checkout@v2
       -
+        name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
@@ -412,16 +417,12 @@ jobs:
           docker cp portal.js:/app ./tmp
           docker stop portal.js
       -
-        name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: '14'
-      -
         name: Publish to NPM
         run: |
           cp .github/workflows/support/docker-images/.npmrc ~/
           cd ./tmp/app
           npm publish --access public --dry-run
+          cd -
       -
         name: Warm up jsDelivr
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   # Build the base stage of the Docker image first so that unit tests can run,
   # as they do not require the full production image to be built.
-  docker-build-base:
+  docker-base-stage:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
@@ -65,7 +65,7 @@ jobs:
   # Run linting and unit tests on pull requests
   test-unit:
     runs-on: ubuntu-latest
-    needs: [docker-build-base]
+    needs: [docker-base-stage]
     if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     steps:
       -
@@ -113,11 +113,45 @@ jobs:
             --mount type=bind,source="$(pwd)"/.eslintrc.cjs,target=/app/.eslintrc.cjs \
             ${DOCKER_REPOSITORY}:${{ steps.meta.outputs.version }} npm run test:unit
 
+# Build and cache build stage.
+docker-build-stage:
+  runs-on: ubuntu-latest
+  needs: [docker-base-stage]
+  if: github.event_name == 'push' || github.event.pull_request.draft == false
+  steps:
+    -
+      name: Checkout
+      uses: actions/checkout@v2
+    -
+      name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    -
+      name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: ${{ env.DOCKER_REPOSITORY }}
+        tags: |
+          type=ref,event=pr,suffix=-build
+          type=ref,event=branch,suffix=-build
+          type=ref,event=tag,suffix=-build
+          type=semver,pattern={{version}},suffix=-build
+    -
+      name: Build and cache
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        pull: true
+        tags: ${{ steps.meta.outputs.tags }}
+        target: build
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
   # Build, and push to Docker Hub, full production Docker image for use throughout
   # other jobs
-  docker-build-push:
+  docker-final-stage:
     runs-on: ubuntu-latest
-    needs: [docker-build-base]
+    needs: [docker-build-stage]
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
       -
@@ -159,7 +193,7 @@ jobs:
   # Run size tests on pull requests
   test-size:
     runs-on: ubuntu-latest
-    needs: [docker-build-push]
+    needs: [docker-final-stage]
     if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     steps:
       -
@@ -203,7 +237,7 @@ jobs:
   # Run e2e tests on pull requests
   test-e2e:
     runs-on: ubuntu-latest
-    needs: [docker-build-push]
+    needs: [docker-final-stage]
     if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     steps:
       -
@@ -241,7 +275,7 @@ jobs:
   # Run visual tests on pull requests, and pushes to master
   test-visual:
     runs-on: ubuntu-latest
-    needs: [docker-build-push]
+    needs: [docker-final-stage]
     if: (github.event_name == 'push' && github.event.ref == 'refs/heads/master') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     env:
       PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
@@ -286,7 +320,7 @@ jobs:
   # * Pushes to master update the deployment in the test namespace
   deploy-ibm-cloud:
     runs-on: ubuntu-latest
-    needs: [docker-build-push]
+    needs: [docker-final-stage]
     if: (github.event_name == 'push' && github.event.ref == 'refs/heads/master') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     env:
       IBMCLOUD_API_URL: https://cloud.ibm.com
@@ -373,7 +407,7 @@ jobs:
   # Publish tagged versions to NPM
   npm-publish:
     runs-on: ubuntu-latest
-    needs: [docker-build-push]
+    needs: [docker-final-stage]
     if: github.event_name == 'push' && startsWith( github.event.ref, 'refs/tags/v' )
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,15 +94,22 @@ jobs:
       -
         name: Check code linting
         run: |
-          docker run --mount type=bind,source="$(pwd)"/tests,target=/app/tests ${DOCKER_REPOSITORY}:${{ steps.meta.outputs.version }} npm run lint
+          docker run \
+            --mount type=bind,source="$(pwd)"/tests,target=/app/tests \
+            --mount type=bind,source="$(pwd)"/bin,target=/app/bin \
+            ${DOCKER_REPOSITORY}:${{ steps.meta.outputs.version }} npm run lint
       -
         name: Check style linting
         run: |
-          docker run --mount type=bind,source="$(pwd)"/tests,target=/app/tests ${DOCKER_REPOSITORY}:${{ steps.meta.outputs.version }} npm run stylelint
+          docker run \
+            --mount type=bind,source="$(pwd)"/tests,target=/app/tests \
+            ${DOCKER_REPOSITORY}:${{ steps.meta.outputs.version }} npm run stylelint
       -
         name: Run unit tests
         run: |
-          docker run --mount type=bind,source="$(pwd)"/tests,target=/app/tests ${DOCKER_REPOSITORY}:${{ steps.meta.outputs.version }} npm run test:unit
+          docker run \
+            --mount type=bind,source="$(pwd)"/tests,target=/app/tests \
+            ${DOCKER_REPOSITORY}:${{ steps.meta.outputs.version }} npm run test:unit
 
   # Build, and push to Docker Hub, full production Docker image for use throughout
   # other jobs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,6 +380,9 @@ jobs:
       NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
     steps:
       -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
@@ -403,7 +406,8 @@ jobs:
         name: Prepare resources for publish
         run: |
           docker run --name portal.js --rm -d ${{ env.DOCKER_REPOSITORY }}:${{ steps.meta.outputs.version }}
-          docker cp portal.js:/app ./
+          mkdir ./tmp
+          docker cp portal.js:/app ./tmp
           docker stop portal.js
       -
         name: Setup Node
@@ -414,7 +418,7 @@ jobs:
         name: Publish to NPM
         run: |
           cp .github/workflows/support/docker-images/.npmrc ~/
-          cd ./app
+          cd ./tmp/app
           npm publish --access public --dry-run
       -
         name: Warm up jsDelivr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,8 +391,10 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: ${{ env.DOCKER_REPOSITORY }}
+          # TODO: remove pr type
           tags: |
             type=ref,event=tag
+            type=ref,event=pr
       -
         name: Load built image
         uses: docker/build-push-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,45 +113,11 @@ jobs:
             --mount type=bind,source="$(pwd)"/.eslintrc.cjs,target=/app/.eslintrc.cjs \
             ${DOCKER_REPOSITORY}:${{ steps.meta.outputs.version }} npm run test:unit
 
-  # Build and cache build stage.
-  docker-build-stage:
-    runs-on: ubuntu-latest
-    needs: [docker-base-stage]
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v2
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      -
-        name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: ${{ env.DOCKER_REPOSITORY }}
-          tags: |
-            type=ref,event=pr,suffix=-build
-            type=ref,event=branch,suffix=-build
-            type=ref,event=tag,suffix=-build
-            type=semver,pattern={{version}},suffix=-build
-      -
-        name: Build and cache
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          pull: true
-          tags: ${{ steps.meta.outputs.tags }}
-          target: build
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
   # Build, and push to Docker Hub, full production Docker image for use throughout
   # other jobs
   docker-final-stage:
     runs-on: ubuntu-latest
-    needs: [docker-build-stage]
+    needs: [docker-base-stage]
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
       -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,8 +374,7 @@ jobs:
   npm-publish:
     runs-on: ubuntu-latest
     needs: [docker-final-stage]
-    # TODO: uncomment
-    # if: github.event_name == 'push' && startsWith( github.event.ref, 'refs/tags/v' )
+    if: github.event_name == 'push' && startsWith( github.event.ref, 'refs/tags/v' )
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
     steps:
@@ -396,10 +395,8 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: ${{ env.DOCKER_REPOSITORY }}
-          # TODO: remove pr type
           tags: |
             type=ref,event=tag
-            type=ref,event=pr
       -
         name: Load built image
         uses: docker/build-push-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           context: .
           pull: true
           tags: ${{ steps.meta.outputs.tags }}
-          target: production-app-base
+          target: base
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -89,7 +89,7 @@ jobs:
           context: .
           load: true
           tags: ${{ steps.meta.outputs.tags }}
-          target: production-app-base
+          target: base
           cache-from: type=gha
       -
         name: Check code linting
@@ -104,46 +104,11 @@ jobs:
         run: |
           docker run --mount type=bind,source="$(pwd)"/tests,target=/app/tests ${DOCKER_REPOSITORY}:${{ steps.meta.outputs.version }} npm run test:unit
 
-  # Build the production-app-build-nuxt stage of the Docker image independently so
-  # that it gets cached by Buildx.
-  docker-build-nuxt:
-    runs-on: ubuntu-latest
-    needs: [docker-build-base]
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v2
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      -
-        name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: ${{ env.DOCKER_REPOSITORY }}
-          tags: |
-            type=ref,event=pr,suffix=-nuxt
-            type=ref,event=branch,suffix=-nuxt
-            type=ref,event=tag,suffix=-nuxt
-            type=semver,pattern={{version}},suffix=-nuxt
-      -
-        name: Build and cache
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          pull: true
-          tags: ${{ steps.meta.outputs.tags }}
-          target: production-app-build-nuxt
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
   # Build, and push to Docker Hub, full production Docker image for use throughout
   # other jobs
   docker-build-push:
     runs-on: ubuntu-latest
-    needs: [docker-build-nuxt]
+    needs: [docker-build-base]
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
       -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
         run: |
           docker run \
             --mount type=bind,source="$(pwd)"/tests,target=/app/tests \
+            --mount type=bind,source="$(pwd)"/.eslintrc.cjs,target=/app/.eslintrc.cjs \
             ${DOCKER_REPOSITORY}:${{ steps.meta.outputs.version }} npm run test:unit
 
   # Build, and push to Docker Hub, full production Docker image for use throughout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,13 +96,14 @@ jobs:
         run: |
           docker run \
             --mount type=bind,source="$(pwd)"/tests,target=/app/tests \
+            --mount type=bind,source="$(pwd)"/.eslintrc.cjs,target=/app/.eslintrc.cjs \
             --mount type=bind,source="$(pwd)"/bin,target=/app/bin \
             ${DOCKER_REPOSITORY}:${{ steps.meta.outputs.version }} npm run lint
       -
         name: Check style linting
         run: |
           docker run \
-            --mount type=bind,source="$(pwd)"/tests,target=/app/tests \
+            --mount type=bind,source="$(pwd)"/.stylelintrc.cjs,target=/app/.stylelintrc.cjs \
             ${DOCKER_REPOSITORY}:${{ steps.meta.outputs.version }} npm run stylelint
       -
         name: Run unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,11 +423,7 @@ jobs:
           npm publish --access public --dry-run ./tmp/app
       -
         name: Warm up jsDelivr
-        run: |
-          docker run \
-            --rm \
-            --mount type=bind,source=$(pwd)/.github/workflows/support/docker-images/warm-up-jsdelivr.sh,target=/root/warm-up-jsdelivr.sh \
-            --entrypoint /root/warm-up-jsdelivr.sh ${{ env.DOCKER_REPOSITORY }}:${{ steps.meta.outputs.version }}
+        run: .github/workflows/support/docker-images/warm-up-jsdelivr.sh ./tmp/app/.nuxt/dist/client
 
   # Send a notification to Slack channel with details of new PR deployments
   notify:

--- a/.github/workflows/support/docker-images/warm-up-jsdelivr.sh
+++ b/.github/workflows/support/docker-images/warm-up-jsdelivr.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-set -e
-
 dir=${1:-.}
 version=$(npm view @europeana/portal version)
 

--- a/.github/workflows/support/docker-images/warm-up-jsdelivr.sh
+++ b/.github/workflows/support/docker-images/warm-up-jsdelivr.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-dir=$1
+dir=${$1:-.}
 version=$(npm view @europeana/portal version)
 
 warm_up_url () {
@@ -29,7 +29,9 @@ warm_up_url () {
   done
 }
 
-for file in $(find ${dir} -type f | sort); do
+cd ${dir}
+for file in $(find .nuxt/dist/client -type f | sort); do
   url="https://cdn.jsdelivr.net/npm/@europeana/portal@${version}/${file}"
   warm_up_url ${url}
 done
+cd -

--- a/.github/workflows/support/docker-images/warm-up-jsdelivr.sh
+++ b/.github/workflows/support/docker-images/warm-up-jsdelivr.sh
@@ -7,7 +7,7 @@ warm_up_url () {
   url=$1
   echo ${url}
 
-  cached=false
+  cached="false"
   attempt=0
   while [[ ${cached} == "false" ]]; do
     attempt=$(( attempt + 1 ))
@@ -17,12 +17,12 @@ warm_up_url () {
     fi
 
     echo "Checking for file availability on jsDelivr, attempt #${attempt}"
-    curl --fail -o /dev/null -I "${url}"
+    curl --fail --silent -o /dev/null -I "${url}"
 
     if [[ "$?" == "0" ]]; then
       echo "OK"
       echo
-      cached=true
+      cached="true"
     else
       sleep 10
     fi

--- a/.github/workflows/support/docker-images/warm-up-jsdelivr.sh
+++ b/.github/workflows/support/docker-images/warm-up-jsdelivr.sh
@@ -17,7 +17,7 @@ warm_up_url () {
     fi
 
     echo "Checking for file availability on jsDelivr, attempt #${attempt}"
-    curl --fail --silent -o /dev/null -I "${url}"
+    curl --fail -o /dev/null -I "${url}"
 
     if [[ "$?" == "0" ]]; then
       echo "OK"

--- a/.github/workflows/support/docker-images/warm-up-jsdelivr.sh
+++ b/.github/workflows/support/docker-images/warm-up-jsdelivr.sh
@@ -1,13 +1,12 @@
 #!/bin/sh
 
+dir=$1
 version=$(npm view @europeana/portal version)
-
-apk add --no-cache curl
 
 warm_up_url () {
   url=$1
   echo ${url}
-  
+
   cached=false
   attempt=0
   while [[ ${cached} == "false" ]]; do
@@ -30,7 +29,7 @@ warm_up_url () {
   done
 }
 
-for file in $(find .nuxt/dist/client -type f | sort); do
+for file in $(find ${dir} -type f | sort); do
   url="https://cdn.jsdelivr.net/npm/@europeana/portal@${version}/${file}"
   warm_up_url ${url}
 done

--- a/.github/workflows/support/docker-images/warm-up-jsdelivr.sh
+++ b/.github/workflows/support/docker-images/warm-up-jsdelivr.sh
@@ -3,9 +3,7 @@
 set -e
 
 dir=${1:-.}
-echo OK
 version=$(npm view @europeana/portal version)
-echo ${version}
 
 warm_up_url () {
   url=$1

--- a/.github/workflows/support/docker-images/warm-up-jsdelivr.sh
+++ b/.github/workflows/support/docker-images/warm-up-jsdelivr.sh
@@ -3,7 +3,9 @@
 set -e
 
 dir=${1:-.}
+echo OK
 version=$(npm view @europeana/portal version)
+echo ${version}
 
 warm_up_url () {
   url=$1
@@ -11,7 +13,7 @@ warm_up_url () {
 
   cached="false"
   attempt=0
-  while [ "${cached}" == "false" ]; do
+  while [ "${cached}" = "false" ]; do
     attempt=$(( attempt + 1 ))
     if [ ${attempt} -gt 12 ]; then
       echo "ERROR: Failed to detect version available on jsDelivr after 12 attempts."
@@ -21,7 +23,7 @@ warm_up_url () {
     echo "Checking for file availability on jsDelivr, attempt #${attempt}"
     curl --fail --silent -o /dev/null -I "${url}"
 
-    if [ "$?" == "0" ]; then
+    if [ "$?" = "0" ]; then
       echo "OK"
       echo
       cached="true"

--- a/.github/workflows/support/docker-images/warm-up-jsdelivr.sh
+++ b/.github/workflows/support/docker-images/warm-up-jsdelivr.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-dir=${$1:-.}
+dir=${1:-.}
 version=$(npm view @europeana/portal version)
 
 warm_up_url () {

--- a/.github/workflows/support/docker-images/warm-up-jsdelivr.sh
+++ b/.github/workflows/support/docker-images/warm-up-jsdelivr.sh
@@ -9,7 +9,7 @@ warm_up_url () {
 
   cached="false"
   attempt=0
-  while [ ${cached} == "false" ]; do
+  while [ "${cached}" == "false" ]; do
     attempt=$(( attempt + 1 ))
     if [ ${attempt} -gt 12 ]; then
       echo "ERROR: Failed to detect version available on jsDelivr after 12 attempts."

--- a/.github/workflows/support/docker-images/warm-up-jsdelivr.sh
+++ b/.github/workflows/support/docker-images/warm-up-jsdelivr.sh
@@ -9,9 +9,9 @@ warm_up_url () {
 
   cached="false"
   attempt=0
-  while [[ ${cached} == "false" ]]; do
+  while [ ${cached} == "false" ]; do
     attempt=$(( attempt + 1 ))
-    if [[ ${attempt} -gt 12 ]]; then
+    if [ ${attempt} -gt 12 ]; then
       echo "ERROR: Failed to detect version available on jsDelivr after 12 attempts."
       exit 1
     fi
@@ -19,7 +19,7 @@ warm_up_url () {
     echo "Checking for file availability on jsDelivr, attempt #${attempt}"
     curl --fail --silent -o /dev/null -I "${url}"
 
-    if [[ "$?" == "0" ]]; then
+    if [ "$?" == "0" ]; then
       echo "OK"
       echo
       cached="true"

--- a/.github/workflows/support/docker-images/warm-up-jsdelivr.sh
+++ b/.github/workflows/support/docker-images/warm-up-jsdelivr.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 dir=${1:-.}
 version=$(npm view @europeana/portal version)
 


### PR DESCRIPTION
[distroless images](https://github.com/GoogleContainerTools/distroless) are smaller and more secure.

For portal.js, the final image is reduced from 267 MB to 250 MB.

Also:
* switch to using `npm ci` in the Dockerfile, which is faster
* reduce the number of stages