### PR TITLE
refactor: SearchForm, SearchQueryOptions and PageHeader components

### DIFF
--- a/src/components/PageHeader.vue
+++ b/src/components/PageHeader.vue
@@ -10,19 +10,9 @@
     <div
       v-if="showSearch"
       class="d-flex justify-content-center w-100"
+      data-qa="search form wrapper"
     >
-      <b-button
-        data-qa="back button"
-        class="button-icon-only icon-back"
-        variant="light-flat"
-        :aria-label="$t('header.backToMenu')"
-        @click="toggleSearchBar"
-      />
-      <SearchForm
-        role="search"
-        aria-label="search form"
-        data-qa="search form"
-      />
+      <SearchForm />
     </div>
     <template
       v-else
@@ -60,6 +50,7 @@
           data-qa="top navigation"
         />
         <b-button
+          id="show-search-button"
           data-qa="show search button"
           class="button-icon-only icon-search ml-lg-3"
           variant="light-flat"
@@ -137,7 +128,7 @@
     },
 
     computed: {
-      ...mapState({ showSearch: state => state.search.showSearchBar      })
+      ...mapState({ showSearch: state => state.search.showSearchBar })
     },
 
     methods: {
@@ -192,13 +183,6 @@
       flex-direction: column;
       width: 100%;
     }
-  }
-
-  .icon-back {
-    position: absolute;
-    left: 1rem;
-    top: 1rem;
-    z-index: 99;
   }
 
   .navbar-toggle {
@@ -263,3 +247,9 @@
   }
 
 </style>
+
+<docs lang="md">
+  ```jsx
+  <PageHeader style="position: relative;"/>
+  ```
+</docs>

--- a/src/components/search/SearchForm.vue
+++ b/src/components/search/SearchForm.vue
@@ -58,6 +58,7 @@
       <SearchQueryOptions
         ref="searchoptions"
         :options="searchQueryOptions"
+        @select="showSearchOptions = false;"
       />
     </div>
   </div>

--- a/src/components/search/SearchForm.vue
+++ b/src/components/search/SearchForm.vue
@@ -165,6 +165,9 @@
 
     watch: {
       '$route.query.query'() {
+        if (this.$refs.searchinput.$el) {
+          this.$refs.searchinput.$el.blur();
+        }
         this.showSearchOptions = false;
         this.initQuery();
       },

--- a/src/components/search/SearchForm.vue
+++ b/src/components/search/SearchForm.vue
@@ -166,9 +166,7 @@
 
     watch: {
       '$route.query.query'() {
-        if (this.$refs.searchinput.$el) {
-          this.$refs.searchinput.$el.blur();
-        }
+        this.blurInput();
         this.showSearchOptions = false;
         this.initQuery();
       },
@@ -222,6 +220,7 @@
 
         this.showSearchOptions = false;
 
+        this.blurInput();
         await this.$goto(newRoute);
       },
 
@@ -325,7 +324,7 @@
           this.navigateWithArrowKeys(event);
         }
         if (event.key === 'Escape') {
-          this.$refs.searchinput.$el.blur();
+          this.blurInput();
           this.showSearchOptions = false;
         }
       },
@@ -349,6 +348,12 @@
 
       getElement(element) {
         return element.$el || element;
+      },
+
+      blurInput() {
+        if (this.$refs.searchinput.$el) {
+          this.$refs.searchinput.$el.blur();
+        }
       }
     }
   };

--- a/src/components/search/SearchForm.vue
+++ b/src/components/search/SearchForm.vue
@@ -1,49 +1,66 @@
 <template>
-  <b-form
-    ref="form"
+  <div
+    ref="searchdropdown"
     class="open"
-    data-qa="search form"
-    inline
-    autocomplete="off"
-    @submit.prevent="submitForm"
   >
-    <b-input-group
-      role="combobox"
-      :aria-owns="showSearchOptions ? 'search-form-options' : null"
-      :aria-expanded="showSearchOptions"
-      class="auto-suggest pr-3"
+    <b-button
+      data-qa="back button"
+      class="button-icon-only icon-back back-button"
+      variant="light-flat"
+      :aria-label="$t('header.backToMenu')"
+      @click="toggleSearchBar()"
+    />
+    <b-form
+      ref="form"
+      role="search"
+      aria-label="search form"
+      data-qa="search form"
+      inline
+      autocomplete="off"
+      @submit.prevent="submitForm"
     >
-      <b-form-input
-        ref="searchbox"
-        v-model="query"
-        :placeholder="$t('searchPlaceholder')"
-        name="query"
-        data-qa="search box"
-        role="searchbox"
-        aria-autocomplete="list"
-        :aria-controls="showSearchOptions ? 'search-form-options' : null"
-        :aria-label="$t('search')"
-        @input="getSearchSuggestions(query);"
-        @focus="showSearchOptions = true; updateSuggestions();"
-        @blur="showSearchOptions = false;"
-      />
-      <b-button
-        v-show="query"
-        data-qa="clear button"
-        class="button-icon-only icon-clear ml-3 my-3"
-        variant="light-flat"
-        :aria-label="$t('header.clearQuery')"
-        @click="clearQuery"
-      />
-      <FilterToggleButton />
+      <b-input-group
+        role="combobox"
+        :aria-owns="showSearchOptions ? 'search-form-options' : null"
+        :aria-expanded="showSearchOptions"
+        class="auto-suggest pr-3"
+      >
+        <b-form-input
+          ref="searchinput"
+          v-model="query"
+          :placeholder="$t('searchPlaceholder')"
+          name="query"
+          data-qa="search box"
+          role="searchbox"
+          aria-autocomplete="list"
+          :aria-controls="showSearchOptions ? 'search-form-options' : null"
+          :aria-label="$t('search')"
+          @input="getSearchSuggestions(query);"
+          @focus="showSearchOptions = true; updateSuggestions();"
+        />
+      </b-input-group>
+    </b-form>
+    <b-button
+      v-show="query"
+      data-qa="clear button"
+      class="button-icon-only icon-clear clear-button"
+      variant="light-flat"
+      :aria-label="$t('header.clearQuery')"
+      @click="clearQuery"
+    />
+    <FilterToggleButton />
+    <div
+      v-if="showSearchOptions"
+      id="search-suggest-dropdown"
+      class="auto-suggest-dropdown"
+      data-qa="search form dropdown"
+    >
       <SearchQueryOptions
-        v-if="showSearchOptions"
+        ref="searchoptions"
         :options="searchQueryOptions"
-        element-id="search-form-options"
-        @select="selectSearchOption"
       />
-    </b-input-group>
-  </b-form>
+    </div>
+  </div>
 </template>
 
 <script>
@@ -67,8 +84,7 @@
         gettingSuggestions: false,
         suggestions: {},
         activeSuggestionsQueryTerm: null,
-        showSearchOptions: false,
-        selectedOptionLink: null
+        showSearchOptions: false
       };
     },
 
@@ -149,17 +165,27 @@
 
     watch: {
       '$route.query.query'() {
-        if (this.$refs.searchbox) {
-          this.$refs.searchbox.$el.blur();
-        }
+        this.showSearchOptions = false;
         this.initQuery();
+      },
+      '$route.path'() {
+        this.showSearchOptions = false;
+      },
+      showSearchOptions(newVal) {
+        if (newVal === true) {
+          window.addEventListener('click', this.clickOutside);
+          window.addEventListener('keydown', this.handleKeyDown);
+        } else {
+          window.removeEventListener('click', this.clickOutside);
+          window.removeEventListener('keydown', this.handleKeyDown);
+        }
       }
     },
 
     mounted() {
       this.initQuery();
       this.$nextTick(() => {
-        this.$refs.searchbox.$el.focus();
+        this.$refs.searchinput.$el.focus();
       });
     },
 
@@ -178,45 +204,21 @@
         this.query = this.$route.query.query;
       },
 
-      selectSearchOption(value) {
-        this.selectedOptionLink = value;
-      },
-
       async submitForm() {
-        let newRoute;
-
-        if (this.selectedOptionLink) {
-          newRoute = this.selectedOptionLink;
-          this.query = this.selectedOptionLink.query.query;
-
-          // This only tracks keyboard events, click events are tracked in the SearchQueryOptions component.
-          // Make sure you are not on a collection page
-          if (!this.onSearchableCollectionPage) {
-            this.$matomo?.trackEvent('Autosuggest_option_selected', 'Autosuggest option is selected', this.query);
-          }
-
-          if (this.query !== this.activeSuggestionsQueryTerm) {
-            this.suggestions = {};
-          }
-        } else {
-          // Matomo event: suggestions are present, but none is selected
-          if (Object.keys(this.suggestions).length > 0) {
-            // This only tracks keyboard events, click events are tracked in the SearchQueryOptions component.
-            this.$matomo?.trackEvent('Autosuggest_option_not_selected', 'Autosuggest option is not selected', this.query);
-          }
-
-          const baseQuery = this.onSearchablePage ? this.$route.query : {};
-          // `query` must fall back to blank string to ensure inclusion in URL,
-          // which is required for analytics site search tracking
-          const newRouteQuery = { ...baseQuery, ...{ page: 1, view: this.view, query: this.query || '' } };
-          newRoute = { path: this.routePath, query: newRouteQuery };
+        // Matomo event: suggestions are present, but none is selected
+        if (Object.keys(this.suggestions).length > 0) {
+          this.$matomo?.trackEvent('Autosuggest_option_not_selected', 'Autosuggest option is not selected', this.query);
         }
 
-        if (this.$refs.searchbox) {
-          this.$refs.searchbox.$el.blur();
-        }
+        const baseQuery = this.onSearchablePage ? this.$route.query : {};
+        // `query` must fall back to blank string to ensure inclusion in URL,
+        // which is required for analytics site search tracking
+        const newRouteQuery = { ...baseQuery, ...{ page: 1, view: this.view, query: this.query || '' } };
+        const newRoute = { path: this.routePath, query: newRouteQuery };
+
+        this.showSearchOptions = false;
+
         await this.$goto(newRoute);
-        this.selectedOptionLink = null;
       },
 
       updateSuggestions() {
@@ -297,10 +299,52 @@
         this.suggestions = {};
 
         this.$nextTick(() => {
-          if (this.$refs.searchbox) {
-            this.$refs.searchbox.$el.focus();
-          }
+          this.getElement(this.$refs.searchinput).focus();
         });
+      },
+
+      clickOutside(event) {
+        const targetOutsideSearchDropdown = event.target?.id !== 'show-search-button' && this.$refs.searchdropdown && !this.$refs.searchdropdown.contains(event.target);
+        if ((event.type === 'click' || event.key === 'Tab') && targetOutsideSearchDropdown) {
+          this.showSearchOptions = false;
+        }
+      },
+
+      toggleSearchBar() {
+        this.$store.commit('search/setShowSearchBar', !this.$store.state.search.showSearchBar);
+      },
+
+      handleKeyDown(event) {
+        this.clickOutside(event);
+        if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+          event.preventDefault();
+          this.navigateWithArrowKeys(event);
+        }
+        if (event.key === 'Escape') {
+          this.$refs.searchinput.$el.blur();
+          this.showSearchOptions = false;
+        }
+      },
+
+      navigateWithArrowKeys(event) {
+        const searchDropdownOptions = this.$refs.searchoptions?.$refs.options || [];
+        const activeOption = searchDropdownOptions.map(option => option.$el || option).indexOf(event.target);
+
+        if (searchDropdownOptions.length) {
+          if (activeOption === -1) {
+            this.getElement(searchDropdownOptions[0]).focus();
+          }
+          if (event.key === 'ArrowDown' && activeOption < searchDropdownOptions.length - 1) {
+            this.getElement(searchDropdownOptions[activeOption + 1]).focus();
+          }
+          if (event.key === 'ArrowUp' && activeOption > 0) {
+            this.getElement(searchDropdownOptions[activeOption - 1]).focus();
+          }
+        }
+      },
+
+      getElement(element) {
+        return element.$el || element;
       }
     }
   };
@@ -317,62 +361,6 @@
     .form-control {
       background-color: $white;
     }
-
-    &.open {
-      width: 100%;
-
-      .form-control {
-        padding: 0.375rem 1rem 0.375rem 3.5rem;
-        height: 3.4rem;
-        box-shadow: none;
-        border-radius: 0;
-        color: $mediumgrey;
-        width: 100%;
-      }
-
-      .search-query {
-        box-shadow: $boxshadow-light;
-        width: 100%;
-        height: 3.5rem;
-        font-size: 1rem;
-        color: $mediumgrey;
-        display: flex;
-        align-items: center;
-        position: relative;
-        background: $white;
-
-        .search {
-          position: absolute;
-          width: 100%;
-          left: 0;
-          top: 0;
-          z-index: 99;
-          height: 3.5rem;
-          padding: 0.375rem 1rem 0.375rem 3.5rem;
-          justify-content: flex-start;
-
-          &:focus {
-            color: $black;
-            background-color: $offwhite;
-
-            ~ span {
-              z-index: 99;
-            }
-          }
-
-          &::before {
-            left: 1rem;
-            top: 1rem;
-            position: absolute;
-            width: 24px;
-            height: 24px;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-          }
-        }
-      }
-    }
   }
 
   .input-group {
@@ -384,5 +372,98 @@
     .input-group-prepend {
       display: none;
     }
+  }
+
+  .open {
+    width: 100%;
+
+    .form-control {
+      padding: 0.375rem 1rem 0.375rem 3.5rem;
+      height: 3.4rem;
+      box-shadow: none;
+      border-radius: 0;
+      color: $mediumgrey;
+      width: 100%;
+    }
+
+    .search-query {
+      box-shadow: $boxshadow-light;
+      width: 100%;
+      height: 3.5rem;
+      font-size: 1rem;
+      color: $mediumgrey;
+      display: flex;
+      align-items: center;
+      position: relative;
+      background: $white;
+
+      .search {
+        position: absolute;
+        width: 100%;
+        left: 0;
+        top: 0;
+        z-index: 99;
+        height: 3.5rem;
+        padding: 0.375rem 1rem 0.375rem 3.5rem;
+        justify-content: flex-start;
+
+        &:focus {
+          color: $black;
+          background-color: $offwhite;
+
+          ~ span {
+            z-index: 99;
+          }
+        }
+
+        &::before {
+          left: 1rem;
+          top: 1rem;
+          position: absolute;
+          width: 24px;
+          height: 24px;
+          display: flex;
+          justify-content: center;
+          align-items: center;
+        }
+      }
+    }
+  }
+
+  .back-button {
+    position: absolute;
+    left: 1rem;
+    top: 1rem;
+    z-index: 99;
+  }
+
+  .clear-button {
+    position: absolute;
+    right: 3.5rem;
+    top: 1rem;
+    z-index: 99;
+
+    @media (min-width: $bp-large) {
+      right: 1rem;
+    }
+  }
+
+  .icon-filter {
+    position: absolute;
+    right: 1rem;
+    top: 0;
+    z-index: 99;
+  }
+
+  .auto-suggest-dropdown {
+    display: block;
+    box-shadow: $boxshadow-light;
+    position: absolute;
+    top: 3.45rem;
+    width: 100%;
+    z-index: 20;
+    border-radius: 0;
+    background-color: $white;
+    transition: $standard-transition;
   }
 </style>

--- a/src/components/search/SearchQueryOptions.vue
+++ b/src/components/search/SearchQueryOptions.vue
@@ -19,7 +19,7 @@
       :to="$link.to(option.link.path, option.link.query)"
       :href="$link.href(option.link.path, option.link.query)"
       role="option"
-      @click="trackSuggestionClick(index, option.link.query.query)"
+      @click="handleClick(index, option.link.query.query)"
     >
       <i18n
         v-if="option.i18n"
@@ -98,6 +98,11 @@
         // unsets the entity ID before the @click event fires on each search option.
         const collectionPagePattern = /(\/[a-z]{2})?\/collections\/(person|topic|time|organisation)\/([0-9]+)+/;
         return collectionPagePattern.test(window.location.href);
+      },
+
+      handleClick(index, query) {
+        this.$emit('select');
+        this.trackSuggestionClick(index, query);
       },
 
       trackSuggestionClick(index, query) {

--- a/src/components/search/SearchQueryOptions.vue
+++ b/src/components/search/SearchQueryOptions.vue
@@ -1,25 +1,25 @@
 <template>
   <b-list-group
-    :id="elementId"
-    class="auto-suggest-dropdown"
-    data-qa="search query options"
+    id="search-form-options"
     role="listbox"
+    data-qa="search query options"
     :aria-label="$t('searchSuggestions')"
   >
+    <!--
+      Will also fire on 'Enter' as @click event is also triggered on keyboard navigation
+      @event click
+      @property {number} index - option index
+      @property {string} query - option link query
+    -->
     <b-list-group-item
       v-for="(option, index) in options"
       :key="index"
+      ref="options"
       :data-qa="option.qa"
       :to="$link.to(option.link.path, option.link.query)"
       :href="$link.href(option.link.path, option.link.query)"
       role="option"
-      :aria-selected="index === focus"
-      :class="{ 'hover': index === focus }"
       @click="trackSuggestionClick(index, option.link.query.query)"
-      @focus="index === focus"
-      @mouseover="focus = index"
-      @mouseout="focus = null"
-      @mousedown.prevent
     >
       <i18n
         v-if="option.i18n"
@@ -60,7 +60,8 @@
       /**
        * Array of objects for the query options to render as links
        *
-       * @example with i18n and named slots
+       * with i18n and named slots
+       * @example
        * [
        *   {
        *     link: { path: '/en/search', query: { query: 'map' } },
@@ -69,8 +70,9 @@
        *       { name: 'query', value: { text: 'map', highlight: true } }
        *     ] }
        *   }
-       * ]
-       * @example with non-i18n texts
+       * ];
+       * with non-i18n texts
+       * @example
        * [
        *   {
        *     link: { path: '/en/search', query: { query: '"Charles Dickens"' } },
@@ -81,90 +83,15 @@
        *       { text: 'ickens ', highlight: false }
        *     ]
        *   }
-       * ]
+       * ];
        */
       options: {
         type: Array,
         required: true
-      },
-
-      elementId: {
-        type: String,
-        default: null
-      },
-
-      inputRefName: {
-        type: String,
-        default: 'searchbox'
       }
-    },
-
-    data() {
-      return {
-        focus: null
-      };
-    },
-
-    computed: {
-      firstOptionHasFocus() {
-        return this.focus === 0;
-      },
-
-      lastOptionHasFocus() {
-        return this.focus === (this.options.length - 1);
-      },
-
-      noOptionHasFocus() {
-        return this.focus === null;
-      },
-
-      inputRef() {
-        return this.$parent.$refs[this.inputRefName];
-      },
-
-      inputElement() {
-        // refs may point to a component or direct to an HTML element
-        return this.inputRef.$el ? this.inputRef.$el : this.inputRef;
-      }
-    },
-
-    mounted() {
-      this.inputElement.addEventListener('keydown', this.keydown);
-      document.addEventListener('mouseup', this.clickOutside);
     },
 
     methods: {
-      keydown(event) {
-        switch (event.keyCode) {
-        case 27: // Escape key
-          this.blurInput();
-          break;
-        case 9: // Tab key
-          this.closeDropdown();
-          break;
-        case 38: // Up key
-          this.keydownUp();
-          break;
-        case 40: // Down key
-          this.keydownDown();
-          break;
-        }
-      },
-
-      keydownUp() {
-        this.focus = (this.noOptionHasFocus || this.firstOptionHasFocus) ? this.options.length - 1 : this.focus - 1;
-        this.selectSuggestion();
-      },
-
-      keydownDown() {
-        this.focus = (this.noOptionHasFocus || this.lastOptionHasFocus) ? 0 : this.focus + 1;
-        this.selectSuggestion();
-      },
-
-      blurInput() {
-        this.inputElement.blur();
-      },
-
       onCollectionPage() {
         // Used for deciding if clicks on search suggestions should be tracked.
         // Uses window.location as the beforeRouteLeave call on collection pages
@@ -176,39 +103,11 @@
       trackSuggestionClick(index, query) {
         // Skip click tracking while on a collection page, there will never be suggestions.
         if (!this.onCollectionPage()) {
-          // While only triggered via @click here, these events are also tracked
-          // in the submitForm logic of the SearchForm component for keyboard events.
           if (index >= 1) {
             this.$matomo?.trackEvent('Autosuggest_option_selected', 'Autosuggest option is selected', query);
           } else if (this.options.length >= 2) {
             this.$matomo?.trackEvent('Autosuggest_option_not_selected', 'Autosuggest option is not selected', query);
           }
-        }
-        this.blurInput();
-      },
-
-      clickOutside(event) {
-        const isParent = (event.target === this.inputElement);
-        const isChild = this.$el.contains(event.target);
-        const isSubmit = event.target.closest('.search-query');
-        const isClear = event.target.classList.contains('clear');
-
-        if (!(isParent || isChild || isSubmit)) {
-          this.closeDropdown(isClear);
-        }
-      },
-
-      closeDropdown() {
-        this.focus = null;
-        this.selectSuggestion();
-      },
-
-      selectSuggestion() {
-        if (this.focus && this.options[this.focus]) {
-          this.$emit('select', this.options[this.focus].link);
-        } else {
-          // fallback to the query by unselecting any suggestions.
-          this.$emit('select', null);
         }
       }
     }
@@ -219,55 +118,48 @@
   @import '@/assets/scss/variables';
   @import '@/assets/scss/icons';
 
-  .auto-suggest-dropdown {
-    display: block;
-    box-shadow: $boxshadow-light;
-    position: absolute;
-    top: 3.45rem;
-    width: 100%;
-    z-index: 20;
+  .list-group-item {
+    border: 0;
     border-radius: 0;
-    background-color: $white;
-    transition: $standard-transition;
+    box-shadow: none;
+    padding: 1rem 1.25rem 1rem 3.4rem;
+    color: $black;
+    font-size: 1rem;
+    text-decoration: none;
+    text-align: left;
 
-    .list-group-item {
-      border: 0;
-      border-radius: 0;
-      box-shadow: none;
-      padding: 1rem 1.25rem 1rem 3.4rem;
-      color: $black;
-      font-size: 1rem;
-      text-decoration: none;
-      text-align: left;
+    &::before {
+      @extend %icon-font;
 
-      &:focus {
-        background-color: $offwhite;
-      }
+      font-size: 1.1rem;
+      content: '\e92b';
+      left: 1rem;
+      top: 1rem;
+      position: absolute;
+      width: 24px;
+      height: 24px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+
+    &:focus,
+    &:hover {
+      background-color: $blue;
+      color: $white;
+    }
+
+    &.list-item-quick-search {
+      padding: 0 1.25rem 1.3125rem;
 
       &::before {
-        @extend %icon-font;
-
-        font-size: 1.1rem;
-        content: '\e92b';
-        left: 1rem;
-        top: 1rem;
-        position: absolute;
-        width: 24px;
-        height: 24px;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-      }
-
-      &.hover {
-        background-color: $blue;
-        color: $white;
+        display: none;
       }
     }
+  }
 
-    .loading {
-      font-size: 0.75rem;
-    }
+  .loading {
+    font-size: 0.75rem;
   }
 
   form:focus-within .auto-suggest-dropdown {
@@ -282,3 +174,28 @@
     }
   }
 </style>
+
+<docs lang="md">
+  ```jsx
+  <SearchQueryOptions
+    :options="[
+      {
+        link: { path: '/en/search', query: { query: 'map' } },
+        qa: 'search button',
+        i18n: { path: 'header.searchFor', slots: [
+          { name: 'query', value: { text: 'map', highlight: true } }
+        ] }
+      },
+      {
+        link: { path: '/en/search', query: { query: 'Charles Dickens' } },
+        qa: 'Charles Dickens search suggestion',
+        texts: [
+          { text: 'Charles ', highlight: false },
+          { text: 'D', highlight: true },
+          { text: 'ickens ', highlight: false }
+        ]
+      }
+    ]"
+  />
+  ```
+</docs>

--- a/styleguide.config.cjs
+++ b/styleguide.config.cjs
@@ -54,6 +54,10 @@ module.exports = async() => {
         name: 'Components',
         sections: [
           {
+            name: 'Page',
+            components: './src/components/[A-Z]*.vue'
+          },
+          {
             name: 'Account',
             components: './src/components/account/[A-Z]*.vue'
           },

--- a/styleguide/styleguide.root.js
+++ b/styleguide/styleguide.root.js
@@ -10,14 +10,24 @@ Vue.use(VueI18n);
 Vue.use(BootstrapVue);
 Vue.use(VueMasonryPlugin);
 // Vue.use(VueRouter);
+Vue.directive('visible-on-scroll', () => {});
 
 Vue.prototype.$path = () => {
   return '/';
 };
+Vue.prototype.$route = () => ({}),
+Vue.prototype.$link = {
+  to: route => route,
+  href: () => null
+};
 Vue.prototype.$store = {
   state: {
+    auth: { loggedIn: false },
     entity: { pinned: [] },
-    search: { liveQueries: [] },
+    search: {
+      liveQueries: [],
+      showSearchBar: false
+    },
     set: { liked: [] }
   },
   getters: {
@@ -25,6 +35,10 @@ Vue.prototype.$store = {
     'search/formatFacetFieldLabel': (name, value) => value,
     'set/isLiked': () => {}
   },
+  mutations: {
+    'search/setShowSearchBar': (state, value) => state.search.showSearchBar = value
+  },
+  commit: () => {},
   dispatch: () => {}
 };
 Vue.prototype.$auth = {};

--- a/tests/e2e/docker/nightwatch/support/step-runners.js
+++ b/tests/e2e/docker/nightwatch/support/step-runners.js
@@ -240,10 +240,10 @@ module.exports = {
     await client.expect.element(qaSelector(qaElementNames)).text.to.contain(text);
   },
   async haveHighlightedATarget(qaElementNames) {
-    await client.expect.element(qaSelector(qaElementNames) + '.hover').to.be.visible;
+    await client.expect.element(qaSelector(qaElementNames) + ':focus').to.be.visible;
   },
   async haveEnabledButtonInTarget(qaElementName) {
-    await client.waitForElementVisible(qaSelector(qaElementName)+ ' button:enabled');
+    await client.waitForElementVisible(qaSelector(qaElementName) + ' button:enabled');
   },
   async seeASectionHeadingWithText(headingLevel, text) {
     await client.expect.element(`h${headingLevel}`).text.to.contain(text);
@@ -261,7 +261,7 @@ module.exports = {
     await client.setCookie({
       name: 'searchResultsView',
       value: viewName
-    });;
+    });
   },
   async doNotSeeTextInTarget(text, qaElementName) {
     const selector = qaSelector(qaElementName);

--- a/tests/unit/components/PageHeader.spec.js
+++ b/tests/unit/components/PageHeader.spec.js
@@ -35,7 +35,7 @@ describe('components/PageHeader', () => {
   it('contains a search form', () => {
     const wrapper = factory({ showSearch: true });
 
-    const form = wrapper.find('[data-qa="search form"]');
+    const form = wrapper.find('[data-qa="search form wrapper"]');
     expect(form.isVisible()).toBe(true);
   });
 

--- a/tests/unit/components/search/SearchQueryOptions.spec.js
+++ b/tests/unit/components/search/SearchQueryOptions.spec.js
@@ -1,163 +1,70 @@
-import SearchQueryOptions from '@/components/search/SearchQueryOptions.vue';
-
-import { createLocalVue, mount } from '@vue/test-utils';
+import { createLocalVue, shallowMount } from '@vue/test-utils';
 import BootstrapVue from 'bootstrap-vue';
-import VueRouter from 'vue-router';
-import VueI18n from 'vue-i18n';
+import SearchQueryOptions from '@/components/search/SearchQueryOptions.vue';
+import sinon from 'sinon';
 
 const localVue = createLocalVue();
 localVue.use(BootstrapVue);
-localVue.use(VueRouter);
-localVue.use(VueI18n);
 
-const parentInputComponent = {
-  name: 'parentInputComponent',
-  components: {
-    SearchQueryOptions
-  },
-  props: ['options'],
-  template: '<div><input id="searchbox" ref="searchbox" type="text" /><SearchQueryOptions :options="options" /></div>'
-};
+const suggestions = [
+  { link: { path: '/en/search', query: { query: 'me' } }, qa: 'search link 1' },
+  { link: { path: '/en/search', query: { query: '"Medicine"' } }, qa: 'search link 2' }
+];
 
-const factory = (options = {}) => {
-  return mount(parentInputComponent, {
-    localVue,
-    i18n: options.i18n || new VueI18n,
-    attachToDocument: true,
-    propsData: options.propsData,
-    mocks: {
-      ...{
-        $t: () => {},
-        $path: (opts) => {
-          return router.resolve(opts).route.fullPath;
-        },
-        $link: {
-          to: (route, query) => route.toString() + '?' + new URLSearchParams(query).toString(),
-          href: () => null
-        }
-      }, ...(options.mocks || {})
+const factory = (options = {}) => shallowMount(SearchQueryOptions, {
+  localVue,
+  propsData: options.propsData || { options: suggestions },
+  mocks: {
+    $t: (key) => key,
+    $i18n: { locale: 'en' },
+    $link: {
+      to: route => route,
+      href: () => null
+    },
+    $matomo: {
+      trackEvent: sinon.spy()
     }
-  });
-};
+  },
+  stubs: {
+    TextHighlighter: { template: '<div></div>' }
+  }
+});
 
 describe('components/search/SearchQueryOptions', () => {
-  it('shows a link for each option', () => {
-    const wrapper = factory({
-      propsData: {
-        options: [
-          { link: { path: '/en/search', query: { query: 'me' } }, qa: 'search link 1' },
-          { link: { path: '/en/search', query: { query: '"Medicine"' } }, qa: 'search link 2' }
-        ]
-      }
-    });
+  describe('when on collection page', () => {
+    it('does not track the suggestion click', () => {
+      const wrapper = factory();
+      delete window.location;
+      window.location = new URL('https://www.europeana.eu/en/collections/topic/01-topic');
 
-    const link1 = wrapper.find('[data-qa="search link 1"]');
-    expect(link1.isVisible()).toBe(true);
-    expect(link1.attributes('href')).toBe('/en/search?query=me');
+      const option = wrapper.find('[data-qa="search link 1"]');
+      option.trigger('click');
 
-    const link2 = wrapper.find('[data-qa="search link 2"]');
-    expect(link2.isVisible()).toBe(true);
-    expect(link2.attributes('href')).toBe('/en/search?query=%22Medicine%22');
-  });
-
-  describe('options with i18n', () => {
-    const i18n = new VueI18n({
-      locale: 'en',
-      messages: {
-        en: {
-          searchFor: 'Search for {query}'
-        }
-      }
-    });
-
-    const wrapper = factory({
-      i18n,
-      propsData: {
-        options: [
-          {
-            link: { path: '/en/search', query: { query: 'map' } },
-            qa: 'highlighted query',
-            i18n: {
-              path: 'searchFor', slots: [
-                { name: 'query', value: { text: 'map', highlight: true } }
-              ]
-            }
-          },
-          {
-            link: { path: '/en/search', query: { query: 'map' } },
-            qa: 'unhighlighted query',
-            i18n: {
-              path: 'searchFor', slots: [
-                { name: 'query', value: { text: 'map' } }
-              ]
-            }
-          }
-        ]
-      }
-    });
-
-    it('localises with named slots', () => {
-      const link = wrapper.find('[data-qa="highlighted query"]');
-
-      expect(link.text()).toBe('Search for map');
-    });
-
-    it('optionally highlights interpolated text', () => {
-      const highlighted = wrapper.find('[data-qa="highlighted query"] strong');
-      expect(highlighted.text()).toBe('map');
-
-      const unhighlighted = wrapper.find('[data-qa="unhighlighted query"] strong');
-      expect(unhighlighted.exists()).toBe(false);
+      expect(wrapper.vm.$matomo.trackEvent.called).toBe(false);
+      window.location = new URL('https://www.europeana.eu/en');
     });
   });
 
-  describe('options with texts', () => {
-    const wrapper = factory({
-      propsData: {
-        options: [
-          {
-            link: { path: '/en/search', query: { query: '"Charles Dickens"' } },
-            qa: 'texts link',
-            texts: [
-              { text: 'Charles ', highlight: false },
-              { text: 'D', highlight: true },
-              { text: 'ickens ', highlight: false }
-            ]
-          }
-        ]
-      }
+  describe('when not on a collection page', () => {
+    describe('and the first option is selected', () => {
+      it('tracks the not selected event', () => {
+        const wrapper = factory();
+
+        const option = wrapper.find('[data-qa="search link 1"]');
+        option.trigger('click');
+
+        expect(wrapper.vm.$matomo.trackEvent.calledWith('Autosuggest_option_not_selected', 'Autosuggest option is not selected', 'me')).toBe(true);
+      });
     });
+    describe('and not the first option', () => {
+      it('tracks the selected event and the clicked suggestion', () => {
+        const wrapper = factory();
 
-    it('outputs all texts in the link', () => {
-      const link = wrapper.find('[data-qa="texts link"]');
+        const option = wrapper.find('[data-qa="search link 2"]');
+        option.trigger('click');
 
-      expect(link.text()).toBe('Charles Dickens');
+        expect(wrapper.vm.$matomo.trackEvent.calledWith('Autosuggest_option_selected', 'Autosuggest option is selected', '"Medicine"')).toBe(true);
+      });
     });
-
-    it('optionally highlights text', () => {
-      const highlighted = wrapper.find('[data-qa="texts link"] strong');
-
-      expect(highlighted.text()).toBe('D');
-    });
-  });
-
-  it('is navigable by keyboard on the parent input', () => {
-    const wrapper = factory({
-      propsData: {
-        options: [
-          { link: { path: '/en/search', query: { query: 'me' } }, qa: 'search link 1' },
-          { link: { path: '/en/search', query: { query: '"Medicine"' } }, qa: 'search link 2' }
-        ]
-      }
-    });
-    const searchInput = wrapper.find('#searchbox');
-    const queryOptionsWrapper = wrapper.find('[data-qa="search query options"]');
-
-    searchInput.trigger('keydown.down');
-    expect(queryOptionsWrapper.vm.focus).toBe(0);
-    searchInput.trigger('keydown.down');
-    expect(queryOptionsWrapper.vm.focus).toBe(1);
-    searchInput.trigger('keydown.up');
-    expect(queryOptionsWrapper.vm.focus).toBe(0);
   });
 });


### PR DESCRIPTION
Refactor to improve and clean up the search form and related components. This includes:

- Move back button from PageHeader to SearchForm component
- Move clear and filter buttons outside b-form. The HTML form should only include the search input
- Logic to close the search options dropdown when clicking outside the SearchForm (or its children, i.e. SearchQueryOptions)
- logic to handle keyboard navigation with arrow keys to select a search option
- Clean up deprecated logic for tracking matomo event on search option selection with enter key. This now happens outside the form element and is tracked on click anyway
- Clean up deprecated logic for manually setting focus on search options
- Add PageHeader and SearchQueryOptions components to the style guide