### PR TITLE
chore: stories page launch clean up

### DIFF
--- a/src/features/toggles.js
+++ b/src/features/toggles.js
@@ -6,7 +6,6 @@ export default [
   { name: 'fieldBoosting' },
   { name: 'jiraServiceDeskFeedbackForm' },
   { name: 'newHomepage' },
-  { name: 'newStoriesPage' },
   { name: 'rejectEntityRecommendations' },
   { name: 'storiesPageAllTags' },
   { name: 'translatedItems' }

--- a/src/pages/stories/index.vue
+++ b/src/pages/stories/index.vue
@@ -1,7 +1,5 @@
 <template>
-  <div
-    v-if="$features.newStoriesPage"
-  >
+  <div>
     <b-container
       v-if="$fetchState.pending"
       data-qa="loading spinner container"
@@ -67,10 +65,6 @@
       />
     </div>
   </div>
-  <IndexPage
-    v-else
-    slug="stories"
-  />
 </template>
 
 <script>
@@ -90,7 +84,6 @@
       ContentCard,
       ContentHeader,
       LoadingSpinner,
-      IndexPage: () => import('../index'),
       CallToActionBanner: () => import('@/components/generic/CallToActionBanner'),
       PaginationNavInput
     },
@@ -104,12 +97,6 @@
         tags: [],
         total: 0,
         sections: [],
-        // TODO: following four properties required when rendering IndexPage as
-        //       a child component; remove when new stories page is launched.
-        browsePage: false,
-        staticPage: false,
-        page: {},
-        identifier: null,
         pageFetched: false
       };
     },

--- a/src/pages/stories/index.vue
+++ b/src/pages/stories/index.vue
@@ -90,7 +90,7 @@
 
     data() {
       return {
-        perPage: 18,
+        perPage: 24,
         selectedTags: [],
         filteredTags: null,
         stories: [],
@@ -102,9 +102,6 @@
     },
 
     async fetch() {
-      if (!this.$features.newStoriesPage) {
-        return;
-      }
       await Promise.all([
         this.fetchPage(),
         this.fetchStories()
@@ -146,9 +143,6 @@
     },
 
     mounted() {
-      if (!this.$features.newStoriesPage) {
-        return;
-      }
       this.fetchCategories();
     },
 

--- a/tests/unit/pages/stories/index.spec.js
+++ b/tests/unit/pages/stories/index.spec.js
@@ -127,7 +127,6 @@ const factory = ({ $features = {}, data = {}, $fetchState = {} } = {}) => shallo
       query: contentfulQueryStub
     },
     $features: {
-      newStoriesPage: true,
       ...$features
     },
     $fetchState,
@@ -180,7 +179,7 @@ describe('pages/stories/index', () => {
         expect(wrapper.vm.$contentful.query.calledWith('storiesBySysId', {
           locale: 'en-GB',
           preview: false,
-          limit: 18,
+          limit: 24,
           ids: sinon.match(['1tuVL9nnfMJzptXshe3Qw8', '796f5YKe4b1u8uXtizSBu0', '3KgVELZ48RKM4kbxJ0bYKi'])
         })).toBe(true);
       });
@@ -248,17 +247,6 @@ describe('pages/stories/index', () => {
 
           expect(alertMessage.exists()).toBe(true);
         });
-      });
-    });
-
-    describe('when new stories page is disabled', () => {
-      const $features = { newStoriesPage: false };
-      it('does not fetch content from Contentful', async() => {
-        const wrapper = factory({ $features });
-
-        await wrapper.vm.fetch();
-
-        expect(wrapper.vm.$contentful.query.called).toBe(false);
       });
     });
   });


### PR DESCRIPTION
i.e. remove feature toggle, so it's always enabled