### PR TITLE
chore: test size of docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,7 @@ jobs:
       -
         name: Check image size
         env:
-          DOCKER_IMAGE_SIZE_LIMIT: '280M'
+          DOCKER_IMAGE_SIZE_LIMIT: '250M'
         run: |
           docker_image_size=$(docker image inspect --format '{{.Size}}' ${{ needs.metadata.outputs.docker-full-tag }})
           if [ ${docker_image_size} -gt $(numfmt --from=si ${DOCKER_IMAGE_SIZE_LIMIT}) ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,6 @@ jobs:
           file: ./packages/portal/Dockerfile
           pull: true
           push: ${{ github.actor != 'dependabot[bot]' }}
-          load: true
           cache-from: type=gha,scope=${{ github.ref_name }}-app
           cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-app
           tags: ${{ needs.metadata.outputs.docker-tags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,7 @@ jobs:
           DOCKER_IMAGE_SIZE_LIMIT: '250M'
         run: |
           docker_image_size=$(docker image inspect --format '{{.Size}}' ${{ needs.metadata.outputs.docker-full-tag }})
-          [ ${docker_image_size} -gt $(numfmt --from=si ${DOCKER_IMAGE_SIZE_LIMIT}) ]; then
+          if [ ${docker_image_size} -gt $(numfmt --from=si ${DOCKER_IMAGE_SIZE_LIMIT}) ]; then
             echo "Image size $(numfmt --to=si ${docker_image_size}) exceeds limit ${DOCKER_IMAGE_SIZE_LIMIT}"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,9 +247,6 @@ jobs:
           tags: ${{ needs.metadata.outputs.docker-full-tag }}
           cache-from: type=gha,scope=${{ github.ref_name }}-app
       -
-        name: Output step summary
-        run: docker image ls ${{ needs.metadata.outputs.docker-full-tag }} >> $GITHUB_STEP_SUMMARY
-      -
         name: Check image size
         env:
           DOCKER_IMAGE_SIZE_LIMIT: '250M'
@@ -257,7 +254,8 @@ jobs:
           docker_image_size=$(docker image inspect --format '{{.Size}}' ${{ needs.metadata.outputs.docker-full-tag }})
           if [ ${docker_image_size} -gt $(numfmt --from=si ${DOCKER_IMAGE_SIZE_LIMIT}) ]; then
             echo "::error ::Image size $(numfmt --to=si ${docker_image_size}) exceeds limit ${DOCKER_IMAGE_SIZE_LIMIT}"
-            exit 1
+          else
+            echo "::notice ::Image size $(numfmt --to=si ${docker_image_size}) within limit ${DOCKER_IMAGE_SIZE_LIMIT}"
           fi
 
   # Run size tests on non-draft pull requests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,9 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-app
           tags: ${{ needs.metadata.outputs.docker-tags }}
           labels: ${{ needs.metadata.outputs.docker-labels }}
+      -
+        name: Output step summary
+        run: docker image ls ${{ needs.metadata.outputs.docker-full-tag }} >> $GITHUB_STEP_SUMMARY
 
   # Run size tests on non-draft pull requests
   test-size:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,7 @@ jobs:
           docker_image_size=$(docker image inspect --format '{{.Size}}' ${{ needs.metadata.outputs.docker-full-tag }})
           if [ ${docker_image_size} -gt $(numfmt --from=si ${DOCKER_IMAGE_SIZE_LIMIT}) ]; then
             echo "::error ::Image size $(numfmt --to=si ${docker_image_size}) exceeds limit ${DOCKER_IMAGE_SIZE_LIMIT}"
+            exit 1
           else
             echo "::notice ::Image size $(numfmt --to=si ${docker_image_size}) within limit ${DOCKER_IMAGE_SIZE_LIMIT}"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,7 @@ jobs:
           file: ./packages/portal/Dockerfile
           pull: true
           push: ${{ github.actor != 'dependabot[bot]' }}
+          load: true
           cache-from: type=gha,scope=${{ github.ref_name }}-app
           cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-app
           tags: ${{ needs.metadata.outputs.docker-tags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,8 +238,28 @@ jobs:
           tags: ${{ needs.metadata.outputs.docker-tags }}
           labels: ${{ needs.metadata.outputs.docker-labels }}
       -
+        name: Build (from cache) and load app image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./packages/portal/Dockerfile
+          pull: true
+          load: true
+          tags: ${{ needs.metadata.outputs.docker-full-tag }}
+          cache-from: type=gha,scope=${{ github.ref_name }}-app
+      -
         name: Output step summary
         run: docker image ls ${{ needs.metadata.outputs.docker-full-tag }} >> $GITHUB_STEP_SUMMARY
+      -
+        name: Check image size
+        env:
+          DOCKER_IMAGE_SIZE_LIMIT: '250M'
+        run: |
+          docker_image_size=$(docker image inspect --format '{{.Size}}' ${{ needs.metadata.outputs.docker-full-tag }})
+          [ ${docker_image_size} -gt $(numfmt --from=si ${DOCKER_IMAGE_SIZE_LIMIT}) ]; then
+            echo "Image size $(numfmt --to=si ${docker_image_size}) exceeds limit ${DOCKER_IMAGE_SIZE_LIMIT}"
+            exit 1
+          fi
 
   # Run size tests on non-draft pull requests
   test-size:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
         run: |
           docker_image_size=$(docker image inspect --format '{{.Size}}' ${{ needs.metadata.outputs.docker-full-tag }})
           if [ ${docker_image_size} -gt $(numfmt --from=si ${DOCKER_IMAGE_SIZE_LIMIT}) ]; then
-            echo "Image size $(numfmt --to=si ${docker_image_size}) exceeds limit ${DOCKER_IMAGE_SIZE_LIMIT}"
+            echo "::error ::Image size $(numfmt --to=si ${docker_image_size}) exceeds limit ${DOCKER_IMAGE_SIZE_LIMIT}"
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,7 @@ jobs:
       -
         name: Check image size
         env:
-          DOCKER_IMAGE_SIZE_LIMIT: '250M'
+          DOCKER_IMAGE_SIZE_LIMIT: '280M'
         run: |
           docker_image_size=$(docker image inspect --format '{{.Size}}' ${{ needs.metadata.outputs.docker-full-tag }})
           if [ ${docker_image_size} -gt $(numfmt --from=si ${DOCKER_IMAGE_SIZE_LIMIT}) ]; then


### PR DESCRIPTION
* sets a size limit on the built Docker image for the portal app (280M)
* tests this during the GHA CI workflow
* if OK, outputs a notice annotation (shown on the [GHA summary](https://github.com/europeana/portal.js/actions/runs/4353326438))
* if too big, output an error annotation (shown on the [GHA summary](https://github.com/europeana/portal.js/actions/runs/4353356150))