### PR TITLE
fix: api filter - sidebar fixes

### DIFF
--- a/packages/portal/src/components/search/SideFilters.vue
+++ b/packages/portal/src/components/search/SideFilters.vue
@@ -350,9 +350,6 @@
       contentTierFacetSwitchApplied() {
         return this.contentTierFacetSwitch && this.filters.contentTier;
       },
-      selectedFiltersCount() {
-        return Object.keys(this.filters).length;
-      },
       filtersTitle() {
         return this.$t('searchFilters', { count: this.resettableFilters.length ? `(${this.resettableFilters.length})` : '' });
       }

--- a/packages/portal/src/components/search/SideFilters.vue
+++ b/packages/portal/src/components/search/SideFilters.vue
@@ -52,7 +52,7 @@
                   :label="$t('facets.api.switch')"
                   :tooltip="$t('facets.api.switchMoreInfo')"
                   checked-value="fulltext"
-                  unchecked-value="metadata"
+                  :unchecked-value="STANDARD_API_DEFAULT"
                   :default-value="apiFilterDefaultValue"
                   :collection="collection"
                   @changed="changeFacet"
@@ -211,6 +211,7 @@
           'proxy_dc_format.en',
           'proxy_dcterms_medium.en'
         ],
+        STANDARD_API_DEFAULT: 'metadata',
         hideFilterSheet: true,
         showAdditionalFilters: false
       };
@@ -247,7 +248,8 @@
         if (this.contentTierFacetSwitch && this.filters.contentTier) {
           filters.push('contentTier');
         }
-        if (this.enableApiFilter && (this.filters.api !== this.apiFilterDefaultValue)) {
+
+        if (this.enableApiFilter && (this.filters.api !== this.STANDARD_API_DEFAULT)) {
           filters.push('api');
         }
         if (this.enableDateFilter && this.filters[this.dateFilterField]) {
@@ -366,7 +368,7 @@
       },
       filtersTitle() {
         if (this.advancedSearchEnabled) {
-          return this.$t('searchFilters', { count: this.selectedFiltersCount ? `(${this.selectedFiltersCount})` : '' });
+          return this.$t('searchFilters', { count: this.resettableFilters.length ? `(${this.resettableFilters.length})` : '' });
         } else {
           return this.$t('filterResults');
         }
@@ -417,7 +419,7 @@
         // Remove collection-specific filters when collection is changed
         if (Object.prototype.hasOwnProperty.call(selected, this.COLLECTION_FACET_NAME) || !this.collection) {
           for (const name in filters) {
-            if (name !== this.COLLECTION_FACET_NAME && !this.DEFAULT_FACET_NAMES.concat(this.ADDITIONAL_FACET_NAMES).includes(name) && this.resettableFilters.includes(name)) {
+            if (name !== this.COLLECTION_FACET_NAME && !this.DEFAULT_FACET_NAMES.concat(this.ADDITIONAL_FACET_NAMES).includes(name)) {
               filters[name] = [];
             }
           }

--- a/packages/portal/tests/unit/components/search/SideFilters.spec.js
+++ b/packages/portal/tests/unit/components/search/SideFilters.spec.js
@@ -545,6 +545,9 @@ describe('components/search/SideFilters', () => {
 
       describe('in a collection having custom filters', () => {
         const propsData = {
+          apiParams: {
+            api: 'fulltext'
+          },
           userParams: {
             qf: ['proxy_dcterms_issued:1900-01-01']
           },
@@ -560,6 +563,40 @@ describe('components/search/SideFilters', () => {
           expect(updates.qf).toContain('proxy_dcterms_issued:1900-01-02');
           expect(updates.api).toBe('metadata');
         });
+
+        describe('when collection is changed', () => {
+          const wrapper = factory({ propsData });
+          const selected = { 'collection': 'art' };
+
+          it('removes collection-specific facet filters', () => {
+            const updates = wrapper.vm.queryUpdatesForFacetChanges(selected);
+
+            expect(updates.qf).not.toContain('proxy_dcterms_issued:1900-01-01');
+          });
+
+          it('removes the api filter', () => {
+            const updates = wrapper.vm.queryUpdatesForFacetChanges(selected);
+
+            expect(updates.api).toStrictEqual([]);
+          });
+        });
+
+        describe('when collection is removed', () => {
+          const wrapper = factory({ propsData });
+          const selected = { 'collection': null };
+
+          it('removes collection-specific facet filters', () => {
+            const updates = wrapper.vm.queryUpdatesForFacetChanges(selected);
+
+            expect(updates.qf).not.toContain('proxy_dcterms_issued:1900-01-01');
+          });
+
+          it('removes the api filter', () => {
+            const updates = wrapper.vm.queryUpdatesForFacetChanges(selected);
+
+            expect(updates.api).toStrictEqual([]);
+          });
+        });
       });
 
       describe('with collection-specific facets already selected', () => {
@@ -568,7 +605,7 @@ describe('components/search/SideFilters', () => {
             qf: [
               'CREATOR:"Missoni (Designer)"',
               'TYPE:"IMAGE"',
-              'contentTier:*'
+              'contentTier:"3"'
             ]
           },
           collection: 'fashion'
@@ -593,7 +630,7 @@ describe('components/search/SideFilters', () => {
           it('removes tier filter', () => {
             const updates = wrapper.vm.queryUpdatesForFacetChanges(selected);
 
-            expect(updates.qf).not.toContain('contentTier:*');
+            expect(updates.qf).not.toContain('contentTier:"3"');
           });
         });
 


### PR DESCRIPTION
properly remove the api filter on theme exit/switch.
fix the resettable count for the api filter as it will be reset to the standard default, not the theme's default