### PR TITLE
fix: replace state in browser history

### DIFF
--- a/src/pages/collections/_type/_.vue
+++ b/src/pages/collections/_type/_.vue
@@ -359,9 +359,13 @@
             name: 'collections-type-all',
             params: { type: this.$route.params.type, pathMatch: desiredPath }
           });
-          return this.$nuxt.context.redirect(302, redirectPath);
+          if (process.server) {
+            this.$nuxt.context.redirect(302, redirectPath);
+          } else {
+            // _Replace_ history entry to prevent interference with back button
+            this.$nuxt.context.app.router.replace(redirectPath);
+          }
         }
-        return true;
       },
       storeSearchOverrides() {
         this.$store.commit('search/set', ['overrideParams', this.searchOverrides]);


### PR DESCRIPTION
To prevent interference with the back button after redirecting to include the entity name in the URL.