### PR TITLE
feat: optional internal/private API URLs

### DIFF
--- a/packages/portal/nuxt.config.js
+++ b/packages/portal/nuxt.config.js
@@ -29,6 +29,71 @@ const buildPublicPath = () => {
   return process.env.NUXT_BUILD_PUBLIC_PATH;
 };
 
+const publicRuntimeConfigEuropeana = {
+  apis: {
+    annotation: {
+      url: process.env.EUROPEANA_ANNOTATION_API_URL,
+      key: process.env.EUROPEANA_ANNOTATION_API_KEY || process.env.EUROPEANA_API_KEY
+    },
+    entity: {
+      url: process.env.EUROPEANA_ENTITY_API_URL || EUROPEANA_ENTITY_API_BASE_URL,
+      key: process.env.EUROPEANA_ENTITY_API_KEY || process.env.EUROPEANA_API_KEY
+    },
+    entityManagement: {
+      url: process.env.EUROPEANA_ENTITY_MANAGEMENT_API_URL || process.env.EUROPEANA_ENTITY_API_URL || EUROPEANA_ENTITY_MANAGEMENT_API_BASE_URL
+    },
+    iiifPresentation: {
+      media: {
+        url: process.env.EUROPEANA_MEDIA_IIIF_PRESENTATION_API_URL || EUROPEANA_IIIF_PRESENTATION_URL
+      }
+    },
+    recommendation: {
+      url: process.env.EUROPEANA_RECOMMENDATION_API_URL
+    },
+    record: {
+      fulltextUrl: process.env.EUROPEANA_RECORD_API_FULLTEXT_URL || EUROPEANA_RECORD_API_FULLTEXT_URL,
+      url: process.env.EUROPEANA_RECORD_API_URL || EUROPEANA_RECORD_API_BASE_URL,
+      key: process.env.EUROPEANA_RECORD_API_KEY || process.env.EUROPEANA_API_KEY
+    },
+    thumbnail: {
+      url: process.env.EUROPEANA_THUMBNAIL_API_URL
+    },
+    set: {
+      url: process.env.EUROPEANA_SET_API_URL || EUROPEANA_SET_API_BASE_URL,
+      key: process.env.EUROPEANA_SET_API_KEY || process.env.EUROPEANA_API_KEY
+    }
+  },
+  proxy: {
+    media: {
+      url: process.env.EUROPEANA_MEDIA_PROXY_URL || EUROPEANA_MEDIA_PROXY_URL
+    }
+  }
+};
+
+const privateRuntimeConfigEuropeana = {
+  apis: {
+    annotation: {
+      url: process.env.EUROPEANA_ANNOTATION_API_URL_PRIVATE
+    },
+    entity: {
+      url: process.env.EUROPEANA_ENTITY_API_URL_PRIVATE
+    },
+    recommendation: {
+      url: process.env.EUROPEANA_RECOMMENDATION_API_URL_PRIVATE
+    },
+    record: {
+      fulltextUrl: process.env.EUROPEANA_RECORD_API_FULLTEXT_URL_PRIVATE,
+      url: process.env.EUROPEANA_RECORD_API_URL_PRIVATE
+    },
+    thumbnail: {
+      url: process.env.EUROPEANA_THUMBNAIL_API_URL_PRIVATE
+    },
+    set: {
+      url: process.env.EUROPEANA_SET_API_URL_PRIVATE
+    }
+  }
+};
+
 export default {
   /*
   ** Runtime config
@@ -68,7 +133,24 @@ export default {
     },
     axiosLogger: {
       clearParams: process.env.AXIOS_LOGGER_CLEAR_PARAMS?.split(',') || ['wskey'],
-      httpMethods: process.env.AXIOS_LOGGER_HTTP_METHODS?.toUpperCase().split(',')
+      httpMethods: process.env.AXIOS_LOGGER_HTTP_METHODS?.toUpperCase().split(','),
+      // Construct a map of Europeana API URLs to rewrite for logging, so that
+      // private network hostnames are replaced with the public equivalent.
+      rewriteOrigins: Object.keys(privateRuntimeConfigEuropeana.apis).reduce((memo, api) => {
+        const urlProps = Object.keys(privateRuntimeConfigEuropeana.apis[api])
+          .filter((prop) => prop.toLowerCase().endsWith('url'));
+
+        for (const urlProp of urlProps) {
+          if (privateRuntimeConfigEuropeana.apis[api][urlProp]) {
+            memo.push({
+              from: privateRuntimeConfigEuropeana.apis[api][urlProp],
+              to: publicRuntimeConfigEuropeana.apis[api][urlProp]
+            });
+          }
+        }
+
+        return memo;
+      }, [])
     },
     contentful: {
       spaceId: process.env.CTF_SPACE_ID,
@@ -97,46 +179,7 @@ export default {
         ]
       }
     },
-    europeana: {
-      apis: {
-        annotation: {
-          url: process.env.EUROPEANA_ANNOTATION_API_URL,
-          key: process.env.EUROPEANA_ANNOTATION_API_KEY || process.env.EUROPEANA_API_KEY
-        },
-        entity: {
-          url: process.env.EUROPEANA_ENTITY_API_URL || EUROPEANA_ENTITY_API_BASE_URL,
-          key: process.env.EUROPEANA_ENTITY_API_KEY || process.env.EUROPEANA_API_KEY
-        },
-        entityManagement: {
-          url: process.env.EUROPEANA_ENTITY_MANAGEMENT_API_URL || process.env.EUROPEANA_ENTITY_API_URL || EUROPEANA_ENTITY_MANAGEMENT_API_BASE_URL
-        },
-        iiifPresentation: {
-          media: {
-            url: process.env.EUROPEANA_MEDIA_IIIF_PRESENTATION_API_URL || EUROPEANA_IIIF_PRESENTATION_URL
-          }
-        },
-        recommendation: {
-          url: process.env.EUROPEANA_RECOMMENDATION_API_URL
-        },
-        record: {
-          fulltextUrl: process.env.EUROPEANA_RECORD_API_FULLTEXT_URL || EUROPEANA_RECORD_API_FULLTEXT_URL,
-          url: process.env.EUROPEANA_RECORD_API_URL || EUROPEANA_RECORD_API_BASE_URL,
-          key: process.env.EUROPEANA_RECORD_API_KEY || process.env.EUROPEANA_API_KEY
-        },
-        thumbnail: {
-          url: process.env.EUROPEANA_THUMBNAIL_API_URL
-        },
-        set: {
-          url: process.env.EUROPEANA_SET_API_URL || EUROPEANA_SET_API_BASE_URL,
-          key: process.env.EUROPEANA_SET_API_KEY || process.env.EUROPEANA_API_KEY
-        }
-      },
-      proxy: {
-        media: {
-          url: process.env.EUROPEANA_MEDIA_PROXY_URL || EUROPEANA_MEDIA_PROXY_URL
-        }
-      }
-    },
+    europeana: publicRuntimeConfigEuropeana,
     features: features(),
     hotjar: {
       id: process.env.HOTJAR_ID,
@@ -176,29 +219,7 @@ export default {
     contentful: {
       graphQlOrigin: process.env.CTF_GRAPHQL_ORIGIN_PRIVATE
     },
-    europeana: {
-      apis: {
-        annotation: {
-          url: process.env.EUROPEANA_ANNOTATION_API_URL_PRIVATE
-        },
-        entity: {
-          url: process.env.EUROPEANA_ENTITY_API_URL_PRIVATE
-        },
-        recommendation: {
-          url: process.env.EUROPEANA_RECOMMENDATION_API_URL_PRIVATE
-        },
-        record: {
-          fulltextUrl: process.env.EUROPEANA_RECORD_API_FULLTEXT_URL_PRIVATE,
-          url: process.env.EUROPEANA_RECORD_API_URL_PRIVATE
-        },
-        thumbnail: {
-          url: process.env.EUROPEANA_THUMBNAIL_API_URL_PRIVATE
-        },
-        set: {
-          url: process.env.EUROPEANA_SET_API_URL_PRIVATE
-        }
-      }
-    },
+    europeana: privateRuntimeConfigEuropeana,
     jira: {
       origin: process.env.JIRA_API_ORIGIN,
       username: process.env.JIRA_API_USERNAME,

--- a/packages/portal/nuxt.config.js
+++ b/packages/portal/nuxt.config.js
@@ -85,9 +85,6 @@ const privateRuntimeConfigEuropeana = {
       fulltextUrl: process.env.EUROPEANA_RECORD_API_FULLTEXT_URL_PRIVATE,
       url: process.env.EUROPEANA_RECORD_API_URL_PRIVATE
     },
-    thumbnail: {
-      url: process.env.EUROPEANA_THUMBNAIL_API_URL_PRIVATE
-    },
     set: {
       url: process.env.EUROPEANA_SET_API_URL_PRIVATE
     }

--- a/packages/portal/nuxt.config.js
+++ b/packages/portal/nuxt.config.js
@@ -190,7 +190,7 @@ export default {
         record: {
           fulltextUrl: process.env.EUROPEANA_RECORD_API_FULLTEXT_URL_PRIVATE,
           url: process.env.EUROPEANA_RECORD_API_URL_PRIVATE
-        }
+        },
         thumbnail: {
           url: process.env.EUROPEANA_THUMBNAIL_API_URL_PRIVATE
         },

--- a/packages/portal/nuxt.config.js
+++ b/packages/portal/nuxt.config.js
@@ -174,7 +174,30 @@ export default {
 
   privateRuntimeConfig: {
     contentful: {
-      graphQlOrigin: process.env.CTF_GRAPHQL_ORIGIN_PRIVATE || process.env.CTF_GRAPHQL_ORIGIN
+      graphQlOrigin: process.env.CTF_GRAPHQL_ORIGIN_PRIVATE
+    },
+    europeana: {
+      apis: {
+        annotation: {
+          url: process.env.EUROPEANA_ANNOTATION_API_URL_PRIVATE
+        },
+        entity: {
+          url: process.env.EUROPEANA_ENTITY_API_URL_PRIVATE
+        },
+        recommendation: {
+          url: process.env.EUROPEANA_RECOMMENDATION_API_URL_PRIVATE
+        },
+        record: {
+          fulltextUrl: process.env.EUROPEANA_RECORD_API_FULLTEXT_URL_PRIVATE,
+          url: process.env.EUROPEANA_RECORD_API_URL_PRIVATE
+        }
+        thumbnail: {
+          url: process.env.EUROPEANA_THUMBNAIL_API_URL_PRIVATE
+        },
+        set: {
+          url: process.env.EUROPEANA_SET_API_URL_PRIVATE
+        }
+      }
     },
     jira: {
       origin: process.env.JIRA_API_ORIGIN,

--- a/packages/portal/nuxt.config.js
+++ b/packages/portal/nuxt.config.js
@@ -15,9 +15,11 @@ import i18nDateTime from './src/plugins/i18n/datetime.js';
 import { parseQuery, stringifyQuery } from './src/plugins/vue-router.cjs';
 import features, { featureIsEnabled, featureNotificationExpiration } from './src/features/index.js';
 
+import { BASE_URL as EUROPEANA_ANNOTATION_API_BASE_URL } from './src/plugins/europeana/annotation.js';
 import { BASE_URL as EUROPEANA_ENTITY_API_BASE_URL } from './src/plugins/europeana/entity.js';
 import { BASE_URL as EUROPEANA_ENTITY_MANAGEMENT_API_BASE_URL } from './src/plugins/europeana/entity-management.js';
 import { BASE_URL as EUROPEANA_MEDIA_PROXY_URL } from './src/plugins/europeana/proxy.js';
+import { BASE_URL as EUROPEANA_RECOMMENDATION_API_BASE_URL } from './src/plugins/europeana/recommendation.js';
 import {
   BASE_URL as EUROPEANA_RECORD_API_BASE_URL,
   FULLTEXT_BASE_URL as EUROPEANA_RECORD_API_FULLTEXT_URL
@@ -32,7 +34,7 @@ const buildPublicPath = () => {
 const publicRuntimeConfigEuropeana = {
   apis: {
     annotation: {
-      url: process.env.EUROPEANA_ANNOTATION_API_URL,
+      url: process.env.EUROPEANA_ANNOTATION_API_URL || EUROPEANA_ANNOTATION_API_BASE_URL,
       key: process.env.EUROPEANA_ANNOTATION_API_KEY || process.env.EUROPEANA_API_KEY
     },
     entity: {
@@ -48,7 +50,7 @@ const publicRuntimeConfigEuropeana = {
       }
     },
     recommendation: {
-      url: process.env.EUROPEANA_RECOMMENDATION_API_URL
+      url: process.env.EUROPEANA_RECOMMENDATION_API_URL || EUROPEANA_RECOMMENDATION_API_BASE_URL
     },
     record: {
       fulltextUrl: process.env.EUROPEANA_RECORD_API_FULLTEXT_URL || EUROPEANA_RECORD_API_FULLTEXT_URL,

--- a/packages/portal/src/modules/axios-logger/templates/plugin.js
+++ b/packages/portal/src/modules/axios-logger/templates/plugin.js
@@ -26,7 +26,7 @@ const requestUri = (requestConfig, moduleConfig) => {
     uri = `${requestConfig.baseURL}${uri}`;
   }
 
-  for (const rewriteOrigin of moduleConfig.rewriteOrigins) {
+  for (const rewriteOrigin of (moduleConfig?.rewriteOrigins || [])) {
     if (uri.startsWith(rewriteOrigin.from)) {
       uri = uri.replace(rewriteOrigin.from, rewriteOrigin.to);
     }

--- a/packages/portal/src/modules/axios-logger/templates/plugin.js
+++ b/packages/portal/src/modules/axios-logger/templates/plugin.js
@@ -26,6 +26,12 @@ const requestUri = (requestConfig, moduleConfig) => {
     uri = `${requestConfig.baseURL}${uri}`;
   }
 
+  for (const rewriteOrigin of moduleConfig.rewriteOrigins) {
+    if (uri.startsWith(rewriteOrigin.from)) {
+      uri = uri.replace(rewriteOrigin.from, rewriteOrigin.to);
+    }
+  }
+
   return uri;
 };
 

--- a/packages/portal/tests/unit/modules/axios-logger/templates/plugin.spec.js
+++ b/packages/portal/tests/unit/modules/axios-logger/templates/plugin.spec.js
@@ -130,5 +130,30 @@ describe('modules/axios-logger/templates/plugin', () => {
         url: 'https://api.example.org/search.json?query=*&apiKey='
       })).toBe(true);
     });
+
+    it('rewrites origins specified by config', () => {
+      const configuredContext = {
+        ...context,
+        $config: {
+          axiosLogger: {
+            rewriteOrigins: [
+              { from: 'http://api.local/record', to: 'https://api.example.org/record' }
+            ]
+          }
+        }
+      };
+      const requestConfig = {
+        method: 'get',
+        url: 'http://api.local/record/search.json'
+      };
+
+      const wrapper = factory(configuredContext);
+      wrapper.requestInterceptor(requestConfig);
+
+      expect(context.store.commit.calledWith('axiosLogger/push', {
+        method: 'GET',
+        url: 'https://api.example.org/record/search.json'
+      })).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
To be used in scenarios such as SSRs to a Kubernetes deployment where the API is on the same cluster, avoiding the use of external networking/DNS.

e.g. `EUROPEANA_RECORD_API_URL_PRIVATE: http://search-api-service-test.test.svc.cluster.local/record`, if service name is "search-api-service-test", namespace is "test" and port is exposed to network as 80.