### PR TITLE
chore: remove Set API itemDescriptions workarounds

### DIFF
--- a/src/components/item/ItemPreviewCard.vue
+++ b/src/components/item/ItemPreviewCard.vue
@@ -1,6 +1,6 @@
 <template>
   <ContentCard
-    :title="item.dcTitleLangAware || item.dcDescriptionLangAware"
+    :title="dcTitle || item.dcDescriptionLangAware"
     :url="url"
     :image-url="imageUrl"
     :texts="texts"
@@ -149,6 +149,17 @@
     },
 
     computed: {
+      dcTitle() {
+        return this.unpublishedItem ?
+          { [this.$i18n.locale]: [this.$t('record.status.unpublished')] } :
+          this.item.dcTitleLangAware;
+      },
+
+      unpublishedItem() {
+        const itemProperties = Object.keys(this.item);
+        return (itemProperties.length === 1) && (itemProperties[0] === 'id');
+      },
+
       texts() {
         const textlessVariants = ['explore', 'mosaic'];
         if (textlessVariants.includes(this.variant)) {

--- a/src/plugins/europeana/set.js
+++ b/src/plugins/europeana/set.js
@@ -66,12 +66,10 @@ export default (context = {}) => {
      * @param {string} id the set's id
      * @param {Object} params retrieval params
      * @param {string} params.profile the set's metadata profile minimal/standard/itemDescriptions
-     * @param {Object} options retrieval options
-     * @param {Boolean} options.withMinimalItems retrieve minimal item metadata from Record API
      * @return {Object} the set's object, containing the requested window of the set's items
      */
     // TODO: pagination for sets with > 100 items
-    async get(id, params = {}, options = {}) {
+    async get(id, params = {}) {
       const defaults = {
         profile: 'standard'
       };
@@ -79,28 +77,7 @@ export default (context = {}) => {
 
       try {
         const response = await $axios.get(`/${setIdFromUri(id)}`, { params: paramsWithDefaults });
-        const set = response.data;
-
-        if (set.items) {
-          set.items = set.items.slice(0, 100);
-
-          if (options.withMinimalItems) {
-            const unpublishedItemDcTitleLangAware = { [context.i18n.locale]: [context.i18n.t('record.status.unpublished')] };
-
-            const minimalItems = await context.$apis.record.find(set.items, {
-              profile: 'minimal',
-              rows: 100
-            });
-
-            set.items = set.items.map(uri => {
-              const itemId = uri.replace(EUROPEANA_DATA_URL_ITEM_PREFIX, '');
-              return minimalItems.items.find(item => item.id === itemId) ||
-                { id: itemId, dcTitleLangAware: unpublishedItemDcTitleLangAware };
-            });
-          }
-        }
-
-        return set;
+        return response.data;
       } catch (error) {
         throw apiError(error, context);
       }

--- a/src/plugins/user-likes.client.js
+++ b/src/plugins/user-likes.client.js
@@ -1,5 +1,7 @@
 export default async({ $auth, store }) => {
   if ($auth?.loggedIn) {
+    // TODO: assess whether there is a more efficient way to do this with fewer
+    //       API requests
     await store.dispatch('set/setLikes');
     await store.dispatch('set/fetchLikes');
   }

--- a/src/store/set.js
+++ b/src/store/set.js
@@ -117,16 +117,16 @@ export default {
 
       const likes = await this.$apis.set.get(state.likesId, {
         pageSize: 100,
-        profile: 'standard'
-      }, { withMinimalItems: true });
+        profile: 'itemDescriptions'
+      });
       return commit('setLikedItems', likes.items || []);
     },
     async fetchActive({ commit }, setId) {
       try {
         const set = await this.$apis.set.get(setId, {
           pageSize: 100,
-          profile: 'standard'
-        }, { withMinimalItems: true });
+          profile: 'itemDescriptions'
+        });
         commit('setActive', set);
       } catch (error) {
         if (process.server && error.statusCode) {
@@ -166,8 +166,8 @@ export default {
       const creations = [].concat(state.creations);
 
       const set = await this.$apis.set.get(setId, {
-        profile: 'standard'
-      }, { withMinimalItems: true });
+        profile: 'itemDescriptions'
+      });
       creations[setToReplaceIndex] = set;
       commit('setCreations', creations);
     },
@@ -180,7 +180,7 @@ export default {
         qf: 'type:Collection'
       };
 
-      const searchResponse = await this.$apis.set.search(searchParams, { withMinimalItemPreviews: true });
+      const searchResponse = await this.$apis.set.search(searchParams);
       const sets = searchResponse.data.items || [];
       commit('setCreations', sets);
     },

--- a/tests/unit/plugins/europeana/set.spec.js
+++ b/tests/unit/plugins/europeana/set.spec.js
@@ -31,11 +31,6 @@ describe('@/plugins/europeana/set', () => {
         'http://data.europeana.eu/item/123/def'
       ]
     };
-    const recordSearchResponse = {
-      items: [
-        { id: '/123/abc', prefLabel: { en: ['ABC'] } }
-      ]
-    };
 
     it('gets the set data', async() => {
       nock(BASE_URL)
@@ -55,66 +50,6 @@ describe('@/plugins/europeana/set', () => {
 
       await plugin({ $config }).get(setId);
       expect(nock.isDone()).toBe(true);
-    });
-
-    describe('options', () => {
-      describe('withMinimalItems', () => {
-        const context = {
-          $config,
-          i18n: { locale: 'nl', t: key => key },
-          $apis: { record: { find: sinon.stub().resolves(recordSearchResponse) } }
-        };
-        beforeEach(() => {
-          nock(BASE_URL)
-            .get(`/${setId}`)
-            .query(true)
-            .reply(200, setGetResponse);
-        });
-
-        describe('when set to `true`', () => {
-          const options = { withMinimalItems: true };
-
-          it('requests 100 minimal profile items from the Record API', async() => {
-            await plugin(context).get(setId, {}, options);
-
-            expect(context.$apis.record.find.calledWith(setGetResponse.items, {
-              profile: 'minimal',
-              rows: 100
-            })).toBe(true);
-          });
-
-          it('stores the found items on the set', async() => {
-            const set = await plugin(context).get(setId, {}, options);
-
-            expect(set.items[0]).toEqual(recordSearchResponse.items[0]);
-          });
-
-          it('stores a dcTitleLangAware warning for items not found', async() => {
-            const set = await plugin(context).get(setId, {}, options);
-
-            expect(set.items[1]).toEqual({
-              id: '/123/def',
-              dcTitleLangAware: { nl: ['record.status.unpublished'] }
-            });
-          });
-        });
-
-        describe('when set to `false` (by default)', () => {
-          const options = {};
-
-          it('does not request items from the Record API', async() => {
-            await plugin(context).get(setId, {}, options);
-
-            expect(context.$apis.record.find.called).toBe(false);
-          });
-
-          it('leaves the item URIs on the set', async() => {
-            const set = await plugin(context).get(setId, {}, options);
-
-            expect(set.items).toEqual(setGetResponse.items);
-          });
-        });
-      });
     });
   });
 

--- a/tests/unit/store/set.spec.js
+++ b/tests/unit/store/set.spec.js
@@ -301,9 +301,9 @@ describe('store/set', () => {
         await store.actions.fetchActive({ commit }, setId);
 
         expect(store.actions.$apis.set.get.calledWith(setId, {
-          profile: 'standard',
+          profile: 'itemDescriptions',
           pageSize: 100
-        }, { withMinimalItems: true })).toBe(true);
+        })).toBe(true);
         expect(commit.calledWith('setActive', set)).toBe(true);
       });
       describe('when API request doesn\'t return a set', () => {
@@ -450,7 +450,7 @@ describe('store/set', () => {
           await store.actions.refreshCreation({ commit, state, dispatch }, setId);
 
           expect(store.actions.$apis.set.get.calledWith(setId, {
-            profile: 'standard'
+            profile: 'itemDescriptions'
           })).toBe(true);
           expect(commit.calledWith('setCreations', [newCreation])).toBe(true);
         });


### PR DESCRIPTION
But keep the optional feature to have set _searches_ then retrieve item previews from the Record API, as the Set API has no efficient equivalent, i.e. we wouldn't want a set search to retrieve itemDescriptions of all the sets' items.