### PR TITLE
refactor: add userHasClientRole helper to $auth

### DIFF
--- a/packages/portal/src/components/item/ItemHero.vue
+++ b/packages/portal/src/components/item/ItemHero.vue
@@ -160,15 +160,13 @@
         return this.rightsStatement && !this.rightsStatement.includes('/InC/') && !this.selectedMedia.isShownAt;
       },
       showPins() {
-        return this.userIsEditor && this.userIsSetsEditor && this.entities.length > 0;
+        return this.userIsEntitiesEditor && this.userIsSetsEditor && this.entities.length > 0;
       },
-      userIsEditor() {
-        // TODO: check if this can be abstracted, it's the same as in  src/pages/collections/_type/_.vue
-        return this.$store.state.auth.user?.resource_access?.entities?.roles?.includes('editor') || false;
+      userIsEntitiesEditor() {
+        return this.$auth.userHasClientRole('entities', 'editor');
       },
       userIsSetsEditor() {
-        // TODO: check if theis can be abstracted, it's the same as in  src/pages/collections/_type/_.vue
-        return this.$store.state.auth.user?.resource_access?.usersets?.roles.includes('editor') || false;
+        return this.$auth.userHasClientRole('usersets', 'editor');
       }
     },
     mounted() {

--- a/packages/portal/src/pages/account/index.vue
+++ b/packages/portal/src/pages/account/index.vue
@@ -200,8 +200,8 @@
         };
       },
       userIsEditor() {
-        return this.loggedInUser?.resource_access?.entities?.roles?.includes('editor') &&
-          this.loggedInUser?.resource_access?.usersets?.roles?.includes('editor');
+        return this.$auth.userHasClientRole('entities', 'editor') &&
+          this.$auth.userHasClientRole('usersets', 'editor');
       },
       ...mapState({
         likesId: state => state.set.likesId,

--- a/packages/portal/src/pages/collections/_type/_.vue
+++ b/packages/portal/src/pages/collections/_type/_.vue
@@ -297,10 +297,10 @@
           ['topic', 'organisation'].includes(this.collectionType);
       },
       userIsEntitiesEditor() {
-        return this.$auth?.user?.resource_access?.entities?.roles.includes('editor') || false;
+        return this.$auth.userHasClientRole('entities', 'editor');
       },
       userIsSetsEditor() {
-        return this.$auth?.user?.resource_access?.usersets?.roles.includes('editor') || false;
+        return this.$auth.userHasClientRole('usersets', 'editor');
       },
       route() {
         return {

--- a/packages/portal/src/pages/galleries/_.vue
+++ b/packages/portal/src/pages/galleries/_.vue
@@ -296,15 +296,11 @@
           this.setCreatorId.endsWith(`/${this.$store.state.auth.user.sub}`);
       },
       userIsEntityEditor() {
-        const user = this.$store.state.auth.user;
-        const entitiesEditor = user?.resource_access?.entities?.roles?.includes('editor');
-        const usersetsEditor = user?.resource_access?.usersets?.roles?.includes('editor');
-        return entitiesEditor && usersetsEditor;
+        return this.$auth.userHasClientRole('entities', 'editor') &&
+          this.$auth.userHasClientRole('usersets', 'editor');
       },
       userIsPublisher() {
-        const user = this.$store.state.auth.user;
-        const publisher = user?.resource_access?.usersets?.roles?.includes('publisher');
-        return !!publisher;
+        return this.$auth.userHasClientRole('usersets', 'publisher');
       },
       userCanEdit() {
         return this.userIsOwner || (this.setIsEntityBestItems && this.userIsEntityEditor);

--- a/packages/portal/src/pages/set/_.vue
+++ b/packages/portal/src/pages/set/_.vue
@@ -249,10 +249,8 @@
           this.setCreatorId.endsWith(`/${this.$store.state.auth.user.sub}`);
       },
       userIsEntityEditor() {
-        const user = this.$store.state.auth.user;
-        const entitiesEditor = user?.resource_access?.entities?.roles?.includes('editor');
-        const usersetsEditor = user?.resource_access?.usersets?.roles?.includes('editor');
-        return entitiesEditor && usersetsEditor;
+        return this.$auth.userHasClientRole('entities', 'editor') &&
+          this.$auth.userHasClientRole('usersets', 'editor');
       },
       userCanEdit() {
         return this.userIsOwner || (this.setIsEntityBestItems && this.userIsEntityEditor);

--- a/packages/portal/src/plugins/authScheme.js
+++ b/packages/portal/src/plugins/authScheme.js
@@ -3,25 +3,34 @@
 // TODO: delete once auth module supports Nuxt runtime config
 // @see https://github.com/nuxt-community/auth-module/issues/713
 
-// This auth plugin will end up in .nuxt/auth/schemes, as will oauth2.js if it's
-// also a registered strategy in the module config.
+// When Nuxt is built, this custom auth plugin will end up in .nuxt/auth/schemes,
+// as will @nuxtjs/auth/lib/schemes/oauth2.js if it's also a registered strategy
+// in the auth module config (in nuxt.config.js).
 import Oauth2Scheme from './oauth2';
 
 const keycloakOpenIDConnectEndpoint = (method, { realm, origin }) =>
   `${origin}/auth/realms/${realm}/protocol/openid-connect/${method}`;
+
+export function userHasClientRole(client, role) {
+  return this.user?.resource_access?.[client]?.roles?.includes(role) || false;
+}
 
 // Inspired by https://github.com/nuxt-community/auth-module/issues/713#issuecomment-724031930
 export default class RuntimeConfigurableOauth2Scheme extends Oauth2Scheme {
   constructor($auth, options) {
     const configOptions = {
       ...options,
-      ...$auth.ctx.$config.auth.strategies[options['_name']]
+      ...$auth.ctx?.$config?.auth?.strategies[options['_name']]
     };
 
     configOptions['authorization_endpoint'] = keycloakOpenIDConnectEndpoint('auth', configOptions);
     configOptions['access_token_endpoint'] = keycloakOpenIDConnectEndpoint('token', configOptions);
     configOptions['userinfo_endpoint'] = keycloakOpenIDConnectEndpoint('userinfo', configOptions);
     configOptions['end_session_endpoint'] = keycloakOpenIDConnectEndpoint('logout', configOptions);
+
+    if (typeof $auth.userHasClientRole !== 'function') {
+      $auth.userHasClientRole = userHasClientRole;
+    }
 
     super($auth, configOptions);
   }

--- a/packages/portal/src/plugins/oauth2.js
+++ b/packages/portal/src/plugins/oauth2.js
@@ -1,4 +1,5 @@
-// Dummy class to support testing of ./authScheme.js
 export default class Oauth2Scheme {
-  constructor() {}
+  constructor() {
+    // Dummy class to support testing of ./authScheme.js
+  }
 }

--- a/packages/portal/src/plugins/oauth2.js
+++ b/packages/portal/src/plugins/oauth2.js
@@ -1,0 +1,4 @@
+// Dummy class to support testing of ./authScheme.js
+export default class Oauth2Scheme {
+  constructor() {}
+}

--- a/packages/portal/tests/unit/components/item/ItemHero.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemHero.spec.js
@@ -17,15 +17,13 @@ const factory = (propsData, options = {}) => mount(ItemHero, {
     $t: (key) => key,
     $i18n: { locale: 'en' },
     $features: { itemEmbedCode: false },
-    $auth: { loggedIn: true },
+    $auth: {
+      loggedIn: true,
+      userHasClientRole: options.userHasClientRoleStub || sinon.stub().returns(false)
+    },
     $store: options.store || {
       state: {
-        set: { ...{ liked: [] }, ...{} },
-        auth: {
-          user: {
-            'resource_access': null
-          }
-        }
+        set: { ...{ liked: [] }, ...{} }
       },
       getters: {
         'set/isLiked': storeIsLikedGetter,
@@ -188,25 +186,12 @@ describe('components/item/ItemHero', () => {
 
   describe('showPins', () => {
     describe('when the user is an editor', () => {
-      const store = {
-        state: {
-          set: { ...{ liked: [] }, ...{} },
-          auth: {
-            user: {
-              'resource_access': {
-                entities: {
-                  roles: ['editor']
-                },
-                usersets: {
-                  roles: ['editor']
-                }
-              }
-            }
-          }
-        }
-      };
+      const userHasClientRoleStub = sinon.stub().returns(false)
+        .withArgs('entities', 'editor').returns(true)
+        .withArgs('usersets', 'editor').returns(true);
+
       it('is `true`', () => {
-        const wrapper = factory({ media, identifier, entities }, { store });
+        const wrapper = factory({ media, identifier, entities }, { userHasClientRoleStub });
 
         const showPins = wrapper.vm.showPins;
 
@@ -214,7 +199,7 @@ describe('components/item/ItemHero', () => {
       });
 
       it('is `false` if no entities', () => {
-        const wrapper = factory({ media, identifier, entities: [] }, { store });
+        const wrapper = factory({ media, identifier, entities: [] }, { userHasClientRoleStub });
 
         const showPins = wrapper.vm.showPins;
 

--- a/packages/portal/tests/unit/pages/account/index.spec.js
+++ b/packages/portal/tests/unit/pages/account/index.spec.js
@@ -10,25 +10,27 @@ localVue.use(BootstrapVue);
 
 const storeDispatch = sinon.stub().resolves({});
 
-const defaultOptions = {
-  fetchState: {},
-  hash: ''
-};
-
-const factory = (options = defaultOptions) => shallowMountNuxt(page, {
+const factory = (options = {}) => shallowMountNuxt(page, {
   localVue,
   stubs: ['client-only'],
   mocks: {
     $t: key => key,
-    $auth: { strategy: { options: {
-      origin: 'https://auth.example.eu', realm: 'europeana', 'client_id': 'portal.js'
-    } } },
+    $auth: {
+      userHasClientRole: options.userHasClientRoleStub || sinon.stub().returns(false),
+      strategy: {
+        options: {
+          origin: 'https://auth.example.eu',
+          realm: 'europeana',
+          'client_id': 'portal.js'
+        }
+      }
+    },
     $config: { app: { baseUrl: 'https://www.example.eu' } },
     $features: {},
-    $fetchState: options.fetchState,
+    $fetchState: options.fetchState || {},
     $path: (path) => path,
     $route: {
-      hash: options.hash
+      hash: options.hash || ''
     },
     $store: {
       dispatch: storeDispatch,
@@ -66,37 +68,35 @@ describe('pages/account/index.vue', () => {
   });
 
   describe('when the user has the editor role', () => {
-    const wrapper = factory({
-      ...defaultOptions,
-      user: {
-        'resource_access': { entities: { roles: ['editor'] },
-          usersets: { roles: 'editor' } }
-      }
-    });
+    const userHasClientRoleStub = sinon.stub().returns(false)
+      .withArgs('entities', 'editor').returns(true)
+      .withArgs('usersets', 'editor').returns(true);
 
     it('fetches the user\'s curated collections', async() => {
+      const wrapper = factory({ userHasClientRoleStub });
+
       await wrapper.vm.fetch();
 
       expect(wrapper.vm.$store.dispatch.calledWith('set/fetchCurations')).toBe(true);
     });
 
     it('shows the curated collections in the tab navigation', () => {
+      const wrapper = factory({ userHasClientRoleStub });
+
       const curatedCollectionsTab = wrapper.find('[data-qa="curated collections"]');
+
       expect(curatedCollectionsTab.exists()).toBe(true);
     });
 
     describe('when visiting the curated collections', () => {
-      const wrapper = factory({
-        ...defaultOptions,
-        hash: '#curated-collections',
-        user: {
-          'resource_access': { entities: { roles: ['editor'] },
-            usersets: { roles: 'editor' } }
-        }
-      });
-
       it('shows the curated collections', () => {
+        const wrapper = factory({
+          hash: '#curated-collections',
+          userHasClientRoleStub
+        });
+
         const publicGalleries = wrapper.find('[data-qa="curated sets"]');
+
         expect(publicGalleries.exists()).toBe(true);
       });
     });
@@ -104,7 +104,6 @@ describe('pages/account/index.vue', () => {
 
   describe('when visiting the likes collection', () => {
     const wrapper = factory({
-      ...defaultOptions,
       hash: '#likes'
     });
 
@@ -116,7 +115,6 @@ describe('pages/account/index.vue', () => {
 
   describe('when visiting the public galleries', () => {
     const wrapper = factory({
-      ...defaultOptions,
       hash: '#public-galleries'
     });
 
@@ -128,7 +126,6 @@ describe('pages/account/index.vue', () => {
 
   describe('when visiting the private galleries', () => {
     const wrapper = factory({
-      ...defaultOptions,
       hash: '#private-galleries'
     });
 

--- a/packages/portal/tests/unit/pages/collections/_type/_.spec.js
+++ b/packages/portal/tests/unit/pages/collections/_type/_.spec.js
@@ -81,7 +81,9 @@ const redirectToPrefPathStub = sinon.stub();
 const factory = (options = {}) => shallowMountNuxt(collection, {
   localVue,
   mocks: {
-    $features: {},
+    $auth: {
+      userHasClientRole: options.userHasClientRoleStub || sinon.stub().returns(false)
+    },
     $fetchState: {},
     $t: (key, args) => args ? `${key} ${args}` : key,
     $route: { query: options.query || '', params: { type: options.type, pathMatch: options.pathMatch } },
@@ -233,10 +235,8 @@ describe('pages/collections/_type/_', () => {
     describe('editable', () => {
       const editableOptions = {
         ...organisationEntity,
-        mocks: {
-          $features: { entityManagement: true },
-          $auth: { user: { 'resource_access': { entities: { roles: ['editor'] } } } }
-        }
+        userHasClientRoleStub: sinon.stub().returns(false)
+          .withArgs('entities', 'editor').returns(true)
       };
 
       it('is truthy if all criteria are met', () => {
@@ -245,19 +245,6 @@ describe('pages/collections/_type/_', () => {
         const editable = wrapper.vm.editable;
 
         expect(editable).toBeTruthy();
-      });
-
-      it('is falsy if entityManagement feature is disabled', () => {
-        const wrapper = factory({
-          ...editableOptions,
-          mocks: {
-            $features: { entityManagement: false }
-          }
-        });
-
-        const editable = wrapper.vm.editable;
-
-        expect(editable).toBeFalsy();
       });
 
       it('is falsy if entity is absent', () => {
@@ -274,9 +261,7 @@ describe('pages/collections/_type/_', () => {
       it('is falsy if user is unauthorized', () => {
         const wrapper = factory({
           ...editableOptions,
-          mocks: {
-            $auth: { user: { 'resource_access': { entities: { roles: [] } } } }
-          }
+          userHasClientRoleStub: sinon.stub().returns(false)
         });
 
         const editable = wrapper.vm.editable;

--- a/packages/portal/tests/unit/pages/set/_.spec.js
+++ b/packages/portal/tests/unit/pages/set/_.spec.js
@@ -36,16 +36,6 @@ const testSet2 = {
 
 const testSetCreator = { loggedIn: true, user: { sub: '0123' } };
 
-const entityEditor = {
-  loggedIn: true,
-  user: {
-    'resource_access': {
-      entities: { roles: ['editor'] },
-      usersets: { roles: ['editor'] }
-    }
-  }
-};
-
 const defaultOptions = {
   set: testSet1,
   user: { loggedIn: false },
@@ -60,7 +50,8 @@ const factory = (options = {}) => shallowMountNuxt(page, {
     $tc: key => key,
     $i18n,
     $auth: {
-      loggedIn: true
+      loggedIn: true,
+      userHasClientRole: options.userHasClientRoleStub || sinon.stub().returns(false)
     },
     $fetchState: options.fetchState || {},
     $route: {
@@ -207,18 +198,31 @@ describe('SetPage', () => {
 
     describe('when user is entity editor and set is a curated collection', () => {
       const testSetEntityBestItems = { ...testSet1, type: 'EntityBestItemsSet' };
-      const wrapper = factory({ set: testSetEntityBestItems, user: entityEditor });
+      const userHasClientRoleStub = sinon.stub().returns(false)
+        .withArgs('entities', 'editor').returns(true)
+        .withArgs('usersets', 'editor').returns(true);
 
       it('gets the pinned items', async() => {
+        const wrapper = factory({
+          set: testSetEntityBestItems,
+          user: { loggedIn: true },
+          userHasClientRoleStub
+        });
+
         await wrapper.vm.fetch();
 
         expect(storeDispatch.calledWith('entity/getPins')).toBe(true);
       });
 
       describe('when accept entity recommendations is enabled', () => {
-        const wrapper = factory({ set: testSetEntityBestItems, user: entityEditor, features: { acceptEntityRecommendations: true } });
-
         it('renders the recommendations', () => {
+          const wrapper = factory({
+            set: testSetEntityBestItems,
+            user: { loggedIn: true },
+            userHasClientRoleStub,
+            features: { acceptEntityRecommendations: true }
+          });
+
           const recommendations = wrapper.find('setrecommendations-stub');
 
           expect(recommendations.exists()).toBe(true);

--- a/packages/portal/tests/unit/plugins/authScheme.spec.js
+++ b/packages/portal/tests/unit/plugins/authScheme.spec.js
@@ -1,0 +1,106 @@
+import sinon from 'sinon';
+import * as plugin from '@/plugins/authScheme';
+
+let defaultExportPrototype;
+const defaultExportPrototypeStub = sinon.stub().callsFake();
+
+describe('plugins/authScheme', () => {
+  describe('default', () => {
+    beforeAll(() => {
+      defaultExportPrototype = Object.getPrototypeOf(plugin.default);
+      Object.setPrototypeOf(plugin.default, defaultExportPrototypeStub);
+    });
+
+    afterAll(() => {
+      Object.setPrototypeOf(plugin.default, defaultExportPrototype);
+    });
+
+    describe('constructor', () => {
+      const strategy = 'keycloak';
+      const origin = 'https://auth.europeana.eu';
+      const realm = 'europeana';
+      const options = {
+        '_name': strategy
+      };
+      const runtimeConfig = {
+        auth: {
+          strategies: {
+            [strategy]: {
+              origin,
+              realm
+            }
+          }
+        }
+      };
+      const $auth = {
+        ctx: {
+          $config: runtimeConfig
+        }
+      };
+
+      it('calls the super class constructor with options including from runtime config', () => {
+        const expectedOptions = {
+          '_name': strategy,
+          origin,
+          realm,
+          'authorization_endpoint': `${origin}/auth/realms/${realm}/protocol/openid-connect/auth`,
+          'access_token_endpoint': `${origin}/auth/realms/${realm}/protocol/openid-connect/token`,
+          'userinfo_endpoint': `${origin}/auth/realms/${realm}/protocol/openid-connect/userinfo`,
+          'end_session_endpoint': `${origin}/auth/realms/${realm}/protocol/openid-connect/logout`
+        };
+
+        new plugin.default($auth, options);
+
+        expect(defaultExportPrototypeStub.calledWith($auth, expectedOptions)).toBe(true);
+      });
+
+      it('decorates $auth with userHasClientRole helper', () => {
+        new plugin.default($auth, options);
+
+        expect(typeof $auth.userHasClientRole).toBe('function');
+      });
+    });
+  });
+
+  describe('userHasClientRole', () => {
+    it('is `false` if no user', () => {
+      const auth = { user: undefined };
+
+      const userHasClientRole = plugin.userHasClientRole.call(auth, 'entities', 'editor');
+
+      expect(userHasClientRole).toBe(false);
+    });
+
+    it('is `false` if user has no resource access', () => {
+      const auth = { user: { 'resource_access': undefined } };
+
+      const userHasClientRole = plugin.userHasClientRole.call(auth, 'entities', 'editor');
+
+      expect(userHasClientRole).toBe(false);
+    });
+
+    it('is `false` if user does not have specified client resource access', () => {
+      const auth = { user: { 'resource_access': { usersets: { roles: ['editor'] } } } };
+
+      const userHasClientRole = plugin.userHasClientRole.call(auth, 'entities', 'editor');
+
+      expect(userHasClientRole).toBe(false);
+    });
+
+    it('is `false` if user does not have specified client resource access role', () => {
+      const auth = { user: { 'resource_access': { entities: { roles: ['editor'] } } } };
+
+      const userHasClientRole = plugin.userHasClientRole.call(auth, 'entities', 'publisher');
+
+      expect(userHasClientRole).toBe(false);
+    });
+
+    it('is `true` if user does have specified client resource access role', () => {
+      const auth = { user: { 'resource_access': { entities: { roles: ['editor'] } } } };
+
+      const userHasClientRole = plugin.userHasClientRole.call(auth, 'entities', 'editor');
+
+      expect(userHasClientRole).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
* Via the custom `RuntimeConfigurableOauth2Scheme` auth scheme class in `packages/portal/src/plugins/authScheme.js`, decorate `$auth` in the Nuxt context with a helper function, `userHasClientRole` which checks whether the logged-in user has a specific Keycloak/oAuth2 client role.
  * For example, to check if the logged-in user has the editor role of the entities client: 
    ```js
    this.$auth.userHasClientRole('entities', 'editor')
    ```
* Update code to use this new helper function
* Add a dummy `Oauth2Scheme` class in `packages/portal/src/plugins/oauth2.js`, purely to facilitate testing `authScheme.js`, which when Nuxt is built, will still extend the auth module's `Oauth2Scheme` class
* Add unit tests for `authScheme.js` to get coverage to 100%