### PR TITLE
feat: cache Matomo visits and organization count

### DIFF
--- a/packages/portal/.env.example
+++ b/packages/portal/.env.example
@@ -85,6 +85,8 @@ OAUTH_CLIENT="YOUR_CLIENT"
 # Matomo URL and site ID
 # MATOMO_HOST=https://matomo.example.org
 # MATOMO_SITE_ID=
+# Auth token for Matomo REST API (used by cachers)
+# MATOMO_AUTH_TOKEN=
 # Time to wait for Matomo script to load from Matomo server and be stored on the
 # VM by vue-matomo, expressed as number of attempted retries, and delay between
 # them (in milliseconds).

--- a/packages/portal/nuxt.config.js
+++ b/packages/portal/nuxt.config.js
@@ -162,6 +162,9 @@ export default {
         }
       }
     },
+    matomo: {
+      authToken: process.env.MATOMO_AUTH_TOKEN
+    },
     redis: {
       url: process.env.REDIS_URL,
       tlsCa: process.env.REDIS_TLS_CA

--- a/packages/portal/src/cachers/README.md
+++ b/packages/portal/src/cachers/README.md
@@ -33,6 +33,10 @@ Entity API.
 
 Localised.
 
+#### `collections:organisations:count`
+Retrieves and caches the number of organization-type, Europeana-scoped entities
+from the Entity API.
+
 #### `collections:organisations:featured`
 Retrieves and caches a daily rotation of 4 times from all organization-type,
 Europeana-scoped entities from the Entity API.
@@ -94,3 +98,9 @@ seeded to today's date, and caches the items' metadata.
 #### `items:type-counts`
 Queries the Europeana Record API for the total number of items available by EDM
 type, of content tiers 1-4.
+
+### `matomo`
+
+#### `matomo:visits`
+Retrieves and caches the number of daily visits to the website from the Matomo
+REST API, calculated as the average number over the past 30 days.

--- a/packages/portal/src/cachers/collections/index.js
+++ b/packages/portal/src/cachers/collections/index.js
@@ -5,6 +5,21 @@ let axiosClient;
 
 const pageSize = 100;
 
+export const countEntities = async(params = {}, config = {}) => {
+  axiosClient = createEuropeanaApiClient(config.europeana?.apis?.entity);
+
+  const response = await axiosClient.get('/search', {
+    params: {
+      ...axiosClient.defaults.config,
+      query: '*:*',
+      scope: 'europeana',
+      pageSize: 0,
+      ...params
+    }
+  });
+  return response.data?.partOf?.total;
+};
+
 const pageOfEntityResults = (page, params = {}) => {
   return axiosClient.get('/search', {
     params: {

--- a/packages/portal/src/cachers/collections/organisations/count.js
+++ b/packages/portal/src/cachers/collections/organisations/count.js
@@ -1,0 +1,12 @@
+import { countEntities } from '../index.js';
+
+const LOCALISE = false;
+const PICK = false;
+
+const data = (config = {}) => countEntities({ type: 'organization' }, config);
+
+export {
+  data,
+  LOCALISE,
+  PICK
+};

--- a/packages/portal/src/cachers/index.js
+++ b/packages/portal/src/cachers/index.js
@@ -8,6 +8,7 @@ const runtimeConfig = defu(nuxtConfig.privateRuntimeConfig, nuxtConfig.publicRun
 
 const cacherNames = [
   'collections:organisations',
+  'collections:organisations:count',
   'collections:organisations:featured',
   'collections:places',
   'collections:places:featured',
@@ -16,7 +17,8 @@ const cacherNames = [
   'collections:topics',
   'collections:topics:featured',
   'items:recent',
-  'items:type-counts'
+  'items:type-counts',
+  'matomo:visits'
 ];
 
 const cacherModule = (cacherName) => {

--- a/packages/portal/src/cachers/matomo/visits.js
+++ b/packages/portal/src/cachers/matomo/visits.js
@@ -1,0 +1,27 @@
+import axios from 'axios';
+
+const LOCALISE = false;
+const PICK = false;
+
+const data = async(config = {}) => {
+  const response = await axios.get('/', {
+    baseURL: config.matomo.host,
+    params: {
+      date: 'yesterday',
+      format: 'JSON',
+      idSite: config.matomo.siteId,
+      method: 'VisitsSummary.get',
+      module: 'API',
+      period: 'day',
+      'token_auth': config.matomo.authToken
+    }
+  });
+
+  return response.data?.['nb_visits'];
+};
+
+export {
+  data,
+  LOCALISE,
+  PICK
+};

--- a/packages/portal/src/cachers/matomo/visits.js
+++ b/packages/portal/src/cachers/matomo/visits.js
@@ -17,6 +17,12 @@ const data = async(config = {}) => {
     }
   });
 
+  // Matomo REST API sometimes returns 200 status code for errors, but with
+  // `result` JSON field being "error"
+  if ((response.status !== 200) || (response.data.result === 'error')) {
+    throw new Error('Failed to get visits data from Matomo');
+  }
+
   const totalVisits = Object.keys(response.data)
     .reduce((memo, date) => memo + (response.data[date]['nb_visits'] || 0), 0);
 

--- a/packages/portal/src/cachers/matomo/visits.js
+++ b/packages/portal/src/cachers/matomo/visits.js
@@ -7,7 +7,7 @@ const data = async(config = {}) => {
   const response = await axios.get('/', {
     baseURL: config.matomo.host,
     params: {
-      date: 'yesterday',
+      date: 'last30',
       format: 'JSON',
       idSite: config.matomo.siteId,
       method: 'VisitsSummary.get',
@@ -17,7 +17,10 @@ const data = async(config = {}) => {
     }
   });
 
-  return response.data?.['nb_visits'];
+  const totalVisits = Object.keys(response.data)
+    .reduce((memo, date) => memo + (response.data[date]['nb_visits'] || 0), 0);
+
+  return Math.round(totalVisits / Object.keys(response.data).length);
 };
 
 export {

--- a/packages/portal/tests/unit/cachers/collections/organisations/count.spec.js
+++ b/packages/portal/tests/unit/cachers/collections/organisations/count.spec.js
@@ -1,0 +1,22 @@
+import * as cacher from '@/cachers/collections/organisations/count.js';
+import * as baseCacher from '@/cachers/collections/index.js';
+import sinon from 'sinon';
+
+describe('@/cachers/collections/organisations/count', () => {
+  it('counts entities with type: organization', () => {
+    sinon.stub(baseCacher, 'countEntities');
+
+    cacher.data();
+
+    expect(baseCacher.countEntities.calledWith({ type: 'organization' }, {})).toBe(true);
+    sinon.resetHistory();
+  });
+
+  it('picks nothing', () => {
+    expect(cacher.PICK).toBe(false);
+  });
+
+  it('localises nothing', () => {
+    expect(cacher.LOCALISE).toBe(false);
+  });
+});

--- a/packages/portal/tests/unit/cachers/matomo/visits.spec.js
+++ b/packages/portal/tests/unit/cachers/matomo/visits.spec.js
@@ -1,0 +1,57 @@
+import nock from 'nock';
+import * as cacher from '@/cachers/matomo/visits.js';
+
+const config = {
+  matomo: {
+    authToken: 'MY_AUTH_TOKEN',
+    host: 'https://stats.example.org',
+    siteId: '1'
+  }
+};
+
+describe('@/cachers/matomo/visits.js', () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe('data', () => {
+    const response = {
+      'nb_visits': 16253
+    };
+
+    beforeEach(() => {
+      nock(config.matomo.host)
+        .get('/')
+        .query(query => (
+          query.date === 'yesterday' &&
+          query.format === 'JSON' &&
+          query.idSite === config.matomo.siteId &&
+          query.method === 'VisitsSummary.get' &&
+          query.module === 'API' &&
+          query.period === 'day' &&
+          query['token_auth'] === config.matomo.authToken
+        ))
+        .reply(200, response);
+    });
+
+    it('fetches the count from the Matomo API', async() => {
+      await cacher.data(config);
+
+      expect(nock.isDone()).toBe(true);
+    });
+
+    it('returns the number of visits, to cache', async() => {
+      const data = await cacher.data(config);
+
+      expect(data).toBe(response['nb_visits']);
+    });
+  });
+
+  it('picks nothing', () => {
+    expect(cacher.PICK).toBe(false);
+  });
+
+  it('localises nothing', () => {
+    expect(cacher.LOCALISE).toBe(false);
+  });
+});

--- a/packages/portal/tests/unit/cachers/matomo/visits.spec.js
+++ b/packages/portal/tests/unit/cachers/matomo/visits.spec.js
@@ -16,14 +16,23 @@ describe('@/cachers/matomo/visits.js', () => {
 
   describe('data', () => {
     const response = {
-      'nb_visits': 16253
+      '2023-01-01': {
+        'nb_visits': undefined
+      },
+      '2023-01-02': {
+        'nb_visits': 10
+      },
+      '2023-01-03': {
+        'nb_visits': 15
+      }
     };
+    const averageVisits = 8;
 
     beforeEach(() => {
       nock(config.matomo.host)
         .get('/')
         .query(query => (
-          query.date === 'yesterday' &&
+          query.date === 'last30' &&
           query.format === 'JSON' &&
           query.idSite === config.matomo.siteId &&
           query.method === 'VisitsSummary.get' &&
@@ -40,10 +49,10 @@ describe('@/cachers/matomo/visits.js', () => {
       expect(nock.isDone()).toBe(true);
     });
 
-    it('returns the number of visits, to cache', async() => {
+    it('returns the average number of visits, to cache', async() => {
       const data = await cacher.data(config);
 
-      expect(data).toBe(response['nb_visits']);
+      expect(data).toBe(averageVisits);
     });
   });
 


### PR DESCRIPTION
* Matomo REST API auth token needs to be set in env var `MATOMO_AUTH_TOKEN`
* New cachers:
  * `collections:organisations:count` - caches the number of Europeana-scoped organization-type entities
  * `matomo:visits` - caches the number of Matomo visits yesterday to the configured site
* NOTE: no new cacher for the total number of items, as that can be derived from the total of all the type-specific items already cached in `items:type-counts`