### PR TITLE
feat: link to related entities from blogs and exhibitions

### DIFF
--- a/src/components/blog/BlogPost.vue
+++ b/src/components/blog/BlogPost.vue
@@ -54,6 +54,12 @@
             v-if="tags"
             :tags="tags"
           />
+          <client-only>
+            <RelatedCollections
+              :entity-uris="relatedLink"
+              :title="$t('youMightAlsoLike')"
+            />
+          </client-only>
         </b-col>
       </b-row>
       <b-row class="footer-margin" />
@@ -62,7 +68,8 @@
 </template>
 
 <script>
-  import SocialShareModal from '../sharing/SocialShareModal.vue';
+  import ClientOnly from 'vue-client-only';
+  import SocialShareModal from '../sharing/SocialShareModal';
   import ShareButton from '../sharing/ShareButton.vue';
   import BrowseSections from '../browse/BrowseSections';
 
@@ -73,9 +80,11 @@
       AuthoredHead: () => import('../../components/authored/AuthoredHead'),
       BlogAuthor: () => import('./BlogAuthor'),
       BlogTags: () => import('../../components/blog/BlogTags'),
+      ClientOnly,
       SocialShareModal,
       ShareButton,
-      BrowseSections
+      BrowseSections,
+      RelatedCollections: () => import('@/components/related/RelatedCollections')
     },
 
     props: {
@@ -115,6 +124,11 @@
       },
 
       tags: {
+        type: Array,
+        default: () => []
+      },
+
+      relatedLink: {
         type: Array,
         default: () => []
       }

--- a/src/components/blog/BlogPost.vue
+++ b/src/components/blog/BlogPost.vue
@@ -140,4 +140,16 @@
   .author ~ .author::before {
     content: ', ';
   }
+
+  ::v-deep .related-collections {
+    &.container {
+      padding: 0;
+    }
+
+    .badge-pill {
+      margin-top: 0.25rem;
+      margin-right: 0.5rem;
+    }
+  }
+
 </style>

--- a/src/components/entity/EntityRelatedCollections.vue
+++ b/src/components/entity/EntityRelatedCollections.vue
@@ -1,20 +1,19 @@
 <template>
   <RelatedCollections
-    v-if="!$fetchState.pending && (relatedCollections.length > 0)"
+    v-if="!$fetchState.pending"
     :title="$t('youMightAlsoLike')"
     :related-collections="relatedCollections"
+    :entity-uris="entityUris"
     @show="$emit('show')"
     @hide="$emit('hide')"
   />
 </template>
 
 <script>
-  import pick from 'lodash/pick';
-
   import { BASE_URL as EUROPEANA_DATA_URL } from '@/plugins/europeana/data';
   import { getEntityUri, getEntityQuery } from '@/plugins/europeana/entity';
 
-  import RelatedCollections from '../generic/RelatedCollections';
+  import RelatedCollections from '../related/RelatedCollections';
 
   export default {
     name: 'EntityRelatedCollections',
@@ -40,29 +39,33 @@
 
     data() {
       return {
+        entityUris: [],
         relatedCollections: []
       };
     },
 
-    fetch() {
+    async fetch() {
       if (this.overrides) {
         this.relatedCollections = this.overrides;
-        return Promise.resolve();
-      } else {
-        const recordSearchParams = {
-          profile: 'facets',
-          facet: 'skos_concept',
-          query: this.entityQuery,
-          qf: ['contentTier:*'],
-          rows: 0
-        };
-
-        return this.$apis.record.search(recordSearchParams)
-          .then(response => response?.facets ? this.fetchEntities(response.facets) : [])
-          // TODO: why are we doing this? (formerly in entity plugin's `getRelatedEntityData` fn)
-          .then(related => related.filter(entity => !!entity.prefLabel.en))
-          .then(related => this.relatedCollections = related.map(entity => pick(entity, ['id', 'prefLabel', 'isShownBy'])));
+        return;
       }
+      const recordSearchParams = {
+        profile: 'facets',
+        facet: 'skos_concept',
+        query: this.entityQuery,
+        qf: ['contentTier:*'],
+        rows: 0
+      };
+
+      const response = await this.$apis.record.search(recordSearchParams);
+      const facets = response?.facets || [];
+      this.entityUris = facets
+        .reduce((memo, facet) => {
+          memo = memo.concat(facet.fields.map(entity => entity.label));
+          return memo;
+        }, [])
+        .filter(uri => uri.startsWith(EUROPEANA_DATA_URL) && (uri !== this.entityUri))
+        .slice(0, 4);
     },
 
     computed: {
@@ -78,19 +81,6 @@
     watch: {
       type: '$fetch',
       identifier: '$fetch'
-    },
-
-    methods: {
-      fetchEntities(facets) {
-        const entityUris = facets.reduce((memo, facet) => {
-          memo = memo.concat(facet.fields.map(entity => entity.label));
-          return memo;
-        }, [])
-          .filter(uri => uri.startsWith(EUROPEANA_DATA_URL) && (uri !== this.entityUri))
-          .slice(0, 4);
-
-        return this.$apis.entity.find(entityUris);
-      }
     }
   };
 </script>

--- a/src/components/related/RelatedCollections.vue
+++ b/src/components/related/RelatedCollections.vue
@@ -1,6 +1,6 @@
 <template>
   <b-container
-    v-if="relatedCollections.length > 0"
+    v-show="collections.length > 0"
     data-qa="related collections"
     class="related-collections"
   >
@@ -9,7 +9,7 @@
     </h2>
     <div class="d-flex flex-wrap">
       <LinkBadge
-        v-for="relatedCollection in relatedCollections"
+        v-for="relatedCollection in collections"
         :id="relatedCollection.id"
         :key="relatedCollection.id"
         :link-to="linkGen(relatedCollection)"
@@ -23,10 +23,11 @@
 </template>
 
 <script>
-  import { BASE_URL as EUROPEANA_DATA_URL } from '../../plugins/europeana/data';
-  import { getEntityTypeHumanReadable, getEntitySlug } from '../../plugins/europeana/entity';
+  import pick from 'lodash/pick';
+  import { BASE_URL as EUROPEANA_DATA_URL } from '@/plugins/europeana/data';
+  import { getEntityTypeHumanReadable, getEntitySlug } from '@/plugins/europeana/entity';
 
-  import LinkBadge from './LinkBadge';
+  import LinkBadge from '../generic/LinkBadge';
 
   export default {
     name: 'RelatedCollections',
@@ -44,10 +45,29 @@
         type: Array,
         default: () => []
       },
+      entityUris: {
+        type: Array,
+        default: () => []
+      },
       badgeVariant: {
         type: String,
         default: 'secondary'
       }
+    },
+
+    data() {
+      return {
+        collections: this.relatedCollections
+      };
+    },
+
+    async fetch() {
+      if (this.entityUris.length === 0 || this.relatedCollections.length > 0) {
+        return;
+      }
+
+      const entities = await this.$apis.entity.find(this.entityUris);
+      this.collections = entities.map(entity => pick(entity, ['id', 'prefLabel', 'isShownBy']));
     },
 
     mounted() {
@@ -64,7 +84,7 @@
 
     methods: {
       draw(showOrHide) {
-        this.$emit(showOrHide || (this.relatedCollections.length > 0 ? 'show' : 'hide'));
+        this.$emit(showOrHide || (this.collections.length > 0 ? 'show' : 'hide'));
         this.$nextTick(() => {
           this.$redrawVueMasonry && this.$redrawVueMasonry();
         });

--- a/src/components/related/RelatedCollections.vue
+++ b/src/components/related/RelatedCollections.vue
@@ -67,7 +67,7 @@
       }
 
       const entities = await this.$apis.entity.find(this.entityUris);
-      this.collections = entities.map(entity => pick(entity, ['id', 'prefLabel', 'isShownBy']));
+      this.collections = entities.map(entity => pick(entity, ['id', 'prefLabel', 'isShownBy', 'logo']));
     },
 
     mounted() {
@@ -97,12 +97,15 @@
         if (collection.id) {
           id = collection.id;
           name = collection.prefLabel.en;
-        } else {
+        } else if (collection.identifier) {
           id = collection.identifier;
           name = collection.name;
         }
 
         const uriMatch = id.match(`^${EUROPEANA_DATA_URL}/([^/]+)(/base)?/(.+)$`);
+        if (!uriMatch) {
+          return null;
+        }
 
         return this.$path({
           name: 'collections-type-all', params: {

--- a/src/components/search/RelatedSection.vue
+++ b/src/components/search/RelatedSection.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script>
-  import RelatedCollections from '../generic/RelatedCollections';
+  import RelatedCollections from '../related/RelatedCollections';
 
   export default {
     name: 'RelatedSection',

--- a/src/modules/contentful-graphql/queries/exhibition-chapter-page.graphql
+++ b/src/modules/contentful-graphql/queries/exhibition-chapter-page.graphql
@@ -19,6 +19,7 @@ query ExhibitionChapterPage(
         name
         description
       }
+      relatedLink
       hasPartCollection(limit: 40) {
         items {
           name

--- a/src/modules/contentful-graphql/queries/exhibition-credits-page.graphql
+++ b/src/modules/contentful-graphql/queries/exhibition-credits-page.graphql
@@ -8,6 +8,7 @@ query ExhibitionCreditsPage(
       name
       identifier
       credits
+      relatedLink
       hasPartCollection(limit: 20) {
         items {
           identifier

--- a/src/modules/contentful-graphql/queries/exhibition-landing-page.graphql
+++ b/src/modules/contentful-graphql/queries/exhibition-landing-page.graphql
@@ -27,6 +27,7 @@ query ExhibitionLandingPage(
         name
         description
       }
+      relatedLink
     }
   }
 }

--- a/src/pages/blog/_.vue
+++ b/src/pages/blog/_.vue
@@ -18,13 +18,14 @@
       :hero="hero"
       :authors="post.authorCollection.items.length > 0 ? post.authorCollection.items : null"
       :tags="post.keywords"
+      :related-link="post.relatedLink"
     />
   </div>
 </template>
 
 <script>
   import { mapGetters } from 'vuex';
-  import BlogPost from '../../components/blog/BlogPost';
+  import BlogPost from '@/components/blog/BlogPost';
 
   export default {
     name: 'BlogPostPage',

--- a/src/pages/exhibitions/_exhibition/_chapter.vue
+++ b/src/pages/exhibitions/_exhibition/_chapter.vue
@@ -63,6 +63,22 @@
           </b-col>
         </b-row>
       </client-only>
+      <b-row
+        v-if="relatedLink"
+        class="justify-content-center"
+      >
+        <b-col
+          cols="12"
+          class="mt-3 col-lg-8"
+        >
+          <client-only>
+            <RelatedCollections
+              :entity-uris="relatedLink"
+              :title="$t('youMightAlsoLike')"
+            />
+          </client-only>
+        </b-col>
+      </b-row>
       <b-row class="footer-margin" />
     </b-container>
   </div>
@@ -85,7 +101,8 @@
       SocialShareModal,
       AuthoredHead: () => import('../../../components/authored/AuthoredHead'),
       LinkList: () => import('../../../components/generic/LinkList'),
-      ContentWarningModal: () => import('@/components/generic/ContentWarningModal')
+      ContentWarningModal: () => import('@/components/generic/ContentWarningModal'),
+      RelatedCollections: () => import('@/components/related/RelatedCollections')
     },
     mixins: [
       exhibitionChapters
@@ -142,6 +159,7 @@
             exhibitionIdentifier: params.exhibition,
             exhibitionTitle: exhibition.name,
             exhibitionContentWarning: exhibition.contentWarning,
+            relatedLink: exhibition.relatedLink,
             page: chapter
           };
         })
@@ -204,3 +222,18 @@
     }
   };
 </script>
+
+<style lang="scss" scoped>
+  ::v-deep .related-collections {
+    &.container {
+      padding: 0;
+    }
+
+    .badge-pill {
+      margin-top: 0.25rem;
+      margin-right: 0.5rem;
+    }
+  }
+
+</style>
+

--- a/src/pages/exhibitions/_exhibition/credits.vue
+++ b/src/pages/exhibitions/_exhibition/credits.vue
@@ -55,6 +55,22 @@
           />
         </b-col>
       </b-row>
+      <b-row
+        v-if="relatedLink"
+        class="justify-content-center"
+      >
+        <b-col
+          cols="12"
+          class="mt-3 col-lg-8"
+        >
+          <client-only>
+            <RelatedCollections
+              :entity-uris="relatedLink"
+              :title="$t('youMightAlsoLike')"
+            />
+          </client-only>
+        </b-col>
+      </b-row>
       <b-row class="footer-margin" />
     </b-container>
   </div>
@@ -71,7 +87,8 @@
     components: {
       ShareButton,
       SocialShareModal,
-      LinkList: () => import('../../../components/generic/LinkList')
+      LinkList: () => import('../../../components/generic/LinkList'),
+      RelatedCollections: () => import('@/components/related/RelatedCollections')
     },
     mixins: [
       exhibitionChapters
@@ -154,5 +171,16 @@
   ::v-deep img {
     display: block;
     margin: 1rem 0;
+  }
+
+  ::v-deep .related-collections {
+    &.container {
+      padding: 0;
+    }
+
+    .badge-pill {
+      margin-top: 0.25rem;
+      margin-right: 0.5rem;
+    }
   }
 </style>

--- a/src/pages/exhibitions/_exhibition/index.vue
+++ b/src/pages/exhibitions/_exhibition/index.vue
@@ -47,12 +47,22 @@
           />
         </b-col>
       </b-row>
-      <client-only>
-        <RelatedCollections
-          :entity-uris="relatedLink"
-          :title="$t('youMightAlsoLike')"
-        />
-      </client-only>
+      <b-row
+        v-if="relatedLink"
+        class="justify-content-center"
+      >
+        <b-col
+          cols="12"
+          class="mt-3 col-lg-8"
+        >
+          <client-only>
+            <RelatedCollections
+              :entity-uris="relatedLink"
+              :title="$t('youMightAlsoLike')"
+            />
+          </client-only>
+        </b-col>
+      </b-row>
       <b-row class="footer-margin" />
     </b-container>
   </div>

--- a/src/pages/exhibitions/_exhibition/index.vue
+++ b/src/pages/exhibitions/_exhibition/index.vue
@@ -154,3 +154,17 @@
     }
   };
 </script>
+
+<style lang="scss" scoped>
+  ::v-deep .related-collections {
+    &.container {
+      padding: 0;
+    }
+
+    .badge-pill {
+      margin-top: 0.25rem;
+      margin-right: 0.5rem;
+    }
+  }
+
+</style>

--- a/src/pages/exhibitions/_exhibition/index.vue
+++ b/src/pages/exhibitions/_exhibition/index.vue
@@ -47,12 +47,19 @@
           />
         </b-col>
       </b-row>
+      <client-only>
+        <RelatedCollections
+          :entity-uris="relatedLink"
+          :title="$t('youMightAlsoLike')"
+        />
+      </client-only>
       <b-row class="footer-margin" />
     </b-container>
   </div>
 </template>
 
 <script>
+  import ClientOnly from 'vue-client-only';
   import { marked } from 'marked';
   import SocialShareModal from '../../../components/sharing/SocialShareModal.vue';
   import ShareButton from '../../../components/sharing/ShareButton.vue';
@@ -61,11 +68,13 @@
   export default {
     name: 'ExhibitionPage',
     components: {
+      ClientOnly,
       LinkList: () => import('../../../components/generic/LinkList'),
       ShareButton,
       SocialShareModal,
       AuthoredHead: () => import('../../../components/authored/AuthoredHead'),
-      ContentWarningModal: () => import('@/components/generic/ContentWarningModal')
+      ContentWarningModal: () => import('@/components/generic/ContentWarningModal'),
+      RelatedCollections: () => import('@/components/related/RelatedCollections')
     },
     mixins: [
       exhibitionChapters

--- a/src/pages/item/_.vue
+++ b/src/pages/item/_.vue
@@ -127,7 +127,7 @@
       ItemHero: () => import('@/components/item/ItemHero'),
       AlertMessage: () => import('@/components/generic/AlertMessage'),
       ItemPreviewCardGroup: () => import('@/components/item/ItemPreviewCardGroup'),
-      RelatedCollections: () => import('@/components/generic/RelatedCollections'),
+      RelatedCollections: () => import('@/components/related/RelatedCollections'),
       SummaryInfo: () => import('@/components/item/SummaryInfo'),
       MetadataBox,
       ItemLanguageSelector: () => import('@/components/item/ItemLanguageSelector')

--- a/tests/size/.size-limit.json
+++ b/tests/size/.size-limit.json
@@ -11,7 +11,7 @@
   {
     "name": "portal.js modern",
     "running": false,
-    "limit": "815 KB",
+    "limit": "820 KB",
     "path": [
       ".nuxt/dist/client/*.modern.js"
     ]

--- a/tests/unit/components/entity/EntityRelatedCollections.spec.js
+++ b/tests/unit/components/entity/EntityRelatedCollections.spec.js
@@ -9,7 +9,7 @@ const localVue = createLocalVue();
 const factory = ({ propsData, responses } = {}) => {
   return shallowMountNuxt(EntityRelatedCollections, {
     localVue,
-    propsData: propsData,
+    propsData,
     mocks: {
       $apis: {
         record: { search: sinon.stub().resolves(responses?.record?.search || {}) }

--- a/tests/unit/components/related/RelatedCollections.spec.js
+++ b/tests/unit/components/related/RelatedCollections.spec.js
@@ -1,18 +1,16 @@
 import { createLocalVue, mount } from '@vue/test-utils';
 import BootstrapVue from 'bootstrap-vue';
-import Vuex from 'vuex';
 import sinon from 'sinon';
 
 import RelatedCollections from '@/components/related/RelatedCollections.vue';
 
 const localVue = createLocalVue();
 localVue.use(BootstrapVue);
-localVue.use(Vuex);
 
-const factory = (options = {}) => {
+const factory = ({ propsData, mocks } = {}) => {
   return mount(RelatedCollections, {
     localVue,
-    propsData: options.propsData,
+    propsData,
     stubs: ['b-container'],
     mocks: {
       $apis: {
@@ -27,17 +25,8 @@ const factory = (options = {}) => {
       $link: {
         to: route => route,
         href: () => null
-      }, ...(options.mocks || {})
-    },
-    store: options.store || store()
-  });
-};
-const store = (options = {}) => {
-  return new Vuex.Store({
-    state: options.state || {
-      i18n: {
-        locale: 'en'
-      }
+      },
+      ...mocks
     }
   });
 };
@@ -81,28 +70,28 @@ const relatedCollections = [
 ];
 
 describe('components/related/RelatedCollections', () => {
-  describe('when related collections are found', () => {
-    const wrapper = factory();
-    wrapper.setProps({ relatedCollections });
+  describe('template', () => {
+    describe('when related collections are supplied', () => {
+      const wrapper = factory({ propsData: { relatedCollections } });
 
-    it('shows a section with related collections chips', () => {
-      const relatedCollections = wrapper.find('[data-qa="related collections"]');
-      expect(relatedCollections.isVisible()).toBe(true);
+      it('shows a section with related collections chips', () => {
+        const relatedCollections = wrapper.find('[data-qa="related collections"]');
+        expect(relatedCollections.isVisible()).toBe(true);
+      });
+
+      it('contains four related chips', () => {
+        const chips = wrapper.findAll('a.badge');
+        expect(chips.length).toBe(4);
+      });
     });
 
-    it('contains four related chips', () => {
-      const chips = wrapper.findAll('a.badge');
-      expect(chips.length).toBe(4);
-    });
-  });
+    describe('when no related collections are supplied', () => {
+      const wrapper = factory({ propsData: { relatedCollections: [] } });
 
-  describe('when no related collections are found', () => {
-    const wrapper = factory();
-    wrapper.setProps({ relatedCollections: [] });
-
-    it('related collections does not render', () => {
-      const relatedCollections = wrapper.find('[data-qa="related collections"]');
-      expect(relatedCollections.exists()).toBe(false);
+      it('is not visible', () => {
+        const relatedCollections = wrapper.find('[data-qa="related collections"]');
+        expect(relatedCollections.isVisible()).toBe(false);
+      });
     });
   });
 

--- a/tests/unit/components/related/RelatedCollections.spec.js
+++ b/tests/unit/components/related/RelatedCollections.spec.js
@@ -3,7 +3,7 @@ import BootstrapVue from 'bootstrap-vue';
 import Vuex from 'vuex';
 import sinon from 'sinon';
 
-import RelatedCollections from '@/components/generic/RelatedCollections.vue';
+import RelatedCollections from '@/components/related/RelatedCollections.vue';
 
 const localVue = createLocalVue();
 localVue.use(BootstrapVue);
@@ -80,7 +80,7 @@ const relatedCollections = [
   }
 ];
 
-describe('components/generic/RelatedCollections', () => {
+describe('components/related/RelatedCollections', () => {
   describe('when related collections are found', () => {
     const wrapper = factory();
     wrapper.setProps({ relatedCollections });

--- a/tests/unit/components/related/RelatedCollections.spec.js
+++ b/tests/unit/components/related/RelatedCollections.spec.js
@@ -108,66 +108,79 @@ describe('components/related/RelatedCollections', () => {
     });
   });
 
-  describe('fetch', () => {
-    afterEach(sinon.resetHistory);
+  describe('hooks', () => {
+    describe('fetch', () => {
+      afterEach(sinon.resetHistory);
 
-    describe('when related collections are supplied', () => {
-      const propsData = { relatedCollections };
+      describe('when related collections are supplied', () => {
+        const propsData = { relatedCollections };
 
-      it('uses them', async() => {
-        const wrapper = factory({ propsData });
-
-        await wrapper.vm.fetch();
-
-        expect(wrapper.vm.collections).toEqual(relatedCollections);
-      });
-
-      it('does not query the Entity API', async() => {
-        const wrapper = factory({ propsData });
-
-        await wrapper.vm.fetch();
-
-        expect(wrapper.vm.$apis.entity.find.called).toBe(false);
-      });
-    });
-
-    describe('when no related collections are supplied', () => {
-      describe('but entity URIs are supplied', () => {
-        const propsData = { entityUris };
-
-        it('queries the Entity API', async() => {
+        it('uses them', async() => {
           const wrapper = factory({ propsData });
 
           await wrapper.vm.fetch();
 
-          expect(wrapper.vm.$apis.entity.find.calledWith(entityUris)).toBe(true);
+          expect(wrapper.vm.collections).toEqual(relatedCollections);
         });
 
-        it('uses the response', async() => {
-          const wrapper = factory({ propsData });
-
-          await wrapper.vm.fetch();
-
-          expect(wrapper.vm.collections).toEqual(entityApiFindResponse);
-        });
-      });
-
-      describe('and no entity URIs are supplied', () => {
         it('does not query the Entity API', async() => {
-          const wrapper = factory();
+          const wrapper = factory({ propsData });
 
           await wrapper.vm.fetch();
 
           expect(wrapper.vm.$apis.entity.find.called).toBe(false);
         });
+      });
 
-        it('has no collections', async() => {
-          const wrapper = factory();
+      describe('when no related collections are supplied', () => {
+        describe('but entity URIs are supplied', () => {
+          const propsData = { entityUris };
 
-          await wrapper.vm.fetch();
+          it('queries the Entity API', async() => {
+            const wrapper = factory({ propsData });
 
-          expect(wrapper.vm.collections).toEqual([]);
+            await wrapper.vm.fetch();
+
+            expect(wrapper.vm.$apis.entity.find.calledWith(entityUris)).toBe(true);
+          });
+
+          it('uses the response', async() => {
+            const wrapper = factory({ propsData });
+
+            await wrapper.vm.fetch();
+
+            expect(wrapper.vm.collections).toEqual(entityApiFindResponse);
+          });
         });
+
+        describe('and no entity URIs are supplied', () => {
+          it('does not query the Entity API', async() => {
+            const wrapper = factory();
+
+            await wrapper.vm.fetch();
+
+            expect(wrapper.vm.$apis.entity.find.called).toBe(false);
+          });
+
+          it('has no collections', async() => {
+            const wrapper = factory();
+
+            await wrapper.vm.fetch();
+
+            expect(wrapper.vm.collections).toEqual([]);
+          });
+        });
+      });
+    });
+
+    describe('beforeDestroy', () => {
+      it('triggers `draw` to hide component', async() => {
+        const wrapper = factory();
+        wrapper.vm.draw = sinon.spy();
+
+        await wrapper.destroy();
+
+        expect(wrapper.vm.draw.calledWith('hide')).toBe(true);
       });
     });
   });


### PR DESCRIPTION
* Move RelatedCollections component to src/components/related/ directory
* Add a new prop, `entityUris`, to RelatedCollections component. If present and `relatedCollections` is not populated, go fetch the data for those entities to render in the component
* Refactor EntityRelatedCollections component to make use of the new prop of RelatedCollections
* Add use of RelatedCollections to blog post and exhibitions landing pages