### PR TITLE
feat: add pagination to user sets in account

### DIFF
--- a/packages/portal/src/components/account/CreateSetButton.vue
+++ b/packages/portal/src/components/account/CreateSetButton.vue
@@ -59,6 +59,7 @@
       },
       setCreated() {
         this.showFormModal = false;
+        this.$emit('created');
       }
     }
   };

--- a/packages/portal/src/components/account/UserSets.vue
+++ b/packages/portal/src/components/account/UserSets.vue
@@ -87,7 +87,7 @@
     },
     data() {
       return {
-        perPage: 1,
+        perPage: 19,
         sets: [],
         total: 0
       };

--- a/packages/portal/src/components/account/UserSets.vue
+++ b/packages/portal/src/components/account/UserSets.vue
@@ -4,65 +4,118 @@
     <b-row class="flex-md-row">
       <b-col cols="12">
         <div
-          v-if="emptyText && sets && sets.length === 0"
+          v-if="$fetchState.pending"
           class="text-center pb-4"
         >
-          {{ emptyText }}
+          <LoadingSpinner />
         </div>
-        <b-card-group
-          class="card-deck-4-cols pb-5"
-          deck
+        <AlertMessage
+          v-else-if="$fetchState.error"
+          :error="$fetchState.error.message"
+        />
+        <template
+          v-else
         >
-          <ContentCard
-            v-for="(set, index) in sets"
-            :key="set.id"
-            :sub-title="setSubTitle(set)"
-            :title="set.title"
-            :image-url="creationPreviewUrl(set)"
-            :media-type="creationPreviewType(set)"
-            :texts="[set.description]"
-            :url="creationLinkUrl(set)"
-            :offset="index"
-            data-qa="user set"
+          <div
+            v-if="emptyText && sets && sets.length === 0"
+            class="text-center pb-4"
+          >
+            {{ emptyText }}
+          </div>
+          <b-card-group
+            class="card-deck-4-cols pb-5"
+            deck
+          >
+            <ContentCard
+              v-for="(set, index) in sets"
+              :key="set.id"
+              :sub-title="setSubTitle(set)"
+              :title="set.title"
+              :image-url="creationPreviewUrl(set)"
+              :media-type="creationPreviewType(set)"
+              :texts="[set.description]"
+              :url="creationLinkUrl(set)"
+              :offset="index"
+              data-qa="user set"
+            />
+            <CreateSetButton
+              v-if="showCreateSetButton"
+              :visibility="visibility"
+              @created="handleSetCreated"
+            />
+          </b-card-group>
+          <PaginationNavInput
+            :total-results="total"
+            :per-page="perPage"
           />
-          <CreateSetButton
-            v-if="showCreateSetButton"
-            :visibility="visibility"
-          />
-        </b-card-group>
+        </template>
       </b-col>
     </b-row>
   </b-container>
 </template>
 
 <script>
+  import AlertMessage from '../generic/AlertMessage';
+  import LoadingSpinner from '../generic/LoadingSpinner';
   import ContentCard from '../generic/ContentCard';
+  import PaginationNavInput from '../generic/PaginationNavInput';
   import { getLabelledSlug } from '@/plugins/europeana/utils';
 
   export default {
     name: 'UserSets',
     components: {
       ContentCard,
-      CreateSetButton: () => import('./CreateSetButton')
+      CreateSetButton: () => import('./CreateSetButton'),
+      AlertMessage,
+      LoadingSpinner,
+      PaginationNavInput
     },
     props: {
-      sets: {
-        type: Array,
-        required: true
-      },
       showCreateSetButton: {
         type: Boolean,
         default: true
       },
-      // May be "public" or "private"
+      // May be "published", "public" or "private"
       visibility: {
         type: String,
-        default: 'public'
+        required: true
       },
       emptyText: {
         type: String,
         default: null
       }
+    },
+    data() {
+      return {
+        perPage: 1,
+        sets: [],
+        total: 0
+      };
+    },
+    async fetch() {
+      const searchParams = {
+        query: `creator:${this.$auth.user.sub}`,
+        profile: 'standard',
+        pageSize: this.perPage,
+        page: this.page - 1,
+        qf: [
+          'type:Collection',
+          `visibility:${this.visibility}`
+        ]
+      };
+
+      const searchResponse = await this.$apis.set.search(searchParams, { withMinimalItemPreviews: true });
+      this.sets = searchResponse.data.items || [];
+      this.total = searchResponse.data.partOf?.total || 0;
+    },
+    computed: {
+      page() {
+        return Number(this.$route.query.page) || 1;
+      }
+    },
+    watch: {
+      visibility: '$fetch',
+      page: '$fetch'
     },
     methods: {
       creationLinkUrl(set) {
@@ -82,6 +135,17 @@
       setPathMatch(set) {
         const id = set.id.replace('http://data.europeana.eu/set/', '');
         return this.$features.setGalleries ? getLabelledSlug(id, set.title.en) : id;
+      },
+      handleSetCreated() {
+        const fetch = (this.page === 1);
+        this.$goto({
+          path: this.$route.path,
+          query: { ...this.$route.query, page: 1 },
+          hash: this.$route.hash
+        });
+        if (fetch) {
+          this.$fetch();
+        }
       }
     }
   };

--- a/packages/portal/src/components/account/UserSets.vue
+++ b/packages/portal/src/components/account/UserSets.vue
@@ -75,10 +75,14 @@
         type: Boolean,
         default: true
       },
+      type: {
+        type: String,
+        default: 'Collection'
+      },
       // May be "published", "public" or "private"
       visibility: {
         type: String,
-        required: true
+        default: null
       },
       emptyText: {
         type: String,
@@ -87,21 +91,22 @@
     },
     data() {
       return {
-        perPage: this.showCreateSetButton ? 19 : 20,
         sets: [],
         total: 0
       };
     },
     async fetch() {
+      const qf = [`type:${this.type}`];
+      if (this.visibility) {
+        qf.push(`visibility:${this.visibility}`);
+      }
+
       const searchParams = {
-        query: `creator:${this.$auth.user.sub}`,
+        query: `${this.userField}:${this.userId}`,
         profile: 'standard',
         pageSize: this.perPage,
         page: this.page - 1,
-        qf: [
-          'type:Collection',
-          `visibility:${this.visibility}`
-        ]
+        qf
       };
 
       const searchResponse = await this.$apis.set.search(searchParams, { withMinimalItemPreviews: true });
@@ -109,13 +114,23 @@
       this.total = searchResponse.data.partOf?.total || 0;
     },
     computed: {
+      userId() {
+        return this.$auth.user?.sub;
+      },
+      userField() {
+        return this.type === 'EntityBestItemsSet' ? 'contributor' : 'creator';
+      },
+      perPage() {
+        return this.showCreateSetButton ? 19 : 20;
+      },
       page() {
         return Number(this.$route.query.page) || 1;
       }
     },
     watch: {
-      visibility: '$fetch',
-      page: '$fetch'
+      page: '$fetch',
+      type: '$fetch',
+      visibility: '$fetch'
     },
     methods: {
       creationLinkUrl(set) {

--- a/packages/portal/src/components/account/UserSets.vue
+++ b/packages/portal/src/components/account/UserSets.vue
@@ -87,7 +87,7 @@
     },
     data() {
       return {
-        perPage: 19,
+        perPage: this.showCreateSetButton ? 19 : 20,
         sets: [],
         total: 0
       };

--- a/packages/portal/src/components/account/UserSets.vue
+++ b/packages/portal/src/components/account/UserSets.vue
@@ -151,15 +151,18 @@
         const id = set.id.replace('http://data.europeana.eu/set/', '');
         return this.$features.setGalleries ? getLabelledSlug(id, set.title.en) : id;
       },
+      // When a new set is created, it will be on page 1, so go back to page 1.
+      // If already on page 1, explicitly trigger `fetch`, otherwise the watcher
+      // for changes to page will trigger it.
       handleSetCreated() {
-        const fetch = (this.page === 1);
-        this.$goto({
-          path: this.$route.path,
-          query: { ...this.$route.query, page: 1 },
-          hash: this.$route.hash
-        });
-        if (fetch) {
+        if (this.page === 1) {
           this.$fetch();
+        } else {
+          this.$goto({
+            path: this.$route.path,
+            query: { ...this.$route.query, page: 1 },
+            hash: this.$route.hash
+          });
         }
       }
     }

--- a/packages/portal/src/components/generic/PaginationNavInput.vue
+++ b/packages/portal/src/components/generic/PaginationNavInput.vue
@@ -127,16 +127,15 @@
     methods: {
       changePaginationNav() {
         if (this.page) {
-          const newRouteQuery = {  ...this.$route.query, page: this.page };
-          const newRoute = { path: this.$route.path, query: newRouteQuery };
-          this.$goto(newRoute);
+          this.$goto(this.linkGen(this.page));
         }
       },
 
       linkGen(pageNo) {
         return {
           path: this.$route.path,
-          query: { ...this.$route.query, page: pageNo }
+          query: { ...this.$route.query, page: pageNo },
+          hash: this.$route.hash
         };
       }
     }

--- a/packages/portal/src/components/set/AddItemToSetModal.vue
+++ b/packages/portal/src/components/set/AddItemToSetModal.vue
@@ -6,7 +6,7 @@
     hide-header-close
     :static="modalStatic"
     @show="fetchCollections"
-    @hide="hideModal()"
+    @hide="hideModal"
   >
     <b-button
       variant="primary"
@@ -18,6 +18,7 @@
     </b-button>
     <div class="collections">
       <AddItemToSetButton
+        v-if="collections"
         v-for="(collection, index) in collections"
         :key="index"
         :set="collection"
@@ -98,6 +99,7 @@
     methods: {
       async fetchCollections() {
         const creator = this.$auth.user?.sub;
+        // TODO: pagination and/or search within one's collections
         const searchParams = {
           query: `creator:${creator}`,
           profile: 'standard',
@@ -109,7 +111,7 @@
         };
 
         const searchResponse = await this.$apis.set.search(searchParams, { withMinimalItemPreviews: true });
-        this.collections = searchResponse.data.items || [];
+        this.collections = searchResponse.data.items;
         this.fetched = true;
       },
 

--- a/packages/portal/src/components/set/AddItemToSetModal.vue
+++ b/packages/portal/src/components/set/AddItemToSetModal.vue
@@ -73,15 +73,13 @@
 
     data() {
       return {
+        collections: [],
         fetched: false,
         added: []
       };
     },
 
     computed: {
-      collections() {
-        return this.$store.state.set.creations;
-      },
       // Array of IDs of sets containing the item
       collectionsWithItem() {
         return this.collections
@@ -99,11 +97,20 @@
     },
 
     methods: {
-      fetchCollections() {
-        this.$store.dispatch('set/fetchCreations')
-          .then(() => {
-            this.fetched = true;
-          });
+      async fetchCollections() {
+        const searchParams = {
+          query: `creator:${this.$auth.user.sub}`,
+          profile: 'standard',
+          pageSize: 100,
+          page: 0,
+          qf: [
+            'type:Collection'
+          ]
+        };
+
+        const searchResponse = await this.$apis.set.search(searchParams, { withMinimalItemPreviews: true });
+        this.collections = searchResponse.data.items || [];
+        this.fetched = true;
       },
 
       hideModal() {
@@ -118,22 +125,23 @@
         return this.$apis.thumbnail.edmPreview(set.items?.[0]?.edmPreview?.[0]);
       },
 
-      addItem(setId) {
-        this.$store.dispatch('set/addItem', { setId, itemId: this.itemId });
+      async addItem(setId) {
+        await this.$store.dispatch('set/addItem', { setId, itemId: this.itemId });
       },
 
-      removeItem(setId) {
-        this.$store.dispatch('set/removeItem', { setId, itemId: this.itemId });
+      async removeItem(setId) {
+        await this.$store.dispatch('set/removeItem', { setId, itemId: this.itemId });
       },
 
-      toggleItem(setId) {
+      async toggleItem(setId) {
         if (this.collectionsWithItem.includes(setId)) {
           this.added = this.added.filter(id => id !== setId);
-          this.removeItem(setId);
+          await this.removeItem(setId);
         } else {
           this.added.push(setId);
-          this.addItem(setId);
+          await this.addItem(setId);
         }
+        this.fetchCollections();
       }
     }
   };

--- a/packages/portal/src/components/set/AddItemToSetModal.vue
+++ b/packages/portal/src/components/set/AddItemToSetModal.vue
@@ -56,7 +56,6 @@
         type: String,
         required: true
       },
-
       modalId: {
         type: String,
         default: 'add-item-to-set-modal'
@@ -98,8 +97,9 @@
 
     methods: {
       async fetchCollections() {
+        const creator = this.$auth.user?.sub;
         const searchParams = {
-          query: `creator:${this.$auth.user.sub}`,
+          query: `creator:${creator}`,
           profile: 'standard',
           pageSize: 100,
           page: 0,

--- a/packages/portal/src/components/set/AddItemToSetModal.vue
+++ b/packages/portal/src/components/set/AddItemToSetModal.vue
@@ -17,7 +17,6 @@
       {{ $t('set.actions.createNew') }}
     </b-button>
     <div
-      v-if="collections"
       class="collections"
     >
       <AddItemToSetButton
@@ -113,7 +112,7 @@
         };
 
         const searchResponse = await this.$apis.set.search(searchParams, { withMinimalItemPreviews: true });
-        this.collections = searchResponse.data.items;
+        this.collections = searchResponse.data.items || [];
         this.fetched = true;
       },
 

--- a/packages/portal/src/components/set/AddItemToSetModal.vue
+++ b/packages/portal/src/components/set/AddItemToSetModal.vue
@@ -16,9 +16,11 @@
     >
       {{ $t('set.actions.createNew') }}
     </b-button>
-    <div class="collections">
+    <div
+      v-if="collections"
+      class="collections"
+    >
       <AddItemToSetButton
-        v-if="collections"
         v-for="(collection, index) in collections"
         :key="index"
         :set="collection"

--- a/packages/portal/src/lang/en.js
+++ b/packages/portal/src/lang/en.js
@@ -15,7 +15,8 @@ export default {
       "noCollections": {
         "curated": "You haven’t curated any collections yet",
         "private": "You haven’t created any private galleries yet",
-        "public": "You haven’t created any public galleries yet"
+        "public": "You haven’t created any public galleries yet",
+        "published": "You haven’t had any galleries published yet"
       },
       "noLikedItems": "You haven’t liked any items yet"
     },
@@ -23,6 +24,7 @@ export default {
     "profile": "My Likes & Galleries",
     "profileSettings": "Profile settings",
     "publicCollections": "Public Galleries",
+    "publishedCollections": "Published Galleries",
     "settings": "Settings",
     "title": "My account"
   },

--- a/packages/portal/src/pages/account/index.vue
+++ b/packages/portal/src/pages/account/index.vue
@@ -129,7 +129,7 @@
             </template>
             <template v-else-if="userIsEditor && activeTab === tabHashes.curatedCollections">
               <UserSets
-                :sets="curations"
+                type="EntityBestItemsSet"
                 :show-create-set-button="false"
                 :empty-text="$t('account.notifications.noCollections.curated')"
                 data-qa="curated sets"
@@ -199,9 +199,6 @@
 
     async fetch() {
       this.fetchLikes();
-      if (this.userIsEditor) {
-        await this.$store.dispatch('set/fetchCurations');
-      }
     },
 
     fetchOnServer: false,

--- a/packages/portal/src/pages/account/index.vue
+++ b/packages/portal/src/pages/account/index.vue
@@ -55,6 +55,13 @@
               {{ $t('account.privateCollections') }}
             </b-nav-item>
             <b-nav-item
+              data-qa="published collections"
+              :to="$path({ hash: tabHashes.publishedGalleries})"
+              :active="activeTab === tabHashes.publishedGalleries"
+            >
+              {{ $t('account.publishedCollections') }}
+            </b-nav-item>
+            <b-nav-item
               v-if="userIsEditor"
               data-qa="curated collections"
               :to="$path({ hash: tabHashes.curatedCollections})"
@@ -100,7 +107,6 @@
             </b-container>
             <template v-else-if="activeTab === tabHashes.publicGalleries">
               <UserSets
-                :sets="publicCreations"
                 visibility="public"
                 :empty-text="$t('account.notifications.noCollections.public')"
                 data-qa="public sets"
@@ -108,10 +114,17 @@
             </template>
             <template v-else-if="activeTab === tabHashes.privateGalleries">
               <UserSets
-                :sets="privateCreations"
                 visibility="private"
                 :empty-text="$t('account.notifications.noCollections.private')"
                 data-qa="private sets"
+              />
+            </template>
+            <template v-else-if="activeTab === tabHashes.publishedGalleries">
+              <UserSets
+                visibility="published"
+                :show-create-set-button="false"
+                :empty-text="$t('account.notifications.noCollections.published')"
+                data-qa="published sets"
               />
             </template>
             <template v-else-if="userIsEditor && activeTab === tabHashes.curatedCollections">
@@ -178,6 +191,7 @@
           likes: '#likes',
           publicGalleries: '#public-galleries',
           privateGalleries: '#private-galleries',
+          publishedGalleries: '#published-galleries',
           curatedCollections: '#curated-collections'
         }
       };
@@ -185,7 +199,6 @@
 
     async fetch() {
       this.fetchLikes();
-      await this.$store.dispatch('set/fetchCreations');
       if (this.userIsEditor) {
         await this.$store.dispatch('set/fetchCurations');
       }
@@ -202,12 +215,6 @@
       userIsEditor() {
         return this.$auth.userHasClientRole('entities', 'editor') &&
           this.$auth.userHasClientRole('usersets', 'editor');
-      },
-      publicCreations() {
-        return this.$store.state.set.creations.filter(set => ['public', 'published'].includes(set.visibility));
-      },
-      privateCreations() {
-        return this.$store.state.set.creations.filter(set => set.visibility === 'private');
       },
       ...mapState({
         likesId: state => state.set.likesId,

--- a/packages/portal/src/plugins/europeana/annotation.js
+++ b/packages/portal/src/plugins/europeana/annotation.js
@@ -1,5 +1,3 @@
-import qs from 'qs';
-
 import { apiError, createAxios } from './utils';
 
 export const BASE_URL = 'https://api.europeana.eu/annotation';
@@ -12,10 +10,6 @@ export default (context = {}) => {
 
     search(params) {
       return this.$axios.get('/search', {
-        // TODO: move serializer into utils as it's common to all APIs
-        paramsSerializer(params) {
-          return qs.stringify(params, { arrayFormat: 'repeat' });
-        },
         params: {
           ...this.$axios.defaults.params,
           ...params

--- a/packages/portal/src/plugins/europeana/search.js
+++ b/packages/portal/src/plugins/europeana/search.js
@@ -5,8 +5,9 @@
 import pick from 'lodash/pick.js';
 
 import {
-  apiError, escapeLuceneSpecials, isLangMap, reduceLangMapsForLocale
+  apiError, createAxios, escapeLuceneSpecials, isLangMap, reduceLangMapsForLocale
 } from './utils.js';
+import { BASE_URL } from './record.js';
 import { truncate } from '../vue-filters.js';
 
 // Some facets do not support enquoting of their field values.
@@ -90,6 +91,10 @@ export function rangeFromQueryParam(paramValue) {
  */
 // TODO: switch options.addContentTierFilter to default to `false`
 export default (context) => ($axios, params, options = {}) => {
+  if (!$axios) {
+    $axios = createAxios({ id: 'record', baseURL: BASE_URL }, context);
+  }
+
   const defaultOptions = { addContentTierFilter: true };
   const localOptions = { ...defaultOptions, ...options };
 

--- a/packages/portal/src/plugins/europeana/search.js
+++ b/packages/portal/src/plugins/europeana/search.js
@@ -2,7 +2,6 @@
  * @file Interface to Europeana Record Search API
  */
 
-import qs from 'qs';
 import pick from 'lodash/pick.js';
 
 import {
@@ -122,9 +121,6 @@ export default (context) => ($axios, params, options = {}) => {
   }
 
   return $axios.get(`${localOptions.url || ''}/search.json`, {
-    paramsSerializer(params) {
-      return qs.stringify(params, { arrayFormat: 'repeat' });
-    },
     params: searchParams
   })
     .then(response => response.data)

--- a/packages/portal/src/plugins/europeana/utils.js
+++ b/packages/portal/src/plugins/europeana/utils.js
@@ -1,4 +1,6 @@
 import axios from 'axios';
+import qs from 'qs';
+
 import locales from '../i18n/locales.js';
 import { keycloakResponseErrorHandler } from './auth.js';
 
@@ -52,6 +54,9 @@ const axiosInstanceOptions = ({ id, baseURL }, { store, $config }) => {
     baseURL: preferredAPIBaseURL({ id, baseURL }, { store, $config }),
     params: {
       wskey: config.key
+    },
+    paramsSerializer(params) {
+      return qs.stringify(params, { arrayFormat: 'repeat' });
     },
     timeout: 10000
   };

--- a/packages/portal/src/store/set.js
+++ b/packages/portal/src/store/set.js
@@ -77,10 +77,10 @@ export default {
         dispatch('fetchLikes');
       }
     },
-    async addItem({}, { setId, itemId }) {
+    async addItem(ctx, { setId, itemId }) {
       await this.$apis.set.modifyItems('add', setId, itemId);
     },
-    async removeItem({}, { setId, itemId }) {
+    async removeItem(ctx, { setId, itemId }) {
       await this.$apis.set.modifyItems('delete', setId, itemId);
     },
     async setLikes({ commit }) {
@@ -123,7 +123,7 @@ export default {
         throw error;
       }
     },
-    async createSet({}, body) {
+    async createSet(ctx, body) {
       await this.$apis.set.create(body);
     },
     async update({ state, commit }, { id, body, params }) {

--- a/packages/portal/src/store/set.js
+++ b/packages/portal/src/store/set.js
@@ -4,8 +4,7 @@ export default {
     likedItems: null,
     likedItemIds: [],
     active: null,
-    activeRecommendations: [],
-    curations: []
+    activeRecommendations: []
   }),
 
   mutations: {
@@ -33,9 +32,6 @@ export default {
     },
     addItemToActive(state, item) {
       state.active.items.push(item);
-    },
-    setCurations(state, value) {
-      state.curations = value;
     }
   },
 
@@ -49,8 +45,6 @@ export default {
     reset({ commit }) {
       commit('setLikesId', null);
       commit('setLikedItems', null);
-      commit('setCreations', []);
-      commit('setCurations', []);
     },
     like({ dispatch, commit, state }, itemId) {
       // TODO: temporary prevention of addition of > 100 items; remove when no longer needed
@@ -158,18 +152,6 @@ export default {
       if (state.active && setId === state.active.id) {
         commit('setActive', 'DELETED');
       }
-    },
-    async fetchCurations({ commit }) {
-      const contributorId = this.$auth.user ? this.$auth.user.sub : null;
-      const searchParams = {
-        query: `contributor:${contributorId}`,
-        profile: 'standard',
-        pageSize: 100, // TODO: pagination?
-        qf: 'type:EntityBestItemsSet'
-      };
-
-      const searchResponse = await this.$apis.set.search(searchParams, { withMinimalItemPreviews: true });
-      commit('setCurations', searchResponse.data.items || []);
     },
     async reviewRecommendation({ state, commit }, params) {
       const response = await this.$apis.recommendation[params.action]('set', params.setId, params.itemIds);

--- a/packages/portal/tests/size/.size-limit.json
+++ b/packages/portal/tests/size/.size-limit.json
@@ -2,7 +2,7 @@
   {
     "name": "portal.js client",
     "running": false,
-    "limit": "1010 KB",
+    "limit": "1015 KB",
     "path": [
       ".nuxt/dist/client/*.js",
       "!.nuxt/dist/client/*.modern.js"
@@ -11,7 +11,7 @@
   {
     "name": "portal.js modern",
     "running": false,
-    "limit": "970 KB",
+    "limit": "975 KB",
     "path": [
       ".nuxt/dist/client/*.modern.js"
     ]

--- a/packages/portal/tests/unit/components/account/UserSets.spec.js
+++ b/packages/portal/tests/unit/components/account/UserSets.spec.js
@@ -27,9 +27,10 @@ const sets = [
   }
 ];
 
-const factory = (propsData) => mount(UserSets, {
+const factory = ({ propsData = {}, data = {} } = {}) => mount(UserSets, {
   localVue,
-  propsData,
+  propsData: { ...propsData },
+  data: () => ({ ...data }),
   mocks: {
     $config: { app: { internalLinkDomain: null } },
     $fetchState: {},
@@ -41,6 +42,9 @@ const factory = (propsData) => mount(UserSets, {
     $path: () => 'localizedPath',
     $i18n: { locale: 'en' },
     $features: {},
+    $route: {
+      query: {}
+    },
     $store: {
       getters: {
         'set/creationPreview': (id) => id
@@ -51,7 +55,7 @@ const factory = (propsData) => mount(UserSets, {
 
 describe('components/account/UserSets', () => {
   it('renders a card for every user set', () => {
-    const wrapper = factory({ sets });
+    const wrapper = factory({ data: { sets, total: 2 } });
 
     const renderedSets =  wrapper.findAll('[data-qa="user set"]');
 

--- a/packages/portal/tests/unit/components/account/UserSets.spec.js
+++ b/packages/portal/tests/unit/components/account/UserSets.spec.js
@@ -1,4 +1,6 @@
-import { createLocalVue, mount } from '@vue/test-utils';
+import { createLocalVue } from '@vue/test-utils';
+import { shallowMountNuxt } from '../../utils';
+import sinon from 'sinon';
 import BootstrapVue from 'bootstrap-vue';
 import UserSets from '@/components/account/UserSets.vue';
 
@@ -27,23 +29,29 @@ const sets = [
   }
 ];
 
-const factory = ({ propsData = {}, data = {} } = {}) => mount(UserSets, {
+const factory = ({ propsData = {}, data = {}, $route = {} } = {}) => shallowMountNuxt(UserSets, {
   localVue,
   propsData: { ...propsData },
   data: () => ({ ...data }),
   mocks: {
+    $auth: { user: { sub: 'user-id' } },
     $config: { app: { internalLinkDomain: null } },
     $fetchState: {},
     $apis: {
+      set: { search: sinon.stub().resolves({ data: { items: sets, partOf: { total: sets.length } } }) },
       thumbnail: { edmPreview: (img) => img?.edmPreview?.[0] }
     },
     $t: (key) => key,
     $tc: (key) => key,
+    $goto: sinon.spy(),
     $path: () => 'localizedPath',
     $i18n: { locale: 'en' },
     $features: {},
     $route: {
-      query: {}
+      path: '/en/account',
+      hash: '#public-galleries',
+      query: {},
+      ...$route
     },
     $store: {
       getters: {
@@ -54,12 +62,129 @@ const factory = ({ propsData = {}, data = {} } = {}) => mount(UserSets, {
 });
 
 describe('components/account/UserSets', () => {
-  it('renders a card for every user set', () => {
-    const wrapper = factory({ data: { sets, total: 2 } });
+  describe('template', () => {
+    it('renders a card for every user set', () => {
+      const wrapper = factory({ data: { sets, total: 2 } });
 
-    const renderedSets =  wrapper.findAll('[data-qa="user set"]');
+      const renderedSets =  wrapper.findAll('[data-qa="user set"]');
 
-    expect(renderedSets.at(0).find('[data-qa="card title"]').text()).toBe('A new collection');
-    expect(renderedSets.at(1).find('[data-qa="card title"]').text()).toBe('A second collection');
+      expect(renderedSets.at(0).attributes('title')).toBe('A new collection');
+      expect(renderedSets.at(1).attributes('title')).toBe('A second collection');
+    });
+  });
+
+  describe('fetch', () => {
+    it('gets sets from the Set API', async() => {
+      const wrapper = factory();
+
+      await wrapper.vm.fetch();
+
+      expect(wrapper.vm.$apis.set.search.calledWith(
+        {
+          query: 'creator:user-id',
+          profile: 'standard',
+          pageSize: 19,
+          page: 0,
+          qf: ['type:Collection']
+        },
+        { withMinimalItemPreviews: true }
+      )).toBe(true);
+    });
+
+    it('optionally includes visibility filter', async() => {
+      const wrapper = factory({ propsData: { visibility: 'public' } });
+
+      await wrapper.vm.fetch();
+
+      expect(wrapper.vm.$apis.set.search.calledWith(
+        {
+          query: 'creator:user-id',
+          profile: 'standard',
+          pageSize: 19,
+          page: 0,
+          qf: ['type:Collection', 'visibility:public']
+        },
+        { withMinimalItemPreviews: true }
+      )).toBe(true);
+    });
+
+    it('queries user in contributor field for type "EntityBestItemsSet"', async() => {
+      const wrapper = factory({ propsData: { type: 'EntityBestItemsSet' } });
+
+      await wrapper.vm.fetch();
+
+      expect(wrapper.vm.$apis.set.search.calledWith(
+        {
+          query: 'contributor:user-id',
+          profile: 'standard',
+          pageSize: 19,
+          page: 0,
+          qf: ['type:EntityBestItemsSet']
+        },
+        { withMinimalItemPreviews: true }
+      )).toBe(true);
+    });
+
+    it('fetches 20 sets if create set button not shown', async() => {
+      const wrapper = factory({ propsData: { showCreateSetButton: false } });
+
+      await wrapper.vm.fetch();
+
+      expect(wrapper.vm.$apis.set.search.calledWith(
+        {
+          query: 'creator:user-id',
+          profile: 'standard',
+          pageSize: 20,
+          page: 0,
+          qf: ['type:Collection']
+        },
+        { withMinimalItemPreviews: true }
+      )).toBe(true);
+    });
+
+    it('stores sets and total', async() => {
+      const wrapper = factory();
+
+      await wrapper.vm.fetch();
+
+      expect(wrapper.vm.sets).toEqual(sets);
+      expect(wrapper.vm.total).toBe(2);
+    });
+  });
+
+  describe('methods', () => {
+    describe('handleSetCreated', () => {
+      it('goes back to page 1 if not already there', () => {
+        const $route = {
+          path: '/en/account',
+          hash: '#public-galleries',
+          query: { page: 2 }
+        };
+        const wrapper = factory({ $route });
+
+        wrapper.vm.handleSetCreated();
+
+        expect(wrapper.vm.$goto.calledWith({
+          path: '/en/account',
+          query: { page: 1 },
+          hash: '#public-galleries'
+        })).toBe(true);
+      });
+
+      it('triggers $fetch if already on page 1', () => {
+        const $route = {
+          path: '/en/account',
+          hash: '#public-galleries',
+          query: { page: 1 }
+        };
+        const wrapper = factory({ $route });
+        sinon.spy(wrapper.vm, '$fetch');
+
+        wrapper.vm.handleSetCreated();
+
+        expect(wrapper.vm.$goto.called).toBe(false);
+        expect(wrapper.vm.$fetch.called).toBe(true);
+      });
+    });
   });
 });

--- a/packages/portal/tests/unit/components/set/AddItemToSetModal.spec.js
+++ b/packages/portal/tests/unit/components/set/AddItemToSetModal.spec.js
@@ -18,25 +18,24 @@ const sets = [
   }
 ];
 
-const factory = (propsData = {}) => mount(AddItemToSetModal, {
+const factory = ({ propsData = {}, data = {} } = {}) => mount(AddItemToSetModal, {
   localVue,
   propsData: {
     modalStatic: true,
     ...propsData
   },
+  data: () => ({ ...data }),
   mocks: {
     $t: () => {},
     $tc: () => {},
     $i18n: {},
     $apis: {
+      set: { search: sinon.stub().resolves({ data: { items: sets } }) },
       thumbnail: { edmPreview: (img) => img?.edmPreview?.[0] }
     },
+    $auth: { user: {} },
     $store: {
-      dispatch: storeDispatch,
-      state: { set: { creations: sets } },
-      getters: {
-        'set/creationPreview': (id) => id
-      }
+      dispatch: storeDispatch
     }
   }
 });
@@ -44,7 +43,8 @@ const factory = (propsData = {}) => mount(AddItemToSetModal, {
 describe('components/set/AddItemToSetModal', () => {
   describe('create set button', () => {
     it('emits "clickCreateSet" event', () => {
-      const wrapper = factory({ itemId: '/123/abc', modalId: 'add-item-to-set-modal-/123/abc' });
+      const propsData = { itemId: '/123/abc', modalId: 'add-item-to-set-modal-/123/abc' };
+      const wrapper = factory({ propsData });
       wrapper.find('[data-qa="create new gallery button"]').trigger('click');
 
       expect(wrapper.emitted('clickCreateSet').length).toEqual(1);
@@ -53,7 +53,8 @@ describe('components/set/AddItemToSetModal', () => {
 
   describe('close button', () => {
     it('hides the modal', () => {
-      const wrapper = factory({ itemId: '/123/abc', modalId: 'add-item-to-set-modal-/123/abc' });
+      const propsData = { itemId: '/123/abc', modalId: 'add-item-to-set-modal-/123/abc' };
+      const wrapper = factory({ propsData });
       const bvModalHide = sinon.spy(wrapper.vm.$bvModal, 'hide');
 
       wrapper.find('[data-qa="close button"]').trigger('click');
@@ -64,8 +65,9 @@ describe('components/set/AddItemToSetModal', () => {
 
   describe('AddItemToSetButton', () => {
     it('adds item to gallery when item is not yet added', async() => {
-      const wrapper = factory({ itemId: '/123/abc', modalId: 'add-item-to-set-modal-/123/abc' });
-      await wrapper.setData({ fetched: true });
+      const propsData = { itemId: '/123/abc', modalId: 'add-item-to-set-modal-/123/abc' };
+      const data = { fetched: true, collections: sets };
+      const wrapper = factory({ propsData, data });
 
       await wrapper.find('[data-qa="toggle item button 0"]').trigger('click');
 
@@ -73,8 +75,9 @@ describe('components/set/AddItemToSetModal', () => {
     });
 
     it('removes item from gallery when item already added', async() => {
-      const wrapper = factory({ itemId: '/000/aaa', modalId: 'add-item-to-set-modal-/000/aaa' });
-      await wrapper.setData({ fetched: true });
+      const propsData = { itemId: '/000/aaa', modalId: 'add-item-to-set-modal-/000/aaa' };
+      const data = { fetched: true, collections: sets };
+      const wrapper = factory({ propsData, data });
 
       await wrapper.find('[data-qa="toggle item button 0"]').trigger('click');
 

--- a/packages/portal/tests/unit/components/set/AddItemToSetModal.spec.js
+++ b/packages/portal/tests/unit/components/set/AddItemToSetModal.spec.js
@@ -33,7 +33,7 @@ const factory = ({ propsData = {}, data = {} } = {}) => mount(AddItemToSetModal,
       set: { search: sinon.stub().resolves({ data: { items: sets } }) },
       thumbnail: { edmPreview: (img) => img?.edmPreview?.[0] }
     },
-    $auth: { user: {} },
+    $auth: { user: { sub: 'user-id' } },
     $store: {
       dispatch: storeDispatch
     }
@@ -41,47 +41,77 @@ const factory = ({ propsData = {}, data = {} } = {}) => mount(AddItemToSetModal,
 });
 
 describe('components/set/AddItemToSetModal', () => {
-  describe('create set button', () => {
-    it('emits "clickCreateSet" event', () => {
-      const propsData = { itemId: '/123/abc', modalId: 'add-item-to-set-modal-/123/abc' };
-      const wrapper = factory({ propsData });
-      wrapper.find('[data-qa="create new gallery button"]').trigger('click');
+  describe('template', () => {
+    describe('create set button', () => {
+      it('emits "clickCreateSet" event', () => {
+        const propsData = { itemId: '/123/abc', modalId: 'add-item-to-set-modal-/123/abc' };
+        const wrapper = factory({ propsData });
+        wrapper.find('[data-qa="create new gallery button"]').trigger('click');
 
-      expect(wrapper.emitted('clickCreateSet').length).toEqual(1);
+        expect(wrapper.emitted('clickCreateSet').length).toEqual(1);
+      });
+    });
+
+    describe('close button', () => {
+      it('hides the modal', () => {
+        const propsData = { itemId: '/123/abc', modalId: 'add-item-to-set-modal-/123/abc' };
+        const wrapper = factory({ propsData });
+        const bvModalHide = sinon.spy(wrapper.vm.$bvModal, 'hide');
+
+        wrapper.find('[data-qa="close button"]').trigger('click');
+
+        expect(bvModalHide.calledWith('add-item-to-set-modal-/123/abc')).toBe(true);
+      });
+    });
+
+    describe('toggle item button', () => {
+      it('adds item to gallery when item is not yet added', async() => {
+        const propsData = { itemId: '/123/abc', modalId: 'add-item-to-set-modal-/123/abc' };
+        const data = { fetched: true, collections: sets };
+        const wrapper = factory({ propsData, data });
+
+        await wrapper.find('[data-qa="toggle item button 0"]').trigger('click');
+
+        expect(storeDispatch.calledWith('set/addItem', { setId: '001', itemId: '/123/abc' })).toBe(true);
+      });
+
+      it('removes item from gallery when item already added', async() => {
+        const propsData = { itemId: '/000/aaa', modalId: 'add-item-to-set-modal-/000/aaa' };
+        const data = { fetched: true, collections: sets };
+        const wrapper = factory({ propsData, data });
+
+        await wrapper.find('[data-qa="toggle item button 0"]').trigger('click');
+
+        expect(storeDispatch.calledWith('set/removeItem', { setId: '001', itemId: '/000/aaa' })).toBe(true);
+      });
     });
   });
 
-  describe('close button', () => {
-    it('hides the modal', () => {
-      const propsData = { itemId: '/123/abc', modalId: 'add-item-to-set-modal-/123/abc' };
-      const wrapper = factory({ propsData });
-      const bvModalHide = sinon.spy(wrapper.vm.$bvModal, 'hide');
+  describe('methods', () => {
+    describe('fetchCollections', () => {
+      it('queries Set API for user\'s sets', async() => {
+        const propsData = { itemId: '/000/aaa' };
+        const wrapper = factory({ propsData });
 
-      wrapper.find('[data-qa="close button"]').trigger('click');
+        await wrapper.vm.fetchCollections();
 
-      expect(bvModalHide.calledWith('add-item-to-set-modal-/123/abc')).toBe(true);
-    });
-  });
+        expect(wrapper.vm.$apis.set.search.calledWith({
+          query: 'creator:user-id',
+          profile: 'standard',
+          pageSize: 100,
+          page: 0,
+          qf: ['type:Collection']
+        }, { withMinimalItemPreviews: true })).toBe(true);
+      });
 
-  describe('AddItemToSetButton', () => {
-    it('adds item to gallery when item is not yet added', async() => {
-      const propsData = { itemId: '/123/abc', modalId: 'add-item-to-set-modal-/123/abc' };
-      const data = { fetched: true, collections: sets };
-      const wrapper = factory({ propsData, data });
+      it('stores sets from the Set API response', async() => {
+        const propsData = { itemId: '/000/aaa' };
+        const wrapper = factory({ propsData });
 
-      await wrapper.find('[data-qa="toggle item button 0"]').trigger('click');
+        await wrapper.vm.fetchCollections();
 
-      expect(storeDispatch.calledWith('set/addItem', { setId: '001', itemId: '/123/abc' })).toBe(true);
-    });
-
-    it('removes item from gallery when item already added', async() => {
-      const propsData = { itemId: '/000/aaa', modalId: 'add-item-to-set-modal-/000/aaa' };
-      const data = { fetched: true, collections: sets };
-      const wrapper = factory({ propsData, data });
-
-      await wrapper.find('[data-qa="toggle item button 0"]').trigger('click');
-
-      expect(storeDispatch.calledWith('set/removeItem', { setId: '001', itemId: '/000/aaa' })).toBe(true);
+        expect(wrapper.vm.collections).toEqual(sets);
+      });
     });
   });
 });

--- a/packages/portal/tests/unit/pages/account/index.spec.js
+++ b/packages/portal/tests/unit/pages/account/index.spec.js
@@ -72,14 +72,6 @@ describe('pages/account/index.vue', () => {
       .withArgs('entities', 'editor').returns(true)
       .withArgs('usersets', 'editor').returns(true);
 
-    it('fetches the user\'s curated collections', async() => {
-      const wrapper = factory({ userHasClientRoleStub });
-
-      await wrapper.vm.fetch();
-
-      expect(wrapper.vm.$store.dispatch.calledWith('set/fetchCurations')).toBe(true);
-    });
-
     it('shows the curated collections in the tab navigation', () => {
       const wrapper = factory({ userHasClientRoleStub });
 
@@ -132,36 +124,6 @@ describe('pages/account/index.vue', () => {
     it('shows the private galleries', () => {
       const privateGalleries = wrapper.find('[data-qa="private sets"]');
       expect(privateGalleries.exists()).toBe(true);
-    });
-  });
-
-  describe('computed', () => {
-    describe('publicCreations', () => {
-      it('includes only created sets with visibility "public" or "published"', () => {
-        const privateSet = { visibility: 'private' };
-        const publicSet = { visibility: 'public' };
-        const publishedSet = { visibility: 'published' };
-        const creations = [privateSet, publicSet, publishedSet];
-
-        const wrapper = factory();
-        wrapper.vm.$store.state.set.creations = creations;
-
-        expect(wrapper.vm.publicCreations).toEqual([publicSet, publishedSet]);
-      });
-    });
-
-    describe('privateCreations', () => {
-      it('includes only created sets with visibility "private"', () => {
-        const privateSet = { visibility: 'private' };
-        const publicSet = { visibility: 'public' };
-        const publishedSet = { visibility: 'published' };
-        const creations = [privateSet, publicSet, publishedSet];
-
-        const wrapper = factory();
-        wrapper.vm.$store.state.set.creations = creations;
-
-        expect(wrapper.vm.privateCreations).toEqual([privateSet]);
-      });
     });
   });
 });

--- a/packages/portal/tests/unit/plugins/europeana/search.spec.js
+++ b/packages/portal/tests/unit/plugins/europeana/search.spec.js
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import nock from 'nock';
 import search, {
   addContentTierFilter, rangeToQueryParam, rangeFromQueryParam
@@ -9,14 +8,13 @@ const apiEndpoint = '/search.json';
 
 const baseRequest = () => nock(BASE_URL).get(apiEndpoint);
 const defaultResponse = { success: true, items: [], totalResults: 123456 };
-const $axios = axios.create({ baseURL: BASE_URL });
 
 describe('plugins/europeana/search', () => {
   afterEach(() => {
     nock.cleanAll();
   });
 
-  describe('search()()', () => {
+  describe('search({})()', () => {
     describe('API request', () => {
       it('requests 24 results by default', async() => {
         baseRequest()
@@ -25,7 +23,7 @@ describe('plugins/europeana/search', () => {
           })
           .reply(200, defaultResponse);
 
-        await search()($axios, { query: 'anything' });
+        await search({})(null, { query: 'anything' });
 
         expect(nock.isDone()).toBe(true);
       });
@@ -37,7 +35,7 @@ describe('plugins/europeana/search', () => {
           })
           .reply(200, defaultResponse);
 
-        await search()($axios, { query: 'anything', rows: 9 });
+        await search({})(null, { query: 'anything', rows: 9 });
 
         expect(nock.isDone()).toBe(true);
       });
@@ -49,7 +47,7 @@ describe('plugins/europeana/search', () => {
           })
           .reply(200, defaultResponse);
 
-        await search()($axios, { page: 2, query: 'anything' });
+        await search({})(null, { page: 2, query: 'anything' });
 
         expect(nock.isDone()).toBe(true);
       });
@@ -61,7 +59,7 @@ describe('plugins/europeana/search', () => {
           })
           .reply(200, defaultResponse);
 
-        await search()($axios, { page: 42, query: 'anything' });
+        await search({})(null, { page: 42, query: 'anything' });
 
         expect(nock.isDone()).toBe(true);
       });
@@ -74,7 +72,7 @@ describe('plugins/europeana/search', () => {
             })
             .reply(200, defaultResponse);
 
-          await search()($axios, { query: 'anything' });
+          await search({})(null, { query: 'anything' });
 
           expect(nock.isDone()).toBe(true);
         });
@@ -84,7 +82,7 @@ describe('plugins/europeana/search', () => {
             .query(query => (query.qf === undefined))
             .reply(200, defaultResponse);
 
-          await search()($axios, { query: 'anything' }, { addContentTierFilter: false });
+          await search({})(null, { query: 'anything' }, { addContentTierFilter: false });
 
           expect(nock.isDone()).toBe(true);
         });
@@ -97,7 +95,7 @@ describe('plugins/europeana/search', () => {
           })
           .reply(200, defaultResponse);
 
-        await search()($axios, { query: 'anything', facet: 'LANGUAGE' });
+        await search({})(null, { query: 'anything', facet: 'LANGUAGE' });
 
         expect(nock.isDone()).toBe(true);
       });
@@ -109,7 +107,7 @@ describe('plugins/europeana/search', () => {
           })
           .reply(200, defaultResponse);
 
-        await search()($axios, { query: 'anything', facet: 'COUNTRY,REUSABILITY' });
+        await search({})(null, { query: 'anything', facet: 'COUNTRY,REUSABILITY' });
 
         expect(nock.isDone()).toBe(true);
       });
@@ -121,7 +119,7 @@ describe('plugins/europeana/search', () => {
           })
           .reply(200, defaultResponse);
 
-        await search()($axios, { query: '' });
+        await search({})(null, { query: '' });
 
         expect(nock.isDone()).toBe(true);
       });
@@ -133,7 +131,7 @@ describe('plugins/europeana/search', () => {
           })
           .reply(200, defaultResponse);
 
-        await search()($axios, { query: 'anything', reusability: 'open' });
+        await search({})(null, { query: 'anything', reusability: 'open' });
 
         expect(nock.isDone()).toBe(true);
       });
@@ -150,7 +148,7 @@ describe('plugins/europeana/search', () => {
             })
             .reply(200, defaultResponse);
 
-          await search(context)($axios, { query: 'flor' }, { locale });
+          await search(context)(null, { query: 'flor' }, { locale });
 
           expect(nock.isDone()).toBe(true);
         });
@@ -163,7 +161,7 @@ describe('plugins/europeana/search', () => {
             })
             .reply(200, defaultResponse);
 
-          await search(context)($axios, { query: 'flor' });
+          await search(context)(null, { query: 'flor' });
 
           expect(nock.isDone()).toBe(true);
         });
@@ -178,7 +176,7 @@ describe('plugins/europeana/search', () => {
             })
             .reply(200, defaultResponse);
 
-          await search(context)($axios, { query: 'flor' }, { locale });
+          await search(context)(null, { query: 'flor' }, { locale });
 
           expect(nock.isDone()).toBe(true);
         });
@@ -192,7 +190,7 @@ describe('plugins/europeana/search', () => {
             })
             .reply(200, defaultResponse);
 
-          await search()($axios, { query: 'dress (red OR blue)' });
+          await search({})(null, { query: 'dress (red OR blue)' });
 
           expect(nock.isDone()).toBe(true);
         });
@@ -204,7 +202,7 @@ describe('plugins/europeana/search', () => {
             })
             .reply(200, defaultResponse);
 
-          await search()($axios, { query: 'dress (red OR blue)' }, { escape: true });
+          await search({})(null, { query: 'dress (red OR blue)' }, { escape: true });
 
           expect(nock.isDone()).toBe(true);
         });
@@ -220,7 +218,7 @@ describe('plugins/europeana/search', () => {
             })
             .reply(200, defaultResponse);
 
-          await search({})($axios, { query: 'test', boost: 'BOOST' });
+          await search({})(null, { query: 'test', boost: 'BOOST' });
 
           expect(nock.isDone()).toBe(true);
         });
@@ -240,7 +238,7 @@ describe('plugins/europeana/search', () => {
 
           let error;
           try {
-            await search()($axios, { query: 'NOT ' });
+            await search({})(null, { query: 'NOT ' });
           } catch (e) {
             error = e;
           }
@@ -252,7 +250,7 @@ describe('plugins/europeana/search', () => {
 
       describe('with `items`', () => {
         function searchResponse(options = {}) {
-          return search()($axios, { query: 'painting' }, options);
+          return search({})(null, { query: 'painting' }, options);
         }
 
         describe('.items', () => {
@@ -363,7 +361,7 @@ describe('plugins/europeana/search', () => {
 
           describe('when page is at the API limit', () => {
             function searchResponse() {
-              return search()($axios, { query: 'painting', page: 42 });
+              return search({})(null, { query: 'painting', page: 42 });
             }
 
             it('is `true`', async() => {

--- a/packages/portal/tests/unit/store/set.spec.js
+++ b/packages/portal/tests/unit/store/set.spec.js
@@ -5,8 +5,6 @@ const likesId = 'http://data.europeana.eu/set/likesset';
 const likedItems = [{ id: 'item001' }];
 const active = { id: 'set001', items: [] };
 const activeRecommendations = [{ id: 'recommendation001' }];
-const creations = [{ id: 'set002' }];
-const curations = [{ id: 'curatedSet001' }];
 
 describe('store/set', () => {
   describe('mutations', () => {
@@ -71,20 +69,6 @@ describe('store/set', () => {
         expect(state.active.items).toEqual([{ id: 'item001' }, newItem]);
       });
     });
-    describe('setCreations()', () => {
-      it('sets the creations state', () => {
-        const state = { creations: [] };
-        store.mutations.setCreations(state, creations);
-        expect(state.creations).toEqual(creations);
-      });
-    });
-    describe('setCurations()', () => {
-      it('sets the curations state', () => {
-        const state = { curations: [] };
-        store.mutations.setCurations(state, curations);
-        expect(state.curations).toEqual(curations);
-      });
-    });
   });
 
   describe('getters', () => {
@@ -138,9 +122,7 @@ describe('store/set', () => {
     describe('reset()', () => {
       const resetCommits = {
         setLikesId: null,
-        setLikedItems: null,
-        setCreations: [],
-        setCurations: []
+        setLikedItems: null
       };
 
       for (const commitName in resetCommits) {
@@ -201,46 +183,24 @@ describe('store/set', () => {
     });
 
     describe('addItem()', () => {
-      it('adds to set via $apis.set, then dispatches "refreshCreation"', async() => {
+      it('adds to set via $apis.set', async() => {
         store.actions.$apis.set.modifyItems = sinon.stub().resolves({});
         const state = {};
 
         await store.actions.addItem({ dispatch, state }, { setId, itemId });
 
         expect(store.actions.$apis.set.modifyItems.calledWith('add', setId, itemId)).toBe(true);
-        expect(dispatch.calledWith('refreshCreation', setId)).toBe(true);
-      });
-      describe('when api call errors', () => {
-        it('refreshes creation', async() => {
-          store.actions.$apis.set.modifyItems = sinon.stub().rejects({});
-          const state = {};
-
-          await store.actions.addItem({ dispatch, state }, { setId, itemId });
-
-          expect(dispatch.calledWith('refreshCreation', setId)).toBe(true);
-        });
       });
     });
 
     describe('removeItem()', () => {
-      it('removes from set via $apis.set, then dispatches "refreshCreation"', async() => {
+      it('removes from set via $apis.set', async() => {
         store.actions.$apis.set.modifyItems = sinon.stub().resolves({});
         const state = {};
 
         await store.actions.removeItem({ dispatch, state }, { setId, itemId });
 
         expect(store.actions.$apis.set.modifyItems.calledWith('delete', setId, itemId)).toBe(true);
-        expect(dispatch.calledWith('refreshCreation', setId)).toBe(true);
-      });
-      describe('when api call errors', () => {
-        it('refreshes creation', async() => {
-          store.actions.$apis.set.modifyItems = sinon.stub().rejects({});
-          const state = {};
-
-          await store.actions.removeItem({ dispatch, state }, { setId, itemId });
-
-          expect(dispatch.calledWith('refreshCreation', setId)).toBe(true);
-        });
       });
     });
 
@@ -332,14 +292,13 @@ describe('store/set', () => {
     });
 
     describe('createSet()', () => {
-      it('create the set via $apis.set, then dispatches "fetchCreations"', async() => {
+      it('create the set via $apis.set', async() => {
         store.actions.$apis.set.create = sinon.stub().resolves();
         const body = {};
 
         await store.actions.createSet({ dispatch }, body);
 
         expect(store.actions.$apis.set.create.calledWith(body)).toBe(true);
-        expect(dispatch.calledWith('fetchCreations')).toBe(true);
       });
     });
 
@@ -487,80 +446,6 @@ describe('store/set', () => {
 
           expect(commit.calledWith('setActive', 'DELETED')).toBe(true);
         });
-      });
-    });
-
-    describe('refreshCreation', () => {
-      describe('when creation is not stored', () => {
-        it('does not fetch it via $apis.set', async() => {
-          store.actions.$apis.set.get = sinon.stub().resolves();
-          const state = { creations: [] };
-
-          await store.actions.refreshCreation({ commit, state }, setId);
-
-          expect(store.actions.$apis.set.get.called).toBe(false);
-        });
-      });
-
-      describe('when creation is stored', () => {
-        it('fetches it via $apis.set, then commits with "setCreations"', async() => {
-          const oldCreation = { id: setId, title: { en: 'Old title' } };
-          const newCreation = { id: setId, title: { en: 'New title' } };
-          const state = { creations: [oldCreation] };
-          store.actions.$apis.set.get = sinon.stub().resolves(newCreation);
-
-          await store.actions.refreshCreation({ commit, state, dispatch }, setId);
-
-          expect(store.actions.$apis.set.get.calledWith(setId, {
-            profile: 'itemDescriptions'
-          })).toBe(true);
-          expect(commit.calledWith('setCreations', [newCreation])).toBe(true);
-        });
-      });
-    });
-
-    describe('fetchCreations()', () => {
-      it('fetches creations via $apis.set', async() => {
-        const searchResponse = { data: { items: ['1', '2'] } };
-        store.actions.$auth.user = { sub: userId };
-        store.actions.$apis.set.search = sinon.stub().resolves(searchResponse);
-
-        await store.actions.fetchCreations({ commit, dispatch });
-
-        expect(store.actions.$apis.set.search.calledWith({
-          query: `creator:${userId}`,
-          profile: 'standard',
-          pageSize: 100,
-          qf: 'type:Collection'
-        })).toBe(true);
-      });
-
-      it('commits creations with "setCreations"', async() => {
-        const searchResponse = { data: { items: ['1', '2'] } };
-        store.actions.$auth.user = { sub: userId };
-        store.actions.$apis.set.search = sinon.stub().resolves(searchResponse);
-
-        await store.actions.fetchCreations({ commit, dispatch });
-
-        expect(commit.calledWith('setCreations', ['1', '2'])).toBe(true);
-      });
-    });
-
-    describe('fetchCurations()', () => {
-      it('fetches entity related galleries the user has curated via $apis.set, then commits with "setCurations"', async() => {
-        const searchResponse = { data: { items: ['1', '2'] } };
-        store.actions.$auth.user = { sub: userId };
-        store.actions.$apis.set.search = sinon.stub().resolves(searchResponse);
-
-        await store.actions.fetchCurations({ commit });
-
-        expect(store.actions.$apis.set.search.calledWith({
-          query: `contributor:${userId}`,
-          profile: 'standard',
-          pageSize: 100,
-          qf: 'type:EntityBestItemsSet'
-        })).toBe(true);
-        expect(commit.calledWith('setCurations', ['1', '2'])).toBe(true);
       });
     });
 


### PR DESCRIPTION
* Introduce pagination in the galleries tabs of the my account page (UserSets component). 20 items at a time unless the create set button is shown, in which case 19 items at a time.
* Add a new tab for published galleries to the my account page
* Stop using the store for retrieval of the logged-in user's sets, and do so in the respective components instead
* Only load the sets when needed for the tab displayed, not all of them in advance
* Update the PaginationNav component to also preserve the hash from the route
* Update API plugins and utils so that the axios params serializer always repeats for arrays, e.g. `qf`