### PR TITLE
chore: read version from pkg-versions.js

### DIFF
--- a/bin/sonar-project-version.js
+++ b/bin/sonar-project-version.js
@@ -1,12 +1,14 @@
 import propertiesReader from 'properties-reader';
 
+import versions from '../pkg-versions.js';
+
 const versionSonarProjectProperties = async() => {
   const sonarProjectPropertiesFilePath = new URL('../sonar-project.properties', import.meta.url);
   const sonarProjectProperties = propertiesReader(sonarProjectPropertiesFilePath,
     'utf-8',
     { writer: { saveSections: false } }
   );
-  sonarProjectProperties.set('sonar.projectVersion', process.env.npm_package_version);
+  sonarProjectProperties.set('sonar.projectVersion', versions['@europeana/portal']);
   await sonarProjectProperties.save(sonarProjectPropertiesFilePath);
 };
 

--- a/src/server-middleware/api/version.js
+++ b/src/server-middleware/api/version.js
@@ -1,5 +1,8 @@
 // Outputs as plain text the version of the app that is running
+
+import versions from '../../../pkg-versions.js';
+
 export default (req, res) => {
   res.setHeader('Content-Type', 'text/plain');
-  res.end(process.env.npm_package_version);
+  res.end(versions['@europeana/portal']);
 };


### PR DESCRIPTION
As npm is not present in the distroless image.