### PR TITLE
feat: filter item page annotation motivations

### DIFF
--- a/packages/portal/src/components/metadata/MetadataBox.vue
+++ b/packages/portal/src/components/metadata/MetadataBox.vue
@@ -42,31 +42,6 @@
           </b-card-text>
         </b-tab>
         <b-tab
-          v-if="Boolean(transcribingAnnotations.length)"
-          :title="$t('record.transcription')"
-          data-qa="transcription tab"
-        >
-          <b-card-text
-            text-tag="div"
-          >
-            <p
-              class="disclaimer px-2 pb-3 d-flex"
-            >
-              {{ $t('record.transcriptionDisclaimer') }}
-            </p>
-            <div
-              v-for="(transcription, index) in transcribingAnnotations"
-              :key="index"
-              :lang="transcription.body.language"
-            >
-              <p>{{ transcription.body.value }}</p>
-              <hr
-                v-if="index !== (transcribingAnnotations.length - 1)"
-              >
-            </div>
-          </b-card-text>
-        </b-tab>
-        <b-tab
           v-if="mappableLocation"
           :title="$t('record.location')"
           class="p-0"
@@ -115,10 +90,6 @@
       metadataLanguage: {
         type: String,
         default: null
-      },
-      transcribingAnnotations: {
-        type: Array,
-        default: () => []
       }
     },
 

--- a/packages/portal/src/lang/en.js
+++ b/packages/portal/src/lang/en.js
@@ -1024,9 +1024,7 @@ export default {
     "similarItems": "Similar items",
     "status": {
       "unpublished": "[Unpublished item]"
-    },
-    "transcription": "Transcription",
-    "transcriptionDisclaimer": "This content is contributed by the public, not by the institution that provided this item."
+    }
   },
   "related": {
     "categoryTags": {

--- a/packages/portal/src/pages/item/_.vue
+++ b/packages/portal/src/pages/item/_.vue
@@ -98,7 +98,6 @@
               :metadata="fieldsAndKeywords"
               :location="locationData"
               :metadata-language="metadataLanguage"
-              :transcribing-annotations="transcribingAnnotations || []"
             />
           </b-col>
         </b-row>
@@ -131,7 +130,7 @@
             :dc-type="title"
             :dc-subject="metadata.dcSubject"
             :dc-creator="metadata.dcCreator"
-            :edm-data-provider="metadata.edmDataProvider?.def?.[0].prefLabel"
+            :edm-data-provider="dataProviderEntityLabel"
           />
         </client-only>
       </b-container>
@@ -296,11 +295,11 @@
       dataProviderEntityUri() {
         return this.metadata.edmDataProvider?.def?.[0].about || null;
       },
+      dataProviderEntityLabel() {
+        return this.metadata.edmDataProvider?.def?.[0].prefLabel;
+      },
       taggingAnnotations() {
         return this.annotationsByMotivation('tagging');
-      },
-      transcribingAnnotations() {
-        return this.annotationsByMotivation('transcribing');
       },
       linkForContributingAnnotation() {
         return this.annotationsByMotivation('linkForContributing')[0]?.body;
@@ -377,6 +376,7 @@
       async fetchAnnotations() {
         this.annotations = await this.$apis.annotation.search({
           query: `target_record_id:"${this.identifier}"`,
+          qf: 'motivation:(linkForContributing OR tagging)',
           profile: 'dereference'
         });
       },

--- a/packages/portal/src/pages/item/_.vue
+++ b/packages/portal/src/pages/item/_.vue
@@ -410,11 +410,14 @@
               }
             }
           }
-        } else {
+        } else if (this.relatedEntityUris.length > 0) {
+          this.dataProviderEntity = null;
+
           const entities  = await this.$apis.entity.find(this.relatedEntityUris, params);
-          if (entities)  {
-            this.relatedCollections = entities;
-          }
+          this.relatedCollections = entities ? entities : [];
+        } else {
+          this.dataProviderEntity = null;
+          this.relatedCollections = [];
         }
       }
     }

--- a/packages/portal/tests/unit/pages/item/_.spec.js
+++ b/packages/portal/tests/unit/pages/item/_.spec.js
@@ -203,15 +203,42 @@ describe('pages/item/_.vue', () => {
     describe('client side fetching', () => {
       const $fetchState = { pending: false };
 
-      it('gets entities and annotations', async() => {
-        const wrapper = await factory({ mocks: { $fetchState } });
-        sinon.spy(wrapper.vm, 'fetchEntities');
-        sinon.spy(wrapper.vm, 'fetchAnnotations');
+      it('fetches annotations', () => {
+        const wrapper = factory({ mocks: { $fetchState } });
 
-        await wrapper.vm.mounted();
+        expect(wrapper.vm.$apis.annotation.search.calledWith({
+          query: 'target_record_id:"/123/abc"',
+          qf: 'motivation:(linkForContributing OR tagging)',
+          profile: 'dereference'
+        })).toBe(true);
+      });
 
-        expect(wrapper.vm.fetchEntities.called).toBe(true);
-        expect(wrapper.vm.fetchAnnotations.called).toBe(true);
+      it('fetches entities', () => {
+        const wrapper = factory({
+          data: {
+            agents: [{ about: 'http://data.europeana.eu/agent/1' }],
+            concepts: [{ about: 'http://data.europeana.eu/concept/1' }],
+            places: [{ about: 'http://data.europeana.eu/place/1' }],
+            timespans: [{ about: 'http://data.europeana.eu/timespan/1' }]
+          },
+          mocks: { $fetchState }
+        });
+
+        expect(wrapper.vm.$apis.entity.find.calledWith(
+          [
+            'http://data.europeana.eu/agent/1',
+            'http://data.europeana.eu/concept/1',
+            'http://data.europeana.eu/timespan/1',
+            'http://data.europeana.eu/place/1'
+          ],
+          { fl: 'skos_prefLabel.*,isShownBy,isShownBy.thumbnail,foaf_logo' }
+        )).toBe(true);
+      });
+
+      it('does not fetch entities if there are none', () => {
+        const wrapper = factory({ mocks: { $fetchState } });
+
+        expect(wrapper.vm.$apis.entity.find.called).toBe(false);
       });
     });
   });


### PR DESCRIPTION
Changes:
* remove transcription tab from item page, and remove redundant UI text for that tab
* filter annotations retrieved on item page to those with motivation `linkForContributing` or `tagging`
* add a computed property on item page for data provider entity prefLabel
* add handling to the entity retrieval on the item page to prevent making an Entity API request should there be no related entities
