### PR TITLE
feat: search editorial content from main search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,9 +111,6 @@ OAUTH_CLIENT="YOUR_CLIENT"
 # Enable experimental use of the translate record API profile
 # ENABLE_TRANSLATED_ITEMS=0
 
-# Enable related editorial on collection page, by relatedLink field
-# ENABLE_COLLECTION_PAGE_RELATED_EDITORIAL=0
-
 # Enable A/B testing code, since A/B tests are by nature experimental this toggle
 # provides a quick way to switch them off in cases where they negatively impact
 # site usage.

--- a/src/assets/scss/cards.scss
+++ b/src/assets/scss/cards.scss
@@ -824,6 +824,10 @@
   }
 }
 
+.card.card-group-card .card-body {
+  padding-bottom: 0.5rem;
+}
+
 .browse-section {
   .content-card:not(.mini-card) a .card-body {
     min-height: 10rem;
@@ -857,7 +861,7 @@
     font-weight: 600;
     line-height: 1rem;
     text-transform: uppercase;
-    margin-bottom: 1.5rem;
+    margin-bottom: 1.25rem;
     color: $mediumgrey;
   }
 
@@ -868,6 +872,7 @@
       box-shadow: none;
       margin-bottom: 1.5rem;
       flex: 100%;
+      border-radius: 0;
 
       @media (min-width: $bp-medium) {
         flex: calc(50% - 1rem);
@@ -876,7 +881,7 @@
       }
 
       &:hover {
-        background: $offwhite;
+        background: $bodygrey;
       }
 
       .card-wrapper {

--- a/src/components/related/RelatedEditorial.vue
+++ b/src/components/related/RelatedEditorial.vue
@@ -70,9 +70,7 @@
     },
 
     async fetch() {
-      // TODO: in future, this component may instead make other queries, e.g
-      //       to search editorial content by title
-      if (!this.entityUri) {
+      if (!this.entityUri && !this.query) {
         return;
       }
 
@@ -84,7 +82,8 @@
         limit: 4
       };
 
-      const response = await this.$contentful.query('entityRelatedContent', variables);
+      const queryName = this.entityUri ? 'entityRelatedContent' : 'relatedContent';
+      const response = await this.$contentful.query(queryName, variables);
       const entries = response.data.data;
 
       this.related = entries.blogPostingCollection.items

--- a/src/features/toggles.js
+++ b/src/features/toggles.js
@@ -2,7 +2,6 @@ export default [
   { name: 'abTests' },
   { name: 'acceptEntityRecommendations' },
   { name: 'acceptSetRecommendations' },
-  { name: 'collectionPageRelatedEditorial' },
   { name: 'entityManagement' },
   { name: 'jiraServiceDeskFeedbackForm' },
   { name: 'rejectEntityRecommendations' },

--- a/src/modules/contentful-graphql/queries/related-content.graphql
+++ b/src/modules/contentful-graphql/queries/related-content.graphql
@@ -2,11 +2,10 @@ query EntityRelatedContent(
   $locale: String!,
   $preview: Boolean = false,
   $limit: Int = 4,
-  $entityUri: String!,
   $query: String = ""
 ) {
   blogPostingCollection(
-    where: { relatedLink_contains_some: [$entityUri], name_contains: $query },
+    where: { name_contains: $query },
     preview: $preview, locale: $locale, order: datePublished_DESC, limit: $limit
   ) {
     items {
@@ -24,7 +23,7 @@ query EntityRelatedContent(
     }
   }
   exhibitionPageCollection(
-    where: { relatedLink_contains_some: [$entityUri], name_contains: $query },
+    where: { name_contains: $query },
     preview: $preview, locale: $locale, order: datePublished_DESC, limit: $limit
   ) {
     items {

--- a/src/pages/collections/_type/_.vue
+++ b/src/pages/collections/_type/_.vue
@@ -70,7 +70,7 @@
             <client-only>
               <b-container class="px-0">
                 <RelatedEditorial
-                  v-if="entity && $features.collectionPageRelatedEditorial"
+                  v-if="entity"
                   :entity-uri="entity.id"
                   :query="$route.query.query"
                 />

--- a/src/pages/search/index.vue
+++ b/src/pages/search/index.vue
@@ -35,7 +35,7 @@
     <client-only>
       <b-container class="px-0">
         <RelatedEditorial
-          v-if="searchQuery && $features.collectionPageRelatedEditorial"
+          v-if="searchQuery"
           :query="searchQuery"
         />
       </b-container>

--- a/src/pages/search/index.vue
+++ b/src/pages/search/index.vue
@@ -32,6 +32,14 @@
         </b-col>
       </b-row>
     </b-container>
+    <client-only>
+      <b-container class="px-0">
+        <RelatedEditorial
+          v-if="searchQuery && $features.collectionPageRelatedEditorial"
+          :query="searchQuery"
+        />
+      </b-container>
+    </client-only>
   </div>
 </template>
 
@@ -45,6 +53,7 @@
     components: {
       ClientOnly,
       SearchInterface,
+      RelatedEditorial: () => import('@/components/related/RelatedEditorial'),
       RelatedSection: () => import('@/components/search/RelatedSection'),
       SideFilters: () => import('@/components/search/SideFilters')
     },

--- a/src/pages/search/index.vue
+++ b/src/pages/search/index.vue
@@ -29,17 +29,17 @@
               </client-only>
             </template>
           </SearchInterface>
+          <client-only>
+            <b-container class="px-0">
+              <RelatedEditorial
+                v-if="searchQuery"
+                :query="searchQuery"
+              />
+            </b-container>
+          </client-only>
         </b-col>
       </b-row>
     </b-container>
-    <client-only>
-      <b-container class="px-0">
-        <RelatedEditorial
-          v-if="searchQuery"
-          :query="searchQuery"
-        />
-      </b-container>
-    </client-only>
   </div>
 </template>
 


### PR DESCRIPTION
1. Search for related editorial content in Contentful from the main search, provided the user has entered a query
    1. NB: this requires a separate GraphQL query because without an entity URI supplied, the other query will never return anything due to the use of the `_contains_some` filter
2. Fix the related editorial content search for collection pages to filter blog posts by the query if there is one
3. Remove the feature toggle as this is the final part of the initial implementation of the display of related editorial