### PR TITLE
feat: prune recommended items

### DIFF
--- a/packages/portal/src/components/item/ItemRecommendations.vue
+++ b/packages/portal/src/components/item/ItemRecommendations.vue
@@ -72,7 +72,12 @@
 
       if (this.$auth.loggedIn) {
         response = await this.$apis.recommendation.recommend('record', this.identifier);
-        response.items = response.items.filter((item) => item.id !== this.identifier).slice(0, 8);
+        response.items = response.items
+          // Remove any recommendations that are the same as the active item,
+          // because the Recommendation API/Engine is broken.
+          // TODO: remove if/when recommendations become useful.
+          .filter((item) => item.id !== this.identifier)
+          .slice(0, 8);
       } else {
         response = await this.$apis.record.search({
           query: similarItemsQuery(this.identifier, this.similarItemsFields),

--- a/packages/portal/src/components/item/ItemRecommendations.vue
+++ b/packages/portal/src/components/item/ItemRecommendations.vue
@@ -72,6 +72,7 @@
 
       if (this.$auth.loggedIn) {
         response = await this.$apis.recommendation.recommend('record', this.identifier);
+        response.items = response.items.filter((item) => item.id !== this.identifier).slice(0, 8);
       } else {
         response = await this.$apis.record.search({
           query: similarItemsQuery(this.identifier, this.similarItemsFields),

--- a/packages/portal/src/store/set.js
+++ b/packages/portal/src/store/set.js
@@ -28,7 +28,11 @@ export default {
       state.active = value;
     },
     setActiveRecommendations(state, value) {
-      state.activeRecommendations = value;
+      // Remove any recommendations that are already in the active set, because
+      // the Recommendation API/Engine is broken.
+      // TODO: remove if/when recommendations become useful.
+      const activeSetItemIds = state.active.items.map((item) => item.id);
+      state.activeRecommendations = value.filter((rec) => !activeSetItemIds.includes(rec.id));
     },
     addItemToActive(state, item) {
       state.active.items.push(item);

--- a/packages/portal/src/store/set.js
+++ b/packages/portal/src/store/set.js
@@ -31,7 +31,7 @@ export default {
       // Remove any recommendations that are already in the active set, because
       // the Recommendation API/Engine is broken.
       // TODO: remove if/when recommendations become useful.
-      const activeSetItemIds = state.active.items.map((item) => item.id);
+      const activeSetItemIds = state.active?.items.map((item) => item.id) || [];
       state.activeRecommendations = value.filter((rec) => !activeSetItemIds.includes(rec.id));
     },
     addItemToActive(state, item) {

--- a/packages/portal/tests/unit/components/item/ItemRecommendations.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemRecommendations.spec.js
@@ -5,7 +5,18 @@ import ItemRecommendations from '@/components/item/ItemRecommendations.vue';
 import sinon from 'sinon';
 const localVue = createLocalVue();
 
-const recommendedItems = [{ id: 'item001' }];
+const recommendedItems = [
+  { id: '/123/abc' },
+  { id: '/123/bcd' },
+  { id: '/123/cde' },
+  { id: '/123/def' },
+  { id: '/123/efg' },
+  { id: '/123/fgh' },
+  { id: '/123/ghi' },
+  { id: '/123/hij' },
+  { id: '/123/ijk' },
+  { id: '/123/jkl' }
+];
 
 const factory = ({ propsData = {}, mocks = {} } = {}) => shallowMountNuxt(ItemRecommendations, {
   localVue,
@@ -32,13 +43,23 @@ describe('components/item/ItemRecommendations', () => {
   describe('fetch', () => {
     describe('when user is logged in', () => {
       const mocks = { $auth: { loggedIn: true } };
+      const propsData = { identifier: '/123/abc' };
+
       it('queries the Recommendation API by the item ID', async() => {
-        const propsData = { identifier: '/123/abc' };
         const wrapper = factory({ propsData, mocks });
 
         await wrapper.vm.fetch();
 
         expect(wrapper.vm.$apis.recommendation.recommend.calledWith('record', propsData.identifier)).toBe(true);
+      });
+
+      it('stores the items, removing self-recommendation, limiting to 8', async() => {
+        const wrapper = factory({ propsData, mocks });
+
+        await wrapper.vm.fetch();
+
+        expect(wrapper.vm.items.length).toBe(8);
+        expect(wrapper.vm.items.some((item) => item.id === propsData.identifier)).toBe(false);
       });
     });
 

--- a/packages/portal/tests/unit/store/set.spec.js
+++ b/packages/portal/tests/unit/store/set.spec.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 const likesId = 'http://data.europeana.eu/set/likesset';
 const likedItems = [{ id: 'item001' }];
 const active = { id: 'set001', items: [] };
-const activeRecommendations = [{ id: 'recommendation001' }];
+const activeRecommendations = [{ id: 'recommendation001' }, { id: 'recommendation002' }];
 
 describe('store/set', () => {
   describe('mutations', () => {
@@ -56,9 +56,15 @@ describe('store/set', () => {
     });
     describe('setActiveRecommendations()', () => {
       it('sets the activeRecommendations state', () => {
-        const state = { activeRecommendations: [] };
+        const state = { activeRecommendations: [], active: { items: [] } };
         store.mutations.setActiveRecommendations(state, activeRecommendations);
         expect(state.activeRecommendations).toEqual(activeRecommendations);
+      });
+
+      it('removes any that are already in the active set', () => {
+        const state = { activeRecommendations: [], active: { items: [activeRecommendations[0]] } };
+        store.mutations.setActiveRecommendations(state, activeRecommendations);
+        expect(state.activeRecommendations.length).toBe(1);
       });
     });
     describe('addItemToActive()', () => {


### PR DESCRIPTION
On the item page:
* omit any self-recommendations (bug in Recommendation API/Engine)
* limit to 8

On the set page:
* omit any recommendations for items already in the set (bug in Recommendation API/Engine)
* show whatever remains