### PR TITLE
fix: only render Masonry item card groups client-side

### DIFF
--- a/src/components/item/ItemPreviewCardGroup.vue
+++ b/src/components/item/ItemPreviewCardGroup.vue
@@ -14,41 +14,44 @@
       :data-qa="`item previews ${view}`"
     >
       <slot />
-      <template
-        v-for="(card, index) in cards"
-      >
+      <!-- client-only while we are using Masonry -->
+      <client-only>
         <template
-          v-if="card === 'related'"
+          v-for="(card, index) in cards"
         >
-          <b-card
-            v-show="showRelated"
-            :key="index"
-            class="text-left related-collections-card mb-4"
+          <template
+            v-if="card === 'related'"
           >
-            <slot
-              v-masonry-tile
-              name="related"
-            />
-          </b-card>
+            <b-card
+              v-show="showRelated"
+              :key="index"
+              class="text-left related-collections-card mb-4"
+            >
+              <slot
+                v-masonry-tile
+                name="related"
+              />
+            </b-card>
+          </template>
+          <ItemPreviewCard
+            v-else
+            :key="index"
+            v-masonry-tile
+            :item="card"
+            :hit-selector="itemHitSelector(card)"
+            :variant="cardVariant"
+            class="item"
+            :lazy="false"
+            :enable-accept-recommendation="enableAcceptRecommendations"
+            :enable-reject-recommendation="enableRejectRecommendations"
+            :show-pins="showPins"
+            :offset="items.findIndex(item => item.id === card.id)"
+            data-qa="item preview"
+            @like="$emit('like', card.id)"
+            @unlike="$emit('unlike', card.id)"
+          />
         </template>
-        <ItemPreviewCard
-          v-else
-          :key="index"
-          v-masonry-tile
-          :item="card"
-          :hit-selector="itemHitSelector(card)"
-          :variant="cardVariant"
-          class="item"
-          :lazy="false"
-          :enable-accept-recommendation="enableAcceptRecommendations"
-          :enable-reject-recommendation="enableRejectRecommendations"
-          :show-pins="showPins"
-          :offset="items.findIndex(item => item.id === card.id)"
-          data-qa="item preview"
-          @like="$emit('like', card.id)"
-          @unlike="$emit('unlike', card.id)"
-        />
-      </template>
+      </client-only>
     </div>
   </div>
   <b-card-group
@@ -92,6 +95,7 @@
 
 <script>
   import ItemPreviewCard from './ItemPreviewCard';
+  import ClientOnly from 'vue-client-only';
 
   export default {
     name: 'ItemPreviewCardGroup',


### PR DESCRIPTION
When using the v3 Thumbnail API, and some item previews have no thumbnail, once the Masonry view initiates client-side it results in duplicate requests for all of the images without a thumbnail, due to vue-masonry's use of imagesloaded: https://github.com/desandro/imagesloaded/blob/v4.1.4/imagesloaded.js#L281

This resolves that by only loading the item card previews client-side if the view is a Masonry one... but at what cost?