### PR TITLE
refactor: create EntityRelatedCollections component

### DIFF
--- a/src/components/entity/EntityRelatedCollections.vue
+++ b/src/components/entity/EntityRelatedCollections.vue
@@ -1,0 +1,61 @@
+<template>
+  <RelatedCollections
+    v-if="!$fetchState.pending && (relatedCollections.length > 0)"
+    :title="$t('youMightAlsoLike')"
+    :related-collections="relatedCollections"
+    @show="$emit('show')"
+    @hide="$emit('hide')"
+  />
+</template>
+
+<script>
+  import pick from 'lodash/pick';
+
+  import RelatedCollections from '../generic/RelatedCollections';
+
+  export default {
+    name: 'EntityRelatedCollections',
+
+    components: {
+      RelatedCollections
+    },
+
+    props: {
+      type: {
+        type: String,
+        required: true
+      },
+      identifier: {
+        type: String,
+        required: true
+      },
+      overrides: {
+        type: Array,
+        default: null
+      }
+    },
+
+    data() {
+      return {
+        relatedCollections: []
+      };
+    },
+
+    fetch() {
+      if (this.overrides) {
+        this.relatedCollections = this.overrides;
+      } else {
+        this.$apis.record.relatedEntities(this.type, this.identifier)
+          .then(facets => facets ? this.$apis.entity.facets(facets, this.identifier) : [])
+          .then(related => this.relatedCollections = related.map(entity => {
+            return pick(entity, ['id', 'prefLabel', 'isShownBy']);
+          }));
+      }
+    },
+
+    watch: {
+      type: '$fetch',
+      identifier: '$fetch'
+    }
+  };
+</script>

--- a/src/components/entity/EntityRelatedCollections.vue
+++ b/src/components/entity/EntityRelatedCollections.vue
@@ -11,6 +11,9 @@
 <script>
   import pick from 'lodash/pick';
 
+  import { BASE_URL as EUROPEANA_DATA_URL } from '@/plugins/europeana/data';
+  import { normalizeEntityId } from '@/plugins/europeana/entity';
+
   import RelatedCollections from '../generic/RelatedCollections';
 
   export default {
@@ -46,7 +49,9 @@
         this.relatedCollections = this.overrides;
       } else {
         this.$apis.record.relatedEntities(this.type, this.identifier)
-          .then(facets => facets ? this.$apis.entity.facets(facets, this.identifier) : [])
+          .then(facets => facets ? this.facets(facets) : [])
+          // TODO: why are we doing this? (formerly in entity plugin's `getRelatedEntityData` fn)
+          .then(related => related.filter(entity => !!entity.prefLabel.en))
           .then(related => this.relatedCollections = related.map(entity => {
             return pick(entity, ['id', 'prefLabel', 'isShownBy']);
           }));
@@ -56,6 +61,30 @@
     watch: {
       type: '$fetch',
       identifier: '$fetch'
+    },
+
+    methods: {
+      /**
+       * Return the facets that include data.europeana.eu
+       * @param {Object} facets the facets retrieved from the search
+       * @param {String} id id of the current entity
+       * @return {Object} related entities
+       * TODO: limit results
+       */
+      facets(facets) {
+        const currentId = normalizeEntityId(this.identifier);
+        let entities = [];
+        for (const facet of facets) {
+          const facetFilter = (value) => value['label'].includes(EUROPEANA_DATA_URL) && value['label'].split('/').pop() !== currentId;
+          entities = entities.concat(facet['fields'].filter(facetFilter));
+        }
+
+        const entityUris = entities.slice(0, 4).map(entity => {
+          return entity['label'];
+        });
+
+        return this.$apis.entity.find(entityUris);
+      }
     }
   };
 </script>

--- a/src/components/entity/EntityRelatedCollections.vue
+++ b/src/components/entity/EntityRelatedCollections.vue
@@ -12,7 +12,7 @@
   import pick from 'lodash/pick';
 
   import { BASE_URL as EUROPEANA_DATA_URL } from '@/plugins/europeana/data';
-  import { normalizeEntityId, getEntityUri, getEntityQuery } from '@/plugins/europeana/entity';
+  import { getEntityUri, getEntityQuery } from '@/plugins/europeana/entity';
 
   import RelatedCollections from '../generic/RelatedCollections';
 

--- a/src/pages/collections/_type/_.vue
+++ b/src/pages/collections/_type/_.vue
@@ -45,12 +45,14 @@
                   :more-info="moreInfo"
                 />
                 <template
+                  v-if="collectionType !== 'organisation'"
                   #related
                 >
                   <client-only>
-                    <RelatedCollections
-                      :title="$t('youMightAlsoLike')"
-                      :related-collections="relatedCollections"
+                    <EntityRelatedCollections
+                      :type="$route.params.type"
+                      :identifier="$route.params.pathMatch"
+                      :overrides="relatedCollectionCards"
                       data-qa="related entities"
                       @show="showRelatedCollections"
                       @hide="hideRelatedCollections"
@@ -96,7 +98,7 @@
       SearchInterface,
       SideFilters: () => import('@/components/search/SideFilters'),
       EntityHeader: () => import('@/components/entity/EntityHeader'),
-      RelatedCollections: () => import('@/components/generic/RelatedCollections')
+      EntityRelatedCollections: () => import('@/components/entity/EntityRelatedCollections')
     },
 
     beforeRouteLeave(to, from, next) {
@@ -283,12 +285,6 @@
       relatedCollectionCards() {
         return ((this.page?.relatedLinksCollection?.items?.length || 0) > 0) ? this.page.relatedLinksCollection.items : null;
       },
-      relatedCollections() {
-        return this.relatedEntities || this.relatedCollectionCards || [];
-      },
-      relatedCollectionsFound() {
-        return this.relatedCollections.length > 0;
-      },
       userIsEditor() {
         return this.$store.state.auth.user?.resource_access?.entities?.roles?.includes('editor') || false;
       },
@@ -350,14 +346,6 @@
     mounted() {
       this.$store.commit('search/setCollectionLabel', this.pageTitle);
       this.storeSearchOverrides();
-      // Disable related collections for organisation (for now)
-      if (!this.relatedCollectionCards && this.collectionType !== 'organisation') {
-        this.$apis.record.relatedEntities(this.$route.params.type, this.$route.params.pathMatch)
-          .then(facets => facets ? this.$apis.entity.facets(facets, this.$route.params.pathMatch) : [])
-          .then(related => this.relatedEntities = related.map(entity => {
-            return pick(entity, ['id', 'prefLabel', 'isShownBy']);
-          }));
-      }
       if (this.userIsEditor) {
         this.$store.dispatch('entity/getFeatured');
       }

--- a/src/plugins/europeana/entity.js
+++ b/src/plugins/europeana/entity.js
@@ -49,29 +49,6 @@ export default (context = {}) => {
     },
 
     /**
-     * Return the facets that include data.europeana.eu
-     * @param {Object} facets the facets retrieved from the search
-     * @param {String} id id of the current entity
-     * @return {Object} related entities
-     * TODO: limit results
-     */
-    facets(facets, id) {
-      const currentId = normalizeEntityId(id);
-      let entities = [];
-      for (const facet of facets) {
-        const facetFilter = (value) => value['label'].includes(EUROPEANA_DATA_URL) && value['label'].split('/').pop() !== currentId;
-        entities = entities.concat(facet['fields'].filter(facetFilter));
-      }
-
-      const entityUris = entities.slice(0, 4).map(entity => {
-        return entity['label'];
-      });
-
-      return this.find(entityUris)
-        .then(response => getRelatedEntityData(response));
-    },
-
-    /**
      * Lookup data for the given list of entity URIs
      * @param {Array} entityUris the URIs of the entities to retrieve
      * @return {Array} entity data
@@ -111,21 +88,6 @@ export default (context = {}) => {
     }
   };
 };
-
-/**
- * Format the entity data for a related entity
- * @param {Object} entities the data returned from the Entity API
- * @return {Object[]} entity data
- */
-function getRelatedEntityData(entities) {
-  const entityDetails = [];
-  for (const entity of entities || []) {
-    if (entity.prefLabel.en) {
-      entityDetails.push(entity);
-    }
-  }
-  return entityDetails;
-}
 
 /**
  * Remove any additional data from the slug in order to retrieve the entity id.

--- a/src/plugins/europeana/record.js
+++ b/src/plugins/europeana/record.js
@@ -5,7 +5,6 @@ import merge from 'deepmerge';
 import { apiError, createAxios, reduceLangMapsForLocale, isLangMap } from './utils';
 import search from './search';
 import { thumbnailUrl, thumbnailTypeForMimeType } from  './thumbnail';
-import { getEntityUri, getEntityQuery } from './entity';
 import { isIIIFPresentation, isIIIFImage } from '../media';
 
 export const BASE_URL = process.env.EUROPEANA_RECORD_API_URL || 'https://api.europeana.eu/record';
@@ -347,26 +346,6 @@ export default (context = {}) => {
           }
           throw apiError(error, context);
         });
-    },
-
-    /**
-     * Search for specific facets for this entity to find the related entities
-     * @param {string} type the type of the entity
-     * @param {string} id the id of the entity, (can contain trailing slug parts as these will be normalized)
-     * @return {Object} related entities
-     * TODO: add people as related entities again
-     */
-    relatedEntities(type, id) {
-      const entityUri = getEntityUri(type, id);
-
-      return this.search({
-        profile: 'facets',
-        facet: 'skos_concept',
-        query: getEntityQuery(entityUri),
-        qf: ['contentTier:*'],
-        rows: 0
-      })
-        .then(response => response.facets);
     },
 
     mediaProxyUrl(mediaUrl, europeanaId, params = {}) {

--- a/tests/unit/components/entity/EntityRelatedCollections.spec.js
+++ b/tests/unit/components/entity/EntityRelatedCollections.spec.js
@@ -125,6 +125,30 @@ describe('components/entity/EntityRelatedCollections', () => {
 
         expect(wrapper.vm.relatedCollections).toEqual(relatedCollections);
       });
+
+      describe('but Record API returned no related collections', () => {
+        const responses = {
+          record: {
+            search: {}
+          }
+        };
+
+        it('records blank array for related collections', async() => {
+          const wrapper = factory({ propsData, responses });
+
+          await wrapper.vm.fetch();
+
+          expect(wrapper.vm.relatedCollections).toEqual([]);
+        });
+
+        it('does not query Entity API for related collection details', async() => {
+          const wrapper = factory({ propsData, responses });
+
+          await wrapper.vm.fetch();
+
+          expect(wrapper.vm.$apis.entity.find.called).toBe(false);
+        });
+      });
     });
   });
 });

--- a/tests/unit/components/entity/EntityRelatedCollections.spec.js
+++ b/tests/unit/components/entity/EntityRelatedCollections.spec.js
@@ -1,0 +1,150 @@
+import { createLocalVue } from '@vue/test-utils';
+import { shallowMountNuxt } from '../../utils';
+import sinon from 'sinon';
+
+import EntityRelatedCollections from '@/components/entity/EntityRelatedCollections.vue';
+
+const localVue = createLocalVue();
+
+const factory = (options = {}) => {
+  return shallowMountNuxt(EntityRelatedCollections, {
+    localVue,
+    propsData: options.propsData,
+    mocks: {
+      $apis: {
+        entity: { find: sinon.stub().resolves(options.responses?.entity?.find || []) },
+        record: { search: sinon.stub().resolves(options.responses?.record?.search || {}) }
+      },
+      $fetchState: {},
+      $t: key => key
+    }
+  });
+};
+
+describe('components/entity/EntityRelatedCollections', () => {
+  describe('fetch', () => {
+    describe('with overrides', () => {
+      const propsData = {
+        type: 'topic',
+        identifier: '30-cartoon',
+        overrides: ['Curated collection']
+      };
+
+      it('uses the overrides as the related collections', async() => {
+        const wrapper = factory({ propsData });
+
+        await wrapper.vm.fetch();
+
+        expect(wrapper.vm.relatedCollections).toEqual(propsData.overrides);
+      });
+
+      it('does not query Record API for related collections', async() => {
+        const wrapper = factory({ propsData });
+
+        await wrapper.vm.fetch();
+
+        expect(wrapper.vm.$apis.record.search.called).toBe(false);
+      });
+
+      it('does not query Entity API for related collection details', async() => {
+        const wrapper = factory({ propsData });
+
+        await wrapper.vm.fetch();
+
+        expect(wrapper.vm.$apis.entity.find.called).toBe(false);
+      });
+
+
+      // it('queries the Entity API for suggestions via $apis plugin', () => {
+      //   const wrapper = factory({ propsData });
+      //
+      //   wrapper.vm.fetch();
+      //
+      //   expect(wrapper.vm.$apis.entity.suggest.calledWith(propsData.query, {
+      //     language: wrapper.vm.$i18n.locale,
+      //     rows: 4
+      //   })).toBe(true);
+      // });
+      //
+      // it('stores response as relatedCollections', async() => {
+      //   const wrapper = factory({ propsData });
+      //
+      //   await wrapper.vm.fetch();
+      //
+      //   expect(wrapper.vm.relatedCollections).toEqual(relatedCollections);
+      // });
+    });
+
+    describe('without overrides', () => {
+      const propsData = {
+        type: 'topic',
+        identifier: '1-stained-glass'
+      };
+      const uri = 'http://data.europeana.eu/concept/base/1';
+      const relatedUris = [
+        'http://data.europeana.eu/concept/base/2',
+        'http://data.europeana.eu/concept/base/3',
+        'http://data.europeana.eu/concept/base/4',
+        'http://data.europeana.eu/concept/base/5'
+      ];
+      const relatedCollections = [
+        { id: 'http://data.europeana.eu/concept/base/2', prefLabel: { en: 'Concept 2' } },
+        { id: 'http://data.europeana.eu/concept/base/3', prefLabel: { en: 'Concept 3' } },
+        { id: 'http://data.europeana.eu/concept/base/4', prefLabel: { en: 'Concept 4' } }
+      ];
+      const responses = {
+        record: {
+          search: {
+            facets: [
+              {
+                name: 'skos_concept',
+                fields: [
+                  { label: 'http://data.europeana.eu/concept/base/1' },
+                  { label: 'http://data.europeana.eu/concept/base/2' },
+                  { label: 'http://www.wikidata.org/entity/1' },
+                  { label: 'http://data.europeana.eu/concept/base/3' },
+                  { label: 'http://www.wikidata.org/entity/2' },
+                  { label: 'http://data.europeana.eu/concept/base/4' },
+                  { label: 'http://data.europeana.eu/concept/base/5' },
+                  { label: 'http://data.europeana.eu/concept/base/6' }
+                ]
+              }
+            ]
+          }
+        },
+        entity: {
+          find: [
+            { id: 'http://data.europeana.eu/concept/base/2', type: 'Concept', prefLabel: { en: 'Concept 2' } },
+            { id: 'http://data.europeana.eu/concept/base/3', type: 'Concept', prefLabel: { en: 'Concept 3' } },
+            { id: 'http://data.europeana.eu/concept/base/4', type: 'Concept', prefLabel: { en: 'Concept 4' } },
+            { id: 'http://data.europeana.eu/concept/base/5', type: 'Concept', prefLabel: { es: 'Concept 5' } }
+          ]
+        }
+      };
+
+      it('queries Record API for related collections', async() => {
+        const wrapper = factory({ propsData, responses });
+
+        await wrapper.vm.fetch();
+
+        expect(wrapper.vm.$apis.record.search.calledWith(sinon.match.has('query', `skos_concept:"${uri}"`))).toBe(true);
+      });
+
+      it('queries Entity API for up to 4 Europeana entity details', async() => {
+        const wrapper = factory({ propsData, responses });
+
+        await wrapper.vm.fetch();
+
+        expect(wrapper.vm.$apis.entity.find.calledWith(relatedUris)).toBe(true);
+      });
+
+      it('filters, reduces, and records the related collections', async() => {
+        const wrapper = factory({ propsData, responses });
+
+        await wrapper.vm.fetch();
+
+        expect(wrapper.vm.relatedCollections).toEqual(relatedCollections);
+      });
+    });
+  });
+});

--- a/tests/unit/components/entity/EntityRelatedCollections.spec.js
+++ b/tests/unit/components/entity/EntityRelatedCollections.spec.js
@@ -53,26 +53,6 @@ describe('components/entity/EntityRelatedCollections', () => {
 
         expect(wrapper.vm.$apis.entity.find.called).toBe(false);
       });
-
-
-      // it('queries the Entity API for suggestions via $apis plugin', () => {
-      //   const wrapper = factory({ propsData });
-      //
-      //   wrapper.vm.fetch();
-      //
-      //   expect(wrapper.vm.$apis.entity.suggest.calledWith(propsData.query, {
-      //     language: wrapper.vm.$i18n.locale,
-      //     rows: 4
-      //   })).toBe(true);
-      // });
-      //
-      // it('stores response as relatedCollections', async() => {
-      //   const wrapper = factory({ propsData });
-      //
-      //   await wrapper.vm.fetch();
-      //
-      //   expect(wrapper.vm.relatedCollections).toEqual(relatedCollections);
-      // });
     });
 
     describe('without overrides', () => {

--- a/tests/unit/plugins/europeana/record.spec.js
+++ b/tests/unit/plugins/europeana/record.spec.js
@@ -528,36 +528,6 @@ describe('plugins/europeana/record', () => {
     });
   });
 
-  describe('record().relatedEntities()', () => {
-    const entityUri = 'http://data.europeana.eu/concept/base/94';
-    const entityFilterField = 'skos_concept';
-    const entityId = '94-architecture';
-    const entityType = 'topic';
-
-    const searchResponse = {
-      facets: [
-        {
-          name: 'skos_concept',
-          fields: [
-            { label: 'http://data.europeana.eu/agent/base/147831' },
-            { label: 'http://data.europeana.eu/agent/base/49928' }
-          ]
-        }
-      ]
-    };
-
-    it('filters on entity URI', async() => {
-      nock(BASE_URL)
-        .get('/search.json')
-        .query(query => query.query === `${entityFilterField}:"${entityUri}"`)
-        .reply(200, searchResponse);
-
-      await record().relatedEntities(entityType, entityId);
-
-      expect(nock.isDone()).toBe(true);
-    });
-  });
-
   describe('isEuropeanaRecordId()', () => {
     describe('with valid record ID', () => {
       it('returns `true`', () => {


### PR DESCRIPTION
Primarily to reduce the amount of logic in the collections page .vue, and move code from entity and record plugins only used for this component into the component.

Also:
* Fix favouring editorially linked collections coming from Contentful, e.g. for the Fashion theme

Re EC-5767