### PR TITLE
feat: lookup WR edm:type from URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "workspaces": [
         "packages/*"
       ],
+      "dependencies": {
+        "mime-types": "^2.1.35"
+      },
       "devDependencies": {
         "@babel/core": "^7.19.1",
         "@babel/preset-env": "^7.19.1",

--- a/package.json
+++ b/package.json
@@ -71,5 +71,8 @@
     "type": "git",
     "url": "https://github.com/europeana/portal.js.git"
   },
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "mime-types": "^2.1.35"
+  }
 }

--- a/packages/portal/src/plugins/europeana/web-resource.js
+++ b/packages/portal/src/plugins/europeana/web-resource.js
@@ -33,6 +33,7 @@ export const WEB_RESOURCE_FIELDS = [
   'ebucoreHeight',
   'ebucoreWidth',
   'edmCodecName',
+  'edmType',
   'isNextInSequence',
   'svcsHasService',
   'webResourceEdmRights',
@@ -81,7 +82,9 @@ export default class WebResource {
 
   // TODO: 3D media types?
   get edmType() {
-    if (this.hasImageMediaType) {
+    if (this['_edmType']) {
+      return this['_edmType'];
+    } else if (this.hasImageMediaType) {
       return EDM_TYPE_IMAGE;
     } else if (this.hasSoundMediaType) {
       return EDM_TYPE_SOUND;
@@ -92,6 +95,10 @@ export default class WebResource {
     } else {
       return undefined;
     }
+  }
+
+  set edmType(edmType) {
+    this['_edmType'] = edmType;
   }
 
   get isHTMLVideo() {

--- a/packages/portal/tests/unit/plugins/europeana/web-resource.spec.js
+++ b/packages/portal/tests/unit/plugins/europeana/web-resource.spec.js
@@ -12,6 +12,12 @@ describe('plugins/europeana/web-resource', () => {
     });
 
     describe('.edmType', () => {
+      it('returns stored value if explicitly set', () => {
+        const wr = new WebResource({ edmType: '3D' });
+
+        expect(wr.edmType).toBe('3D');
+      });
+
       it('is IMAGE if ebucoreHasMimeType starts with image/', () => {
         const wr = new WebResource({ ebucoreHasMimeType: 'image/jpeg' });
 


### PR DESCRIPTION
**NB: don't merge. Refactor for #1727.**

If no ebucore:hasMimeType stored.

e.g. item `/09102/_GNM_693983` where video and audio WRs do not have technical metadata, but their URLs include filename extensions.