### PR TITLE
chore: reduce interval and timeout on chrome healthcheck

### DIFF
--- a/tests/e2e/docker/docker-compose.yml
+++ b/tests/e2e/docker/docker-compose.yml
@@ -45,6 +45,8 @@ services:
     image: selenium/standalone-chrome:88.0
     healthcheck:
       test: curl -fs http://localhost:4444 || exit 1
+      interval: 5s
+      timeout: 2s
     environment:
       - DBUS_SESSION_BUS_ADDRESS=/dev/null
       - LANG=en_GB.UTF-8
@@ -55,6 +57,8 @@ services:
     image: selenium/standalone-chrome:88.0
     healthcheck:
       test: curl -fs http://localhost:4444 || exit 1
+      interval: 5s
+      timeout: 2s
     environment:
       - DBUS_SESSION_BUS_ADDRESS=/dev/null
       - LANG=ja_JP.UTF-8
@@ -65,6 +69,8 @@ services:
     image: selenium/standalone-chrome:88.0
     healthcheck:
       test: curl -fs http://localhost:4444 || exit 1
+      interval: 5s
+      timeout: 2s
     environment:
       - DBUS_SESSION_BUS_ADDRESS=/dev/null
       - LANG=nl_NL.UTF-8


### PR DESCRIPTION
Running the e2e tests via Docker Compose hangs for 30s after starting the containers, due to the [default healthcheck interval](https://docs.docker.com/engine/reference/builder/#healthcheck) (for the Chrome containers) being 30s.

This reduces that interval to 5s, so e2e tests will start running 25s earlier, provided the healthcheck passes.