### PR TITLE
feat: represent depublished items in user sets

### DIFF
--- a/tests/unit/store/set.spec.js
+++ b/tests/unit/store/set.spec.js
@@ -315,15 +315,17 @@ describe('store/set', () => {
     });
 
     describe('fetchActive()', () => {
-      it('fetches the active set with itemDescriptions via $apis.set, then commits it with "setActive"', async() => {
+      it('fetches the active set and items via Set & Record APIs, then commits it with "setActive"', async() => {
         store.actions.$apis.set.get = sinon.stub().resolves(set);
+        store.actions.$apis.record.search = sinon.stub().resolves({ items: [] });
 
         await store.actions.fetchActive({ commit }, setId);
 
         expect(store.actions.$apis.set.get.calledWith(setId, {
-          profile: 'itemDescriptions',
+          profile: 'standard',
           pageSize: 100
         })).toBe(true);
+        expect(store.actions.$apis.record.search.called).toBe(true);
         expect(commit.calledWith('setActive', set)).toBe(true);
       });
       describe('when API request doesn\'t return a set', () => {


### PR DESCRIPTION
* Stop using the `itemDescriptions` profile of the Set API which contains vastly more data than is needed, and instead make a subsequent `minimal` profile request to the Record API's search method
* Where items are present in a set but not returned from the Record API, i.e. have been depublished, represent them as a blank card with default thumbnail, linking to the item page which will 404