### PR TITLE
refactor: align related badge pill spacing

### DIFF
--- a/packages/portal/src/assets/scss/cards.scss
+++ b/packages/portal/src/assets/scss/cards.scss
@@ -10,17 +10,8 @@
   }
 
   .card-body {
-    padding-right: 0.25rem;
+    padding-right: 0.5rem;
     padding-bottom: 0.5rem;
-  }
-
-  .related-collections {
-    padding: 0;
-
-    .badge-pill {
-      margin-bottom: 0.75rem;
-      margin-right: 1rem;
-    }
   }
 }
 

--- a/packages/portal/src/components/blog/BlogPost.vue
+++ b/packages/portal/src/components/blog/BlogPost.vue
@@ -142,16 +142,4 @@
   .author ~ .author::before {
     content: ', ';
   }
-
-  ::v-deep .related-collections {
-    &.container {
-      padding: 0;
-    }
-
-    .badge-pill {
-      margin-top: 0.25rem;
-      margin-right: 0.5rem;
-    }
-  }
-
 </style>

--- a/packages/portal/src/components/related/RelatedCategoryTags.vue
+++ b/packages/portal/src/components/related/RelatedCategoryTags.vue
@@ -7,7 +7,7 @@
     >
       <h2
         v-if="heading"
-        class="related-heading text-uppercase mb-2"
+        class="related-heading text-uppercase"
       >
         {{ $t('related.categoryTags.title') }}
       </h2>
@@ -87,6 +87,10 @@
 
 <style lang="scss" scoped>
   @import '@/assets/scss/variables';
+
+  .related-heading {
+    margin-bottom: 0.75rem;
+  }
 
   .icon-ic-tag {
     color: $mediumgrey;

--- a/packages/portal/src/components/related/RelatedCollections.vue
+++ b/packages/portal/src/components/related/RelatedCollections.vue
@@ -141,8 +141,8 @@
 </script>
 
 <style lang="scss" scoped>
-  ::v-deep .badge-pill {
-    margin-right: 0.75rem;
-    margin-bottom: 0.75rem;
+  .related-collections ::v-deep .badge-pill {
+    margin-right: 0.5rem;
+    margin-bottom: 0.5rem;
   }
 </style>

--- a/packages/portal/src/components/related/RelatedCollections.vue
+++ b/packages/portal/src/components/related/RelatedCollections.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-container
+  <div
     v-show="collections.length > 0"
     data-qa="related collections"
     class="related-collections"
@@ -24,7 +24,7 @@
         :image-src-set="imageSrcSet(relatedCollection)"
       />
     </div>
-  </b-container>
+  </div>
 </template>
 
 <script>
@@ -139,3 +139,10 @@
     }
   };
 </script>
+
+<style lang="scss" scoped>
+  ::v-deep .badge-pill {
+    margin-right: 0.75rem;
+    margin-bottom: 0.75rem;
+  }
+</style>

--- a/packages/portal/src/components/related/RelatedCollections.vue
+++ b/packages/portal/src/components/related/RelatedCollections.vue
@@ -4,7 +4,7 @@
     data-qa="related collections"
     class="related-collections"
   >
-    <h2 class="related-heading text-uppercase mb-2">
+    <h2 class="related-heading text-uppercase">
       {{ title || $t('related.collections.title') }}
     </h2>
     <div
@@ -144,5 +144,10 @@
   .related-collections ::v-deep .badge-pill {
     margin-right: 0.5rem;
     margin-bottom: 0.5rem;
+  }
+
+  .related-collections-card .related-collections ::v-deep .badge-pill {
+    margin-bottom: 0.75rem;
+    margin-right: 0.75rem;
   }
 </style>

--- a/packages/portal/src/components/related/RelatedCollections.vue
+++ b/packages/portal/src/components/related/RelatedCollections.vue
@@ -150,4 +150,8 @@
     margin-bottom: 0.75rem;
     margin-right: 0.75rem;
   }
+
+  .related-heading {
+    margin-bottom: 0.75rem;
+  }
 </style>

--- a/packages/portal/src/components/search/QuickSearch.vue
+++ b/packages/portal/src/components/search/QuickSearch.vue
@@ -68,10 +68,6 @@
     .related-collections {
       max-width: 100%;
 
-      &.container {
-        padding: 0;
-      }
-
       ::v-deep .badge-pill {
         margin-right: 0.5rem;
         margin-bottom: 0.5rem;

--- a/packages/portal/src/components/search/QuickSearch.vue
+++ b/packages/portal/src/components/search/QuickSearch.vue
@@ -69,8 +69,6 @@
       max-width: 100%;
 
       ::v-deep .badge-pill {
-        margin-right: 0.5rem;
-        margin-bottom: 0.5rem;
         flex-shrink: 0;
 
         @media (min-width: $bp-xxxl) {

--- a/packages/portal/src/components/search/RelatedSection.vue
+++ b/packages/portal/src/components/search/RelatedSection.vue
@@ -63,10 +63,3 @@
     }
   };
 </script>
-
-<style lang="scss" scoped>
-  .related-collections-card ::v-deep .related-collections .badge-pill {
-    margin-bottom: 0.75rem;
-    margin-right: 0.75rem;
-  }
-</style>

--- a/packages/portal/src/components/search/RelatedSection.vue
+++ b/packages/portal/src/components/search/RelatedSection.vue
@@ -63,3 +63,10 @@
     }
   };
 </script>
+
+<style lang="scss" scoped>
+  .related-collections-card ::v-deep .related-collections .badge-pill {
+    margin-bottom: 0.75rem;
+    margin-right: 0.75rem;
+  }
+</style>

--- a/packages/portal/src/pages/collections/_type/_.vue
+++ b/packages/portal/src/pages/collections/_type/_.vue
@@ -403,16 +403,6 @@
     &.top-header {
       margin-top: -1rem;
     }
-
-    .related-collections {
-      padding: 0;
-    }
-
-    ::v-deep .related-collections .badge {
-      // TODO: Remove this when the badges move into the search results
-      margin-top: 0.25rem;
-      margin-right: 0.5rem;
-    }
   }
 
   .page-container {

--- a/packages/portal/src/pages/exhibitions/_exhibition/_chapter.vue
+++ b/packages/portal/src/pages/exhibitions/_exhibition/_chapter.vue
@@ -226,17 +226,3 @@
     }
   };
 </script>
-
-<style lang="scss" scoped>
-  ::v-deep .related-collections {
-    &.container {
-      padding: 0;
-    }
-
-    .badge-pill {
-      margin-top: 0.25rem;
-      margin-right: 0.5rem;
-    }
-  }
-
-</style>

--- a/packages/portal/src/pages/exhibitions/_exhibition/credits.vue
+++ b/packages/portal/src/pages/exhibitions/_exhibition/credits.vue
@@ -178,15 +178,4 @@
     display: block;
     margin: 1rem 0;
   }
-
-  ::v-deep .related-collections {
-    &.container {
-      padding: 0;
-    }
-
-    .badge-pill {
-      margin-top: 0.25rem;
-      margin-right: 0.5rem;
-    }
-  }
 </style>

--- a/packages/portal/src/pages/exhibitions/_exhibition/index.vue
+++ b/packages/portal/src/pages/exhibitions/_exhibition/index.vue
@@ -176,17 +176,3 @@
     }
   };
 </script>
-
-<style lang="scss" scoped>
-  ::v-deep .related-collections {
-    &.container {
-      padding: 0;
-    }
-
-    .badge-pill {
-      margin-top: 0.25rem;
-      margin-right: 0.5rem;
-    }
-  }
-
-</style>

--- a/packages/portal/src/pages/item/_.vue
+++ b/packages/portal/src/pages/item/_.vue
@@ -347,7 +347,7 @@
 <style scoped>
   .related-collections {
     margin-top: -0.5rem;
-    margin-bottom: 2rem;
+    margin-bottom: 1.5rem;
   }
 
   ::v-deep .card-header-tabs {

--- a/packages/portal/src/pages/item/_.vue
+++ b/packages/portal/src/pages/item/_.vue
@@ -348,12 +348,6 @@
   .related-collections {
     margin-top: -0.5rem;
     margin-bottom: 2rem;
-    padding: 0;
-  }
-
-  ::v-deep .related-collections .badge-light {
-    margin-top: 0.25rem;
-    margin-right: 0.5rem;
   }
 
   ::v-deep .card-header-tabs {

--- a/packages/portal/tests/unit/components/related/RelatedCollections.spec.js
+++ b/packages/portal/tests/unit/components/related/RelatedCollections.spec.js
@@ -88,7 +88,6 @@ const factory = ({ propsData, mocks, storeData } = {}) => {
       title: 'title value',
       ...propsData
     },
-    stubs: ['b-container'],
     mocks: {
       $apis: {
         entity: {


### PR DESCRIPTION
- Sets default 0.5rem margins for badges
- Overrides to 0.75rem margins for badges inside related cards
- Aligns related-heading margins when used for badges/tags