### PR TITLE
fix: handle absent linked entries

### DIFF
--- a/src/components/related/RelatedCategoryTags.vue
+++ b/src/components/related/RelatedCategoryTags.vue
@@ -9,7 +9,7 @@
       <span class="icon-ic-tag" />
       <div>
         <b-badge
-          v-for="(tag, index) in tags"
+          v-for="(tag, index) in tags.filter((tag) => !!tag)"
           :key="index"
           variant="outline-light"
           :active="isActive(tag.identifier)"

--- a/src/pages/stories/index.vue
+++ b/src/pages/stories/index.vue
@@ -159,7 +159,7 @@
         };
         const pageResponse = await this.$contentful.query('storiesPage', pageVariables);
         const storiesPage = pageResponse.data.data.browsePageCollection.items[0];
-        this.sections = storiesPage.hasPartCollection.items;
+        this.sections = storiesPage?.hasPartCollection?.items || [];
         this.pageFetched = true;
       },
 
@@ -182,11 +182,11 @@
         // Filter by categories
         if (this.selectedTags.length > 0) {
           stories = stories.filter((story) => {
-            const storyTags = story.cats.items.map((cat) => cat.id);
+            const storyTags = story.cats.items.map((cat) => cat?.id);
             return this.selectedTags.every((tag) => storyTags.includes(tag));
           });
         }
-        this.filteredTags = uniq(stories.map((story) => story.cats.items.map((cat) => cat.id)).flat());
+        this.filteredTags = uniq(stories.map((story) => story.cats.items.filter((cat) => !!cat).map((cat) => cat.id)).flat());
 
         // Order by date published
         stories = stories.sort((a, b) => (new Date(b.date)).getTime() - (new Date(a.date)).getTime());

--- a/tests/unit/components/related/RelatedCategoryTags.spec.js
+++ b/tests/unit/components/related/RelatedCategoryTags.spec.js
@@ -52,6 +52,14 @@ describe('components/related/RelatedCategoryTags', () => {
         expect(badges.length).toBe(tags.length);
       });
 
+      it('excludes null tags', () => {
+        const wrapper = factory({ propsData: { tags: tags.concat([null]) } });
+
+        const badges = wrapper.findAll('b-badge-stub');
+
+        expect(badges.length).toBe(tags.length);
+      });
+
       describe('clicking the badge', () => {
         it('tracks selecting tag', () => {
           const wrapper = factory({ propsData: { tags } });

--- a/tests/unit/pages/stories/index.spec.js
+++ b/tests/unit/pages/stories/index.spec.js
@@ -42,7 +42,7 @@ const storiesMinimalContentfulResponse = {
     data: {
       blogPostingCollection: {
         items: [
-          { date: '2022-02-12T08:00:00.000+01:00', sys: { id: '796f5YKe4b1u8uXtizSBu0' }, cats: { items: [{ id: '3d' }] } }
+          { date: '2022-02-12T08:00:00.000+01:00', sys: { id: '796f5YKe4b1u8uXtizSBu0' }, cats: { items: [{ id: '3d' }, null] } }
         ]
       },
       exhibitionPageCollection: {


### PR DESCRIPTION
Fixes for:
1. Deleting a category content entry prevents the /stories page from loading if blog posts or exhibitions are linked to that category
2. Deleting a category content entry prevents any individual blog post or exhibition page from loading it if the respective entry linked to it
3. Archiving or deleting the stories browse page in CTF prevents the /stories page from loading