### PR TITLE
fix: status messages for adding filter options

### DIFF
--- a/packages/portal/src/components/search/SideFacetDropdown.vue
+++ b/packages/portal/src/components/search/SideFacetDropdown.vue
@@ -509,10 +509,10 @@
           removeTag(this.selectedOptions[0]);
         }
 
-        const selected = this.isRadio ? option : option.label;
-
-        addTag(selected);
+        addTag(option);
         this.searchFacet = '';
+
+        const selected = this.isRadio ? option : option.label;
 
         this.$emit('changed', this.name, this.isRadio ? selected : this.selected.concat(this.enquoteFacetFieldFilterValue(selected)));
       },


### PR DESCRIPTION
Status messages are read out by screen-readers on content changes so visually impaired users are noted of these changes on the page. When **adding** a filter option it reads out "[option name] removed". In this case the status messages are created by Bootstrap-Vue's form-tags component.
This PR fixes the status message by passing the selected option and not just the label. Then Bootstrap-Vue can compare the tags/options properly and create the correct status messages.