### PR TITLE
chore: stop using experimental JSON imports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ ENV CHROMEDRIVER_SKIP_DOWNLOAD=true \
 
 WORKDIR /app
 
-COPY bin ./bin
 COPY package.json package-lock.json ./
 
 RUN npm ci
@@ -21,7 +20,7 @@ COPY styleguide ./styleguide
 FROM base AS build
 
 RUN npm run build
-RUN rm -r babel.config.cjs jest.config.js bin styleguide
+RUN rm -r babel.config.cjs jest.config.js styleguide
 RUN npm prune --production
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage image to build and run europeana/portal.js
 
-FROM node:16.13-alpine AS base
+FROM node:16-alpine AS base
 
 ENV CHROMEDRIVER_SKIP_DOWNLOAD=true \
     GECKODRIVER_SKIP_DOWNLOAD=true \
@@ -25,11 +25,7 @@ RUN rm -r babel.config.cjs jest.config.js bin styleguide
 RUN npm prune --production
 
 
-# FIXME: ideally we would always use the latest version of Node 16, from the
-#        distroless image `gcr.io/distroless/nodejs:16`, but as of 16.14 that
-#        encounters issues with our imports of .json files. Locked to 16.13
-#        on the non-distroless image as a temporary workaround.
-FROM node:16.13-alpine
+FROM gcr.io/distroless/nodejs:16
 
 ENV PORT=8080 \
     HOST=0.0.0.0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,12 @@ ENV CHROMEDRIVER_SKIP_DOWNLOAD=true \
 
 WORKDIR /app
 
+COPY bin ./bin
 COPY package.json package-lock.json ./
 
 RUN npm ci
 
-COPY nuxt.config.js babel.config.cjs jest.config.js *.md .env.example ./
+COPY nuxt.config.js pkg-versions.js babel.config.cjs jest.config.js *.md .env.example ./
 COPY src ./src
 COPY styleguide ./styleguide
 
@@ -20,7 +21,7 @@ COPY styleguide ./styleguide
 FROM base AS build
 
 RUN npm run build
-RUN rm -r babel.config.cjs jest.config.js styleguide
+RUN rm -r babel.config.cjs jest.config.js bin styleguide
 RUN npm prune --production
 
 
@@ -28,8 +29,7 @@ FROM gcr.io/distroless/nodejs:16
 
 ENV PORT=8080 \
     HOST=0.0.0.0 \
-    NODE_ENV=production \
-    NODE_OPTIONS=--experimental-json-modules
+    NODE_ENV=production
 
 EXPOSE ${PORT}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,4 @@ COPY --from=build /app .
 
 USER 1000
 
-CMD ["node", "node_modules/.bin/nuxt-cli", "start"]
+CMD ["node_modules/.bin/nuxt-cli", "start"]

--- a/bin/pkg-versions.js
+++ b/bin/pkg-versions.js
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import versions from '../pkg-versions.js';
+
+const versionsFile = new URL('../pkg-versions.js', import.meta.url);
+
+let versionsSrc = fs.readFileSync(versionsFile, { encoding: 'utf8' });
+
+for (const pkg in versions) {
+  let pkgJsonFile;
+  if (pkg === '@europeana/portal') {
+    pkgJsonFile = new URL('../package.json', import.meta.url);
+  } else {
+    pkgJsonFile = new URL(`../node_modules/${pkg}/package.json`, import.meta.url);
+  }
+  const version = JSON.parse(fs.readFileSync(pkgJsonFile, { encoding: 'utf8' })).version;
+
+  versionsSrc = versionsSrc.replace(new RegExp(`'${pkg}': '[^']+'`), `'${pkg}': '${version}'`);
+}
+
+fs.writeFileSync(versionsFile, versionsSrc);

--- a/bin/sonar-project-version.js
+++ b/bin/sonar-project-version.js
@@ -1,14 +1,12 @@
 import propertiesReader from 'properties-reader';
 
-import pkg from '../package.json';
-
 const versionSonarProjectProperties = async() => {
   const sonarProjectPropertiesFilePath = new URL('../sonar-project.properties', import.meta.url);
   const sonarProjectProperties = propertiesReader(sonarProjectPropertiesFilePath,
     'utf-8',
     { writer: { saveSections: false } }
   );
-  sonarProjectProperties.set('sonar.projectVersion', pkg.version);
+  sonarProjectProperties.set('sonar.projectVersion', process.env.npm_package_version);
   await sonarProjectProperties.save(sonarProjectPropertiesFilePath);
 };
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -6,9 +6,9 @@
 */
 
 const APP_SITE_NAME = 'Europeana';
+const APP_PKG_NAME = '@europeana/portal';
 
-import pkg from './package.json';
-import nuxtCorePkg from '@nuxt/core/package.json';
+import versions from './pkg-versions.js';
 
 import i18nLocales from './src/plugins/i18n/locales.js';
 import i18nDateTime from './src/plugins/i18n/datetime.js';
@@ -17,7 +17,7 @@ import features, { featureIsEnabled } from './src/features/index.js';
 
 const buildPublicPath = () => {
   if (featureIsEnabled(process.env.ENABLE_JSDELIVR_BUILD_PUBLIC_PATH)) {
-    return `https://cdn.jsdelivr.net/npm/${pkg.name}@${pkg.version}/.nuxt/dist/client`;
+    return `https://cdn.jsdelivr.net/npm/${APP_PKG_NAME}@${versions[APP_PKG_NAME]}/.nuxt/dist/client`;
   } else {
     return process.env.NUXT_BUILD_PUBLIC_PATH;
   }
@@ -72,9 +72,9 @@ export default {
         environment: process.env.ELASTIC_APM_ENVIRONMENT || 'development',
         logLevel: process.env.ELASTIC_APM_LOG_LEVEL || 'info',
         serviceName: 'portal-js',
-        serviceVersion: pkg.version,
+        serviceVersion: versions[APP_PKG_NAME],
         frameworkName: 'Nuxt',
-        frameworkVersion: nuxtCorePkg.version,
+        frameworkVersion: versions['@nuxt/core'],
         ignoreUrls: [
           /^\/(_nuxt|__webpack_hmr)\//
         ],
@@ -186,7 +186,7 @@ export default {
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-      { hid: 'description', name: 'description', content: pkg.description }
+      { hid: 'description', name: 'description', content: APP_SITE_NAME }
     ],
     link: [
       { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@europeana/portal",
       "version": "1.62.2",
+      "hasInstallScript": true,
       "license": "EUPL-1.2",
       "dependencies": {
         "@elastic/apm-rum-vue": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "scripts": {
     "analyze": "nuxt build --analyze",
     "build": "nuxt build",
-    "cache": "node --experimental-json-modules --require dotenv/config src/cachers/index.js",
+    "cache": "node --require dotenv/config src/cachers/index.js",
     "dev": "nuxt",
     "generate": "nuxt generate",
     "lint:fix": "npm run lint -- --fix",
     "lint": "eslint --no-fix bin src tests/unit *.js styleguide",
-    "start:inspect": "node --experimental-json-modules --inspect node_modules/.bin/nuxt-cli start",
+    "start:inspect": "node --inspect node_modules/.bin/nuxt-cli start",
     "start": "nuxt-cli start",
     "styleguide": "vue-styleguidist server --config ./styleguide.config.cjs",
     "stylelint": "stylelint \"**/*.scss\" \"**/*.vue\" --config .stylelintrc.cjs",
@@ -26,7 +26,7 @@
     "test:visual": "touch tests/e2e/docker/nightwatch-visual/.env && docker-compose -f ./tests/e2e/docker/docker-compose.yml run --rm nightwatch-visual",
     "test:watch": "jest --watch",
     "test": "npm run test:unit && npm run test:size && npm run test:e2e",
-    "version": "node --experimental-json-modules bin/version.js && git add sonar-project.properties"
+    "version": "node bin/pkg-versions.js && node bin/sonar-project-version.js && git add pkg-versions.js sonar-project.properties"
   },
   "dependencies": {
     "@elastic/apm-rum-vue": "^1.3.1",

--- a/pkg-versions.js
+++ b/pkg-versions.js
@@ -1,0 +1,14 @@
+// Version numbers of the app itself and select dependencies, that need to be
+// known in various places throughout the codebase. Intended as a temporary
+// solution until importing JSON files is no longer considered experimental in
+// Node.js, at which time we may instead import from the respective package.json
+// files to get the versions.
+//
+// NOTE: This file is auto-updated by ../bin/pkg-versions.js
+
+export default {
+  '@europeana/portal': '1.62.2',
+  '@nuxt/core': '2.15.8',
+  'bootstrap': '4.6.1',
+  'bootstrap-vue': '2.21.2'
+};

--- a/pkg-versions.js
+++ b/pkg-versions.js
@@ -4,7 +4,7 @@
 // Node.js, at which time we may instead import from the respective package.json
 // files to get the versions.
 //
-// NOTE: This file is auto-updated by ../bin/pkg-versions.js
+// NOTE: This file is auto-updated by ./bin/pkg-versions.js
 
 export default {
   '@europeana/portal': '1.62.2',

--- a/src/layouts/contentful.vue
+++ b/src/layouts/contentful.vue
@@ -9,16 +9,13 @@
 </template>
 
 <script>
-  import { version as bootstrapVersion } from 'bootstrap/package.json';
-  import { version as bootstrapVueVersion } from 'bootstrap-vue/package.json';
+  import versions from '../../pkg-versions';
 
   export default {
     name: 'ContentfulLayout',
 
     data() {
       return {
-        bootstrapVersion,
-        bootstrapVueVersion,
         contentfulExtensionsUiSdkVersion: '3.23.2'
       };
     },
@@ -30,8 +27,8 @@
         },
         link: [
           { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,700italic,400,600,700&subset=latin,greek,cyrillic&display=swap', body: true },
-          { rel: 'stylesheet', href: `https://unpkg.com/bootstrap@${this.bootstrapVersion}/dist/css/bootstrap.min.css` },
-          { rel: 'stylesheet', href: `https://unpkg.com/bootstrap-vue@${this.bootstrapVueVersion}/dist/bootstrap-vue.min.css` }
+          { rel: 'stylesheet', href: `https://unpkg.com/bootstrap@${versions.bootstrap}/dist/css/bootstrap.min.css` },
+          { rel: 'stylesheet', href: `https://unpkg.com/bootstrap-vue@${versions['bootstrap-vue']}/dist/bootstrap-vue.min.css` }
         ],
         script: [
           { src: `https://unpkg.com/contentful-ui-extensions-sdk@${this.contentfulExtensionsUiSdkVersion}/dist/cf-extension-api.js` }

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -67,8 +67,7 @@
   import PageHeader from '../components/PageHeader';
   import makeToastMixin from '@/mixins/makeToast';
   import klaroConfig, { version as klaroVersion } from '../plugins/klaro-config';
-  import { version as bootstrapVersion } from 'bootstrap/package.json';
-  import { version as bootstrapVueVersion } from 'bootstrap-vue/package.json';
+  import versions from '../../pkg-versions';
   import featureNotifications from '@/features/notifications';
 
   export default {
@@ -107,9 +106,9 @@
         link: [
           { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,700italic,400,600,700&subset=latin,greek,cyrillic&display=swap',
             body: true },
-          { rel: 'stylesheet', href: `https://unpkg.com/bootstrap@${bootstrapVersion}/dist/css/bootstrap.min.css` },
+          { rel: 'stylesheet', href: `https://unpkg.com/bootstrap@${versions.bootstrap}/dist/css/bootstrap.min.css` },
           { rel: 'stylesheet', href: `https://unpkg.com/klaro@${klaroVersion}/dist/klaro.min.css` },
-          { rel: 'stylesheet', href: `https://unpkg.com/bootstrap-vue@${bootstrapVueVersion}/dist/bootstrap-vue.min.css` },
+          { rel: 'stylesheet', href: `https://unpkg.com/bootstrap-vue@${versions['bootstrap-vue']}/dist/bootstrap-vue.min.css` },
           { hreflang: 'x-default', rel: 'alternate', href: this.canonicalUrlWithoutLocale },
           ...i18nHead.link
         ],

--- a/src/server-middleware/api/version.js
+++ b/src/server-middleware/api/version.js
@@ -1,7 +1,5 @@
 // Outputs as plain text the version of the app that is running
-import { version } from '../../../package.json';
-
 export default (req, res) => {
   res.setHeader('Content-Type', 'text/plain');
-  res.end(version);
+  res.end(process.env.npm_package_version);
 };

--- a/tests/e2e/features/ZZ-finally/memory-usage.feature
+++ b/tests/e2e/features/ZZ-finally/memory-usage.feature
@@ -3,4 +3,4 @@ Feature: Memory budget
     Given I am on the `home page`
     # Wait a bit to allow garbage collection, to prevent false positives for memory leaks
     And I wait 5 seconds
-    Then the memory used is less than 85 MB
+    Then the memory used is less than 90 MB


### PR DESCRIPTION
Instead, create a file ./pkg-versions.js with hard-coded values for the package versions of the app itself, @nuxt/core, bootstrap and bootstrap-vue.

The version numbers in this file can be automatically updated using the new script `node bin/pkg-versions.js`.