### PR TITLE
fix: store related collections

### DIFF
--- a/packages/portal/src/components/entity/EntityRelatedCollections.vue
+++ b/packages/portal/src/components/entity/EntityRelatedCollections.vue
@@ -7,6 +7,7 @@
       :title="$t('youMightAlsoLike')"
       :related-collections="relatedCollections"
       :entity-uris="entityUris"
+      data-qa="related collections"
       @fetched="handleRelatedCollectionsFetched"
     />
   </b-card>

--- a/packages/portal/src/components/entity/EntityRelatedCollections.vue
+++ b/packages/portal/src/components/entity/EntityRelatedCollections.vue
@@ -1,12 +1,15 @@
 <template>
-  <RelatedCollections
-    v-if="!$fetchState.pending"
-    :title="$t('youMightAlsoLike')"
-    :related-collections="relatedCollections"
-    :entity-uris="entityUris"
-    @show="$emit('show')"
-    @hide="$emit('hide')"
-  />
+  <b-card
+    v-if="relatedCollections.length > 0 || entityUris.length > 0"
+    class="text-left related-collections-card mb-4"
+  >
+    <RelatedCollections
+      :title="$t('youMightAlsoLike')"
+      :related-collections="relatedCollections"
+      :entity-uris="entityUris"
+      @fetched="handleRelatedCollectionsFetched"
+    />
+  </b-card>
 </template>
 
 <script>
@@ -94,6 +97,13 @@
     watch: {
       type: '$fetch',
       identifier: '$fetch'
+    },
+
+    methods: {
+      handleRelatedCollectionsFetched(relatedCollections) {
+        this.relatedCollections = relatedCollections;
+        this.$emit('fetched', relatedCollections);
+      }
     }
   };
 </script>

--- a/packages/portal/src/components/item/ItemPreviewCardGroup.vue
+++ b/packages/portal/src/components/item/ItemPreviewCardGroup.vue
@@ -25,15 +25,10 @@
           v-if="card === 'related'"
           :key="index"
         >
-          <b-card
-            v-show="showRelated"
-            class="text-left related-collections-card mb-4"
-          >
-            <slot
-              v-masonry-tile
-              name="related"
-            />
-          </b-card>
+          <slot
+            v-masonry-tile
+            name="related"
+          />
         </aside>
         <ItemPreviewCard
           v-else
@@ -69,19 +64,14 @@
     <template
       v-for="(card, index) in cards"
     >
-      <template
+      <aside
         v-if="card === 'related'"
+        :key="index"
       >
-        <b-card
-          v-show="showRelated"
-          :key="index"
-          class="text-left related-collections-card mb-4"
-        >
-          <slot
-            name="related"
-          />
-        </b-card>
-      </template>
+        <slot
+          name="related"
+        />
+      </aside>
       <ItemPreviewCard
         v-else
         :key="card.id"
@@ -130,10 +120,6 @@
         default: 'grid'
       },
       showPins: {
-        type: Boolean,
-        default: false
-      },
-      showRelated: {
         type: Boolean,
         default: false
       },
@@ -210,11 +196,9 @@
         return hit ? hit.selectors[0] : null;
       },
       redrawMasonry() {
-        if (typeof this.$redrawVueMasonry === 'function' && this.masonryActive) {
-          this.$nextTick(() => {
-            this.$redrawVueMasonry();
-          });
-        }
+        this.$nextTick(() => {
+          this.$redrawVueMasonry && this.$redrawVueMasonry();
+        });
       }
     }
   };

--- a/packages/portal/src/components/related/RelatedCollections.vue
+++ b/packages/portal/src/components/related/RelatedCollections.vue
@@ -84,6 +84,7 @@
       let entities = await this.$apis.entity.find(this.entityUris);
       entities = entities.map(entity => pick(entity, ['id', 'prefLabel', 'isShownBy', 'logo', 'type']));
       this.collections = await withEditorialContent(this, entities);
+      this.$emit('fetched', this.collections);
     },
 
     mounted() {
@@ -94,13 +95,8 @@
       this.draw();
     },
 
-    beforeDestroy() {
-      this.draw('hide');
-    },
-
     methods: {
-      draw(showOrHide) {
-        this.$emit(showOrHide || (this.collections.length > 0 ? 'show' : 'hide'));
+      draw() {
         this.$nextTick(() => {
           this.$redrawVueMasonry && this.$redrawVueMasonry();
         });

--- a/packages/portal/src/components/search/RelatedSection.vue
+++ b/packages/portal/src/components/search/RelatedSection.vue
@@ -1,12 +1,14 @@
 <template>
-  <RelatedCollections
-    v-if="!$fetchState.pending && (relatedCollections.length > 0)"
-    :title="$t('collectionsYouMightLike')"
-    :related-collections="relatedCollections"
-    :badge-variant="badgeVariant"
-    @show="$emit('show')"
-    @hide="$emit('hide')"
-  />
+  <b-card
+    v-if="relatedCollections.length > 0"
+    class="text-left related-collections-card mb-4"
+  >
+    <RelatedCollections
+      :title="$t('collectionsYouMightLike')"
+      :related-collections="relatedCollections"
+      badge-variant="secondary"
+    />
+  </b-card>
 </template>
 
 <script>
@@ -25,9 +27,9 @@
         type: String,
         default: null
       },
-      badgeVariant: {
-        type: String,
-        default: 'secondary'
+      overrides: {
+        type: Array,
+        default: null
       }
     },
 
@@ -37,11 +39,13 @@
       };
     },
 
-    fetch() {
-      return this.getSearchSuggestions(this.query)
-        .then(response => {
-          this.relatedCollections = response;
-        });
+    async fetch() {
+      if (this.overrides) {
+        this.relatedCollections = this.overrides;
+      } else if (this.query && this.query !== '') {
+        this.relatedCollections = await this.getSearchSuggestions(this.query);
+        this.$emit('fetched', this.relatedCollections);
+      }
     },
 
     watch: {

--- a/packages/portal/src/components/search/RelatedSection.vue
+++ b/packages/portal/src/components/search/RelatedSection.vue
@@ -54,9 +54,6 @@
 
     methods: {
       getSearchSuggestions(query) {
-        if (!query) {
-          return Promise.resolve([]);
-        }
         return this.$apis.entity.suggest(query, {
           language: this.$i18n.locale,
           rows: 4

--- a/packages/portal/src/components/search/SearchInterface.vue
+++ b/packages/portal/src/components/search/SearchInterface.vue
@@ -79,7 +79,6 @@
                           :hits="hits"
                           :view="view"
                           :show-pins="showPins"
-                          :show-related="showRelated"
                         >
                           <slot />
                           <template
@@ -166,10 +165,6 @@
       showPins: {
         type: Boolean,
         default: false
-      },
-      showRelated: {
-        type: Boolean,
-        default: true
       },
       editorialOverrides: {
         type: Object,

--- a/packages/portal/src/components/search/SearchInterface.vue
+++ b/packages/portal/src/components/search/SearchInterface.vue
@@ -266,7 +266,7 @@
       '$route.query.boost': '$fetch',
       '$route.query.reusability': '$fetch',
       '$route.query.query': '$fetch',
-      '$route.query.qf': '$fetch',
+      '$route.query.qf': 'watchRouteQueryQf',
       '$route.query.page': '$fetch'
     },
 
@@ -275,6 +275,23 @@
     },
 
     methods: {
+      watchRouteQueryQf(newVal, oldVal) {
+        // Coerce into arrays, handling undefined
+        const newVals = newVal ? [].concat(newVal) : [];
+        const oldVals = oldVal ? [].concat(oldVal) : [];
+
+        // Test that the values in the two arrays have in fact changed in their
+        // contents, as the watch gets triggered by other changes to the route
+        // which result in new array objects being constructed for qf, but having
+        // the same contents.
+        const addedVals = newVals.filter((val) => !oldVals.includes(val));
+        const removedVals = oldVals.filter((val) => !newVals.includes(val));
+        if (addedVals.length === 0 && removedVals.length === 0) {
+          return;
+        }
+
+        this.$fetch();
+      },
       viewFromRouteQuery() {
         if (this.routeQueryView) {
           this.view = this.routeQueryView;

--- a/packages/portal/src/pages/collections/_type/_.vue
+++ b/packages/portal/src/pages/collections/_type/_.vue
@@ -24,7 +24,6 @@
         :show-content-tier-toggle="false"
         :show-pins="userIsEntitiesEditor && userIsSetsEditor"
         :editorial-overrides="editorialOverrides"
-        :show-related="showRelated"
       >
         <EntityHeader
           v-if="entity"
@@ -49,10 +48,9 @@
             <EntityRelatedCollections
               :type="$route.params.type"
               :identifier="$route.params.pathMatch"
-              :overrides="relatedCollectionCards"
+              :overrides="relatedCollectionCards || relatedCollections"
               data-qa="related entities"
-              @show="showRelatedCollections"
-              @hide="hideRelatedCollections"
+              @fetched="handleEntityRelatedCollectionsFetched"
             />
           </client-only>
         </template>
@@ -126,8 +124,8 @@
       return {
         page: null,
         proxy: null,
-        showRelated: false,
-        themes: themes.map(theme => theme.id)
+        themes: themes.map(theme => theme.id),
+        relatedCollections: null
       };
     },
 
@@ -403,6 +401,9 @@
       }
     },
     methods: {
+      handleEntityRelatedCollectionsFetched(relatedCollections) {
+        this.relatedCollections = relatedCollections;
+      },
       storeSearchOverrides() {
         this.$store.commit('search/set', ['overrideParams', this.searchOverrides]);
       },
@@ -411,12 +412,6 @@
           values: [title],
           code: null
         };
-      },
-      showRelatedCollections() {
-        this.showRelated = true;
-      },
-      hideRelatedCollections() {
-        this.showRelated = false;
       },
       proxyUpdated() {
         this.$fetch();

--- a/packages/portal/src/pages/search/index.vue
+++ b/packages/portal/src/pages/search/index.vue
@@ -2,17 +2,16 @@
   <div data-qa="search page">
     <SearchInterface
       id="search-interface"
-      :show-related="showRelated"
     >
       <template
-        v-if="searchQuery"
+        v-if="!!searchQuery"
         #related
       >
         <client-only>
           <RelatedSection
             :query="searchQuery"
-            @show="showRelatedSection"
-            @hide="hideRelatedSection"
+            :overrides="relatedCollections"
+            @fetched="handleRelatedSectionFetched"
           />
         </client-only>
       </template>
@@ -56,7 +55,7 @@
 
     data() {
       return {
-        showRelated: false
+        relatedCollections: null
       };
     },
 
@@ -81,12 +80,8 @@
     },
 
     methods: {
-      showRelatedSection() {
-        this.showRelated = true;
-      },
-
-      hideRelatedSection() {
-        this.showRelated = false;
+      handleRelatedSectionFetched(relatedCollections) {
+        this.relatedCollections = relatedCollections;
       }
     }
   };

--- a/packages/portal/src/pages/search/index.vue
+++ b/packages/portal/src/pages/search/index.vue
@@ -11,12 +11,13 @@
           <RelatedSection
             :query="searchQuery"
             :overrides="relatedCollections"
+            data-qa="related section"
             @fetched="handleRelatedSectionFetched"
           />
         </client-only>
       </template>
       <template
-        v-if="searchQuery"
+        v-if="!!searchQuery"
         #after-results
       >
         <client-only>

--- a/packages/portal/tests/unit/components/entity/EntityRelatedCollections.spec.js
+++ b/packages/portal/tests/unit/components/entity/EntityRelatedCollections.spec.js
@@ -10,7 +10,7 @@ const factory = ({ propsData = {}, data = {}, responses } = {}) => {
   return shallowMountNuxt(EntityRelatedCollections, {
     localVue,
     propsData,
-    data: () => ( { ...data }),
+    data: () => ({ ...data }),
     mocks: {
       $apis: {
         record: { search: sinon.stub().resolves(responses?.record?.search || {}) }

--- a/packages/portal/tests/unit/components/entity/EntityRelatedCollections.spec.js
+++ b/packages/portal/tests/unit/components/entity/EntityRelatedCollections.spec.js
@@ -6,10 +6,11 @@ import EntityRelatedCollections from '@/components/entity/EntityRelatedCollectio
 
 const localVue = createLocalVue();
 
-const factory = ({ propsData, responses } = {}) => {
+const factory = ({ propsData = {}, data = {}, responses } = {}) => {
   return shallowMountNuxt(EntityRelatedCollections, {
     localVue,
     propsData,
+    data: () => ( { ...data }),
     mocks: {
       $apis: {
         record: { search: sinon.stub().resolves(responses?.record?.search || {}) }
@@ -112,6 +113,29 @@ describe('components/entity/EntityRelatedCollections', () => {
 
           expect(wrapper.vm.relatedCollections).toEqual([]);
         });
+      });
+    });
+  });
+
+  describe('methods', () => {
+    describe('handleRelatedCollectionsFetched', () => {
+      const propsData = {
+        type: 'topic',
+        identifier: '3012-fishing'
+      };
+      const data = { entityUris: ['http://data.europeana.eu/concept/48'] };
+      const relatedCollections = [{ id: 'http://data.europeana.eu/concept/48' }];
+
+      it('is triggered by fetched event on related collections component', () => {
+        const mocks = { handleRelatedCollectionsFetched: sinon.spy() };
+        const wrapper = factory({ propsData, data, mocks });
+
+        const relatedCollectionsComponent = wrapper.find('[data-qa="related collections"]');
+
+        relatedCollectionsComponent.vm.$emit('fetched', relatedCollections);
+
+        expect(wrapper.vm.relatedCollections).toEqual(relatedCollections);
+        expect(wrapper.emitted('fetched')[0][0]).toEqual(relatedCollections);
       });
     });
   });

--- a/packages/portal/tests/unit/components/entity/EntityRelatedCollections.spec.js
+++ b/packages/portal/tests/unit/components/entity/EntityRelatedCollections.spec.js
@@ -16,7 +16,8 @@ const factory = ({ propsData, responses } = {}) => {
       },
       $fetchState: {},
       $t: key => key
-    }
+    },
+    stubs: ['b-card']
   });
 };
 

--- a/packages/portal/tests/unit/components/related/RelatedCollections.spec.js
+++ b/packages/portal/tests/unit/components/related/RelatedCollections.spec.js
@@ -278,37 +278,8 @@ describe('components/related/RelatedCollections', () => {
     });
   });
 
-  describe('beforeDestroy', () => {
-    it('triggers `draw` to hide component', async() => {
-      const wrapper = factory();
-      wrapper.vm.draw = sinon.spy();
-
-      await wrapper.destroy();
-
-      expect(wrapper.vm.draw.calledWith('hide')).toBe(true);
-    });
-  });
-
   describe('methods', () => {
     describe('draw', () => {
-      it('emits "show" when relatedCollections has members', async() => {
-        const wrapper = factory({ propsData: { relatedCollections } });
-
-        await wrapper.vm.draw();
-
-        expect(wrapper.emitted('show').length).toBeGreaterThanOrEqual(1);
-        expect(wrapper.emitted('hide')).toBe(undefined);
-      });
-
-      it('emits "hide" when relatedCollections is blank', async() => {
-        const wrapper = factory({ propsData: { relatedCollections: [] } });
-
-        await wrapper.vm.draw();
-
-        expect(wrapper.emitted('hide').length).toBeGreaterThanOrEqual(1);
-        expect(wrapper.emitted('show')).toBe(undefined);
-      });
-
       it('redraws Masonry', async() => {
         const wrapper = factory({ propsData: { relatedCollections } });
         wrapper.vm.$redrawVueMasonry = sinon.spy();

--- a/packages/portal/tests/unit/components/search/RelatedSection.spec.js
+++ b/packages/portal/tests/unit/components/search/RelatedSection.spec.js
@@ -74,7 +74,7 @@ describe('components/search/RelatedSection', () => {
 
         await wrapper.vm.fetch();
 
-        expect(wrapper.emitted('fetched')).not.toBeDefined;
+        expect(wrapper.emitted('fetched')).toBeUndefined();
       });
     });
 

--- a/packages/portal/tests/unit/components/search/RelatedSection.spec.js
+++ b/packages/portal/tests/unit/components/search/RelatedSection.spec.js
@@ -42,7 +42,8 @@ const factory = (options = {}) => {
           }
         }
       }
-    }
+    },
+    stubs: ['b-card']
   });
 };
 

--- a/packages/portal/tests/unit/components/search/RelatedSection.spec.js
+++ b/packages/portal/tests/unit/components/search/RelatedSection.spec.js
@@ -49,13 +49,42 @@ const factory = (options = {}) => {
 
 describe('components/search/RelatedSection', () => {
   describe('fetch', () => {
+    describe('with overrides', () => {
+      const overrides = relatedCollections;
+      const propsData = { overrides };
+
+      it('stores them as relatedCollections', async() => {
+        const wrapper = factory({ propsData });
+
+        await wrapper.vm.fetch();
+
+        expect(wrapper.vm.relatedCollections).toEqual(relatedCollections);
+      });
+
+      it('does not query the Entity API', async() => {
+        const wrapper = factory({ propsData });
+
+        await wrapper.vm.fetch();
+
+        expect(wrapper.vm.$apis.entity.suggest.called).toBe(false);
+      });
+
+      it('does not emit fetched event', async() => {
+        const wrapper = factory({ propsData });
+
+        await wrapper.vm.fetch();
+
+        expect(wrapper.emitted('fetched')).not.toBeDefined;
+      });
+    });
+
     describe('with a query', () => {
       const propsData = { query: 'art' };
 
-      it('queries the Entity API for suggestions via $apis plugin', () => {
+      it('queries the Entity API for suggestions via $apis plugin', async() => {
         const wrapper = factory({ propsData });
 
-        wrapper.vm.fetch();
+        await wrapper.vm.fetch();
 
         expect(wrapper.vm.$apis.entity.suggest.calledWith(propsData.query, {
           language: wrapper.vm.$i18n.locale,
@@ -67,9 +96,18 @@ describe('components/search/RelatedSection', () => {
         const wrapper = factory({ propsData });
 
         await wrapper.vm.fetch();
+
         const expectedRelated = relatedCollections;
         expectedRelated[3].prefLabel = { en: 'Manuscripts' };
         expect(wrapper.vm.relatedCollections).toEqual(expectedRelated);
+      });
+
+      it('emits fetched event with response', async() => {
+        const wrapper = factory({ propsData });
+
+        await wrapper.vm.fetch();
+
+        expect(wrapper.emitted('fetched')[0][0]).toEqual(relatedCollections);
       });
     });
 

--- a/packages/portal/tests/unit/components/search/SearchInterface.spec.js
+++ b/packages/portal/tests/unit/components/search/SearchInterface.spec.js
@@ -268,6 +268,98 @@ describe('components/search/SearchInterface', () => {
   });
 
   describe('methods', () => {
+    describe('watchRouteQueryQf', () => {
+      describe('when values have been added', () => {
+        describe('and old value was `undefined`', () => {
+          const oldVal = undefined;
+          const newVal = 'TYPE:"TEXT"';
+
+          it('triggers $fetch', () => {
+            const wrapper = factory();
+            sinon.spy(wrapper.vm, '$fetch');
+
+            wrapper.vm.watchRouteQueryQf(newVal, oldVal);
+
+            expect(wrapper.vm.$fetch.called).toBe(true);
+          });
+        });
+
+        describe('and old value was present', () => {
+          const oldVal = 'TYPE:"TEXT"';
+          const newVal = ['TYPE:"TEXT"', 'TYPE:"IMAGE"'];
+
+          it('triggers $fetch', () => {
+            const wrapper = factory();
+            sinon.spy(wrapper.vm, '$fetch');
+
+            wrapper.vm.watchRouteQueryQf(newVal, oldVal);
+
+            expect(wrapper.vm.$fetch.called).toBe(true);
+          });
+        });
+      });
+
+      describe('when values have been removed', () => {
+        describe('and new value is `undefined`', () => {
+          const oldVal = 'TYPE:"TEXT"';
+          const newVal = undefined;
+
+          it('triggers $fetch', () => {
+            const wrapper = factory();
+            sinon.spy(wrapper.vm, '$fetch');
+
+            wrapper.vm.watchRouteQueryQf(newVal, oldVal);
+
+            expect(wrapper.vm.$fetch.called).toBe(true);
+          });
+        });
+
+        describe('and new value is present', () => {
+          const oldVal = ['TYPE:"TEXT"', 'TYPE:"IMAGE"'];
+          const newVal = 'TYPE:"TEXT"';
+
+          it('triggers $fetch', () => {
+            const wrapper = factory();
+            sinon.spy(wrapper.vm, '$fetch');
+
+            wrapper.vm.watchRouteQueryQf(newVal, oldVal);
+
+            expect(wrapper.vm.$fetch.called).toBe(true);
+          });
+        });
+      });
+
+      describe('when values have not changed', () => {
+        describe('and both are `undefined`', () => {
+          const oldVal = undefined;
+          const newVal = undefined;
+
+          it('does not trigger $fetch', () => {
+            const wrapper = factory();
+            sinon.spy(wrapper.vm, '$fetch');
+
+            wrapper.vm.watchRouteQueryQf(newVal, oldVal);
+
+            expect(wrapper.vm.$fetch.called).toBe(false);
+          });
+        });
+
+        describe('and both are present', () => {
+          const oldVal = ['TYPE:"TEXT"', 'TYPE:"IMAGE"'];
+          const newVal = ['TYPE:"TEXT"', 'TYPE:"IMAGE"'];
+
+          it('does not trigger $fetch', () => {
+            const wrapper = factory();
+            sinon.spy(wrapper.vm, '$fetch');
+
+            wrapper.vm.watchRouteQueryQf(newVal, oldVal);
+
+            expect(wrapper.vm.$fetch.called).toBe(false);
+          });
+        });
+      });
+    });
+
     describe('viewFromRouteQuery', () => {
       describe('with view in route query', () => {
         const route = { query: { view: 'mosaic', query: 'sport' } };

--- a/packages/portal/tests/unit/pages/collections/_type/_.spec.js
+++ b/packages/portal/tests/unit/pages/collections/_type/_.spec.js
@@ -524,26 +524,6 @@ describe('pages/collections/_type/_', () => {
   });
 
   describe('methods', () => {
-    describe('showRelatedCollections()', () => {
-      it('sets showRelated to true', async() => {
-        const wrapper = factory(topicEntity);
-
-        await wrapper.vm.showRelatedCollections();
-
-        expect(wrapper.vm.showRelated).toBe(true);
-      });
-    });
-
-    describe('hideRelatedCollections()', () => {
-      it('sets showRelated to true', async() => {
-        const wrapper = factory(topicEntity);
-
-        await wrapper.vm.hideRelatedCollections();
-
-        expect(wrapper.vm.showRelated).toBe(false);
-      });
-    });
-
     describe('proxyUpdated', () => {
       it('triggers $fetch', () => {
         const wrapper = factory(topicEntity);

--- a/packages/portal/tests/unit/pages/collections/_type/_.spec.js
+++ b/packages/portal/tests/unit/pages/collections/_type/_.spec.js
@@ -125,7 +125,7 @@ const factory = (options = {}) => shallowMountNuxt(collection, {
     'SearchInterface': {
       template: '<div><slot /><slot name="related" /><slot name="after-results" /></div>'
     }
-  },
+  }
 });
 
 describe('pages/collections/_type/_', () => {

--- a/packages/portal/tests/unit/pages/collections/_type/_.spec.js
+++ b/packages/portal/tests/unit/pages/collections/_type/_.spec.js
@@ -118,7 +118,14 @@ const factory = (options = {}) => shallowMountNuxt(collection, {
       commit: sinon.spy()
     },
     ...options.mocks
-  }
+  },
+  stubs: {
+    'client-only': true,
+    'EntityRelatedCollections': true,
+    'SearchInterface': {
+      template: '<div><slot /><slot name="related" /><slot name="after-results" /></div>'
+    }
+  },
 });
 
 describe('pages/collections/_type/_', () => {
@@ -532,6 +539,18 @@ describe('pages/collections/_type/_', () => {
         wrapper.vm.proxyUpdated();
 
         expect(wrapper.vm.$fetch.called).toBe(true);
+      });
+    });
+
+    describe('handleEntityRelatedCollectionsFetched', () => {
+      it('is triggered by fetched event on related entities component', () => {
+        const wrapper = factory(topicEntity);
+        const relatedCollections = [{ id: 'http://data.europeana.eu/concept/3012' }];
+
+        const relatedEntitiesComponent = wrapper.find('[data-qa="related entities"]');
+        relatedEntitiesComponent.vm.$emit('fetched', relatedCollections);
+
+        expect(wrapper.vm.relatedCollections).toEqual(relatedCollections);
       });
     });
   });

--- a/packages/portal/tests/unit/pages/search/index.spec.js
+++ b/packages/portal/tests/unit/pages/search/index.spec.js
@@ -42,7 +42,13 @@ const store = new Vuex.Store({
 
 const factory = (query) => shallowMountNuxt(page, {
   localVue,
-  stubs: ['client-only'],
+  stubs: {
+    'client-only': true,
+    'RelatedSection': true,
+    'SearchInterface': {
+      template: '<div><slot name="related" /><slot name="after-results" /></div>'
+    }
+  },
   mocks: {
     $features: {},
     $pageHeadTitle: key => key,
@@ -120,6 +126,20 @@ describe('pages/item/_.vue', () => {
 
       expect(setShowSearchBar.calledWith(false)).toBe(true);
       expect(next.called).toBe(true);
+    });
+  });
+
+  describe('methods', () => {
+    describe('handleRelatedSectionFetched', () => {
+      it('is triggered by fetched event on related section component', () => {
+        const wrapper = factory('fish');
+        const relatedCollections = [{ id: 'http://data.europeana.eu/concept/3012' }];
+
+        const relatedSectionComponent = wrapper.find('[data-qa="related section"]');
+        relatedSectionComponent.vm.$emit('fetched', relatedCollections);
+
+        expect(wrapper.vm.relatedCollections).toEqual(relatedCollections);
+      });
     });
   });
 });

--- a/packages/portal/tests/unit/pages/search/index.spec.js
+++ b/packages/portal/tests/unit/pages/search/index.spec.js
@@ -87,28 +87,6 @@ describe('pages/item/_.vue', () => {
     });
   });
 
-  describe('methods', () => {
-    describe('showRelatedSection()', () => {
-      it('sets showRelated to true', async() => {
-        const wrapper = factory();
-
-        await wrapper.vm.showRelatedSection();
-
-        expect(wrapper.vm.showRelated).toBe(true);
-      });
-    });
-
-    describe('hideRelatedSection()', () => {
-      it('sets showRelated to true', async() => {
-        const wrapper = factory();
-
-        await wrapper.vm.hideRelatedSection();
-
-        expect(wrapper.vm.showRelated).toBe(false);
-      });
-    });
-  });
-
   describe('head()', () => {
     describe('with no query', () => {
       it('is only "search"', async() => {


### PR DESCRIPTION
To prevent repeating API requests.

* Make search/RelatedSection and entity/EntityRelatedCollections components emit the data they retrieve for related collections, and have the parent view store it then pass it back to those components as a prop, so that if those components need to be re-rendered, the data does not need to be re-fetched from APIs
* Refactor (and simplify) the logic for showing/hiding those components in the `related` slot of the item/ItemPreviewCardGroup component, to make the Masonry display more stable