### PR TITLE
chore: client-only SearchInterface on collection page

### DIFF
--- a/packages/portal/.env.example
+++ b/packages/portal/.env.example
@@ -177,6 +177,14 @@ OAUTH_CLIENT="YOUR_CLIENT"
 # translation.
 # APP_SEARCH_TRANSLATE_LOCALES=es,de
 
+# Search for related items on the collections pages client-side only.
+# If not enabled, items will be searched for server-side too.
+# APP_SEARCH_COLLECTIONS_CLIENT_ONLY=0
+
+# Prevent translation of search results, i.e. related items, on the collections
+# pages, even for the locales set in `APP_SEARCH_TRANSLATE_LOCALES.`
+# APP_SEARCH_COLLECTIONS_DO_NOT_TRANSLATE=0
+
 # Name of a feature to highlight in a notification, from those declared in
 # src/features/notifications.js
 # APP_FEATURE_NOTIFICATION=interestingNewFeature

--- a/packages/portal/nuxt.config.js
+++ b/packages/portal/nuxt.config.js
@@ -29,6 +29,7 @@ export default {
     app: {
       // TODO: rename env vars to prefix w/ APP_, except feature toggles
       baseUrl: process.env.PORTAL_BASE_URL,
+      clientOnlyCollection: process.env.APP_CLIENT_ONLY_COLLECTION,
       galleries: {
         europeanaAccount: process.env.APP_GALLERIES_EUROPEANA_ACCOUNT || 'europeana'
       },

--- a/packages/portal/nuxt.config.js
+++ b/packages/portal/nuxt.config.js
@@ -13,7 +13,7 @@ import versions from './pkg-versions.js';
 import i18nLocales from './src/plugins/i18n/locales.js';
 import i18nDateTime from './src/plugins/i18n/datetime.js';
 import { parseQuery, stringifyQuery } from './src/plugins/vue-router.cjs';
-import features, { featureNotificationExpiration } from './src/features/index.js';
+import features, { featureIsEnabled, featureNotificationExpiration } from './src/features/index.js';
 
 import { nuxtRuntimeConfig as europeanaApisRuntimeConfig, publicPrivateRewriteOrigins } from './src/plugins/apis.js';
 
@@ -29,7 +29,6 @@ export default {
     app: {
       // TODO: rename env vars to prefix w/ APP_, except feature toggles
       baseUrl: process.env.PORTAL_BASE_URL,
-      clientOnlyCollection: process.env.APP_CLIENT_ONLY_COLLECTION,
       galleries: {
         europeanaAccount: process.env.APP_GALLERIES_EUROPEANA_ACCOUNT || 'europeana'
       },
@@ -40,6 +39,10 @@ export default {
       schemaOrgDatasetId: process.env.SCHEMA_ORG_DATASET_ID,
       siteName: APP_SITE_NAME,
       search: {
+        collections: {
+          clientOnly: featureIsEnabled(process.env.APP_SEARCH_COLLECTIONS_CLIENT_ONLY),
+          doNotTranslate: featureIsEnabled(process.env.APP_SEARCH_COLLECTIONS_DO_NOT_TRANSLATE)
+        },
         translateLocales: (process.env.APP_SEARCH_TRANSLATE_LOCALES || '').split(',')
       }
     },

--- a/packages/portal/src/components/search/SearchInterface.vue
+++ b/packages/portal/src/components/search/SearchInterface.vue
@@ -230,6 +230,10 @@
     ],
 
     props: {
+      doNotTranslate: {
+        type: Boolean,
+        default: false
+      },
       perPage: {
         type: Number,
         default: 24
@@ -302,6 +306,10 @@
         if (this.hasFulltextQa) {
           // TODO: ensure this is aware of per-request fulltext url, e.g. from ingress headers
           apiOptions.url = this.$config.europeana.apis.fulltext.url;
+        }
+
+        if (this.translateLang) {
+          apiOptions.translateLang = this.translateLang;
         }
 
         return apiOptions;
@@ -404,6 +412,20 @@
       },
       hasFulltextQa() {
         return this.fulltextQas.length > 0;
+      },
+      translateLang() {
+        // Translation disabled from prop `doNotTranslate`
+        if (this.doNotTranslate) {
+          return null;
+        }
+
+        // Either translate locale(s) not configured, or current locale is not
+        // among them.
+        if (!this.$config?.app?.search?.translateLocales?.includes(this.$i18n.locale)) {
+          return null;
+        }
+
+        return this.$i18n.locale;
       }
     },
 
@@ -423,7 +445,7 @@
 
     methods: {
       async runSearch() {
-        const response = await this.$apis.record.search(this.apiParams, { ...this.apiOptions, locale: this.$i18n.locale });
+        const response = await this.$apis.record.search(this.apiParams, this.apiOptions);
 
         this.hits = response.hits;
         this.lastAvailablePage = response.lastAvailablePage;

--- a/packages/portal/src/pages/collections/_type/_.vue
+++ b/packages/portal/src/pages/collections/_type/_.vue
@@ -9,7 +9,7 @@
       data-qa="error message container"
       :error="$fetchState.error"
     />
-    <template v-else>
+    <client-only v-else>
       <SearchInterface
         v-if="!$fetchState.pending"
         :route="route"
@@ -60,7 +60,7 @@
           </client-only>
         </template>
       </SearchInterface>
-    </template>
+    </client-only>
   </div>
 </template>
 

--- a/packages/portal/src/pages/collections/_type/_.vue
+++ b/packages/portal/src/pages/collections/_type/_.vue
@@ -10,11 +10,12 @@
       :error="$fetchState.error"
     />
     <component
-      :is="$config?.app?.clientOnlyCollection ? 'client-only' : 'div'"
+      :is="$config.app.search.collections.clientOnly ? 'client-only' : 'div'"
       v-else
     >
       <SearchInterface
         v-if="!$fetchState.pending"
+        :do-not-translate="$config.app.search.collections.doNotTranslate"
         :route="route"
         :show-content-tier-toggle="false"
         :show-pins="userIsEntitiesEditor && userIsSetsEditor"

--- a/packages/portal/src/pages/collections/_type/_.vue
+++ b/packages/portal/src/pages/collections/_type/_.vue
@@ -9,7 +9,10 @@
       data-qa="error message container"
       :error="$fetchState.error"
     />
-    <client-only v-else>
+    <component
+      :is="$config?.app?.clientOnlyCollection ? 'client-only' : 'div'"
+      v-else
+    >
       <SearchInterface
         v-if="!$fetchState.pending"
         :route="route"
@@ -60,7 +63,7 @@
           </client-only>
         </template>
       </SearchInterface>
-    </client-only>
+    </component>
   </div>
 </template>
 

--- a/packages/portal/src/plugins/europeana/search.js
+++ b/packages/portal/src/plugins/europeana/search.js
@@ -84,7 +84,7 @@ export function rangeFromQueryParam(paramValue) {
  * @param {string} params.wskey API key, to override `config.record.key`
  * @param {Object} options search options
  * @param {Boolean} options.escape whether or not to escape Lucene reserved characters in the search query
- * @param {string} options.locale source locale for multilingual search
+ * @param {string} options.translateLang source locale for multilingual search
  * @param {string} options.url override the API URL
  * @param {Boolean} options.addContentTierFilter if `true`, add a content tier filter. default `true`
  * @return {{results: Object[], totalResults: number, facets: FacetSet, error: string}} search results for display
@@ -121,12 +121,14 @@ export default (context) => ($axios, params, options = {}) => {
     start
   };
 
-  if (context?.$config?.app?.search?.translateLocales?.includes(localOptions.locale)) {
+  // TODO: this should be the responsibility of the caller; move to an exported
+  //       function for callers to run first, when needed
+  if (localOptions.translateLang) {
     const targetLocale = 'en';
-    if (localOptions.locale !== targetLocale) {
+    if (localOptions.translateLang !== targetLocale) {
       searchParams.profile = `${searchParams.profile},translate`;
-      searchParams.lang = localOptions.locale;
-      searchParams['q.source'] = localOptions.locale;
+      searchParams.lang = localOptions.translateLang;
+      searchParams['q.source'] = localOptions.translateLang;
       searchParams['q.target'] = targetLocale;
     }
   }

--- a/packages/portal/tests/unit/components/search/SearchInterface.spec.js
+++ b/packages/portal/tests/unit/components/search/SearchInterface.spec.js
@@ -34,6 +34,24 @@ const factory = ({ $fetchState = {}, mocks = {}, propsData = {}, data = {} } = {
     $route: { path: '/search', name: 'search', query: {} },
     $error: sinon.spy(),
     localise: (val) => val,
+    $apis: {
+      record: {
+        search: sinon.stub().resolves(searchResult)
+      }
+    },
+    $i18n: {
+      locale: 'en'
+    },
+    $config: {
+      europeana: {
+        apis: {
+          fulltext: {
+            url: 'https://newspapers.eanadev.org/api/v2'
+          }
+        }
+      },
+      ...mocks.$config
+    },
     ...mocks,
     $store: {
       commit: sinon.spy(),
@@ -48,23 +66,6 @@ const factory = ({ $fetchState = {}, mocks = {}, propsData = {}, data = {} } = {
         },
         ...mocks.$store?.state
       }
-    },
-    $config: {
-      europeana: {
-        apis: {
-          fulltext: {
-            url: 'https://newspapers.eanadev.org/api/v2'
-          }
-        }
-      }
-    },
-    $apis: {
-      record: {
-        search: sinon.stub().resolves(searchResult)
-      }
-    },
-    $i18n: {
-      locale: 'en'
     }
   },
   propsData,
@@ -152,6 +153,64 @@ describe('components/search/SearchInterface', () => {
   });
 
   describe('computed', () => {
+    describe('apiOptions', () => {
+      describe('translateLang', () => {
+        describe('when locales to translate are configured', () => {
+          const $config = { app: { search: { translateLocales: ['nl'] } } };
+
+          describe('and current locale is one of the configured locales to translate', () => {
+            const $i18n = { locale: 'nl' };
+
+            describe('and doNotTranslate prop is not set (defaulting to false)', () => {
+              it('returns the current locale', () => {
+                const wrapper = factory({ mocks: { $config, $i18n } });
+
+                const translateLang = wrapper.vm.apiOptions.translateLang;
+
+                expect(translateLang).toBe('nl');
+              });
+            });
+
+            describe('but doNotTranslate prop is set to `true`', () => {
+              const doNotTranslate = true;
+
+              it('is undefined', () => {
+                const wrapper = factory({ mocks: { $config, $i18n }, propsData: { doNotTranslate } });
+
+                const translateLang = wrapper.vm.apiOptions.translateLang;
+
+                expect(translateLang).toBeUndefined();
+              });
+            });
+          });
+
+          describe('but current locale is not one of the configured locales to translate', () => {
+            const $i18n = { locale: 'fr' };
+
+            it('is undefined', () => {
+              const wrapper = factory({ mocks: { $config, $i18n } });
+
+              const translateLang = wrapper.vm.apiOptions.translateLang;
+
+              expect(translateLang).toBeUndefined();
+            });
+          });
+        });
+
+        describe('when locales to translate are not configured', () => {
+          const $config = { app: { search: { translateLocales: [] } } };
+
+          it('is undefined', () => {
+            const wrapper = factory({ mocks: { $config } });
+
+            const translateLang = wrapper.vm.apiOptions.translateLang;
+
+            expect(translateLang).toBeUndefined();
+          });
+        });
+      });
+    });
+
     describe('apiParams', () => {
       it('combines user params and overrides', () => {
         const $route = {

--- a/packages/portal/tests/unit/pages/collections/_type/_.spec.js
+++ b/packages/portal/tests/unit/pages/collections/_type/_.spec.js
@@ -77,6 +77,13 @@ const factory = (options = {}) => shallowMountNuxt(collection, {
     },
     localePath: sinon.stub().returns('/'),
     $error: sinon.spy(),
+    $config: {
+      app: {
+        search: {
+          collections: {}
+        }
+      }
+    },
     $store: {
       state: {
         entity: {

--- a/packages/portal/tests/unit/plugins/europeana/search.spec.js
+++ b/packages/portal/tests/unit/plugins/europeana/search.spec.js
@@ -137,23 +137,21 @@ describe('plugins/europeana/search', () => {
       });
 
       describe('multilingual queries', () => {
-        const context = { $config: { app: { search: { translateLocales: ['es'] } } } };
-
-        it('passes API i18n params if configured and locale option given', async() => {
-          const locale = 'es';
+        it('passes API translation params if translateLang option given', async() => {
+          const translateLang = 'es';
 
           baseRequest()
             .query(query => {
-              return query['q.source'] === locale && query['q.target'] === 'en' && query.lang === locale;
+              return query['q.source'] === translateLang && query['q.target'] === 'en' && query.lang === translateLang;
             })
             .reply(200, defaultResponse);
 
-          await search(context)(null, { query: 'flor' }, { locale });
+          await search()(null, { query: 'flor' }, { translateLang });
 
           expect(nock.isDone()).toBe(true);
         });
 
-        it('does not pass API i18n params if no locale option', async() => {
+        it('does not pass API translation params if no translateLang option', async() => {
           baseRequest()
             .query(query => {
               const queryKeys = Object.keys(query);
@@ -161,13 +159,13 @@ describe('plugins/europeana/search', () => {
             })
             .reply(200, defaultResponse);
 
-          await search(context)(null, { query: 'flor' });
+          await search()(null, { query: 'flor' });
 
           expect(nock.isDone()).toBe(true);
         });
 
-        it('does not pass API i18n params if locale is already "en"', async() => {
-          const locale = 'en';
+        it('does not pass API translation params if translateLang is "en"', async() => {
+          const translateLang = 'en';
 
           baseRequest()
             .query(query => {
@@ -176,7 +174,7 @@ describe('plugins/europeana/search', () => {
             })
             .reply(200, defaultResponse);
 
-          await search(context)(null, { query: 'flor' }, { locale });
+          await search()(null, { query: 'flor' }, { translateLang });
 
           expect(nock.isDone()).toBe(true);
         });


### PR DESCRIPTION
* Two new env vars:
  * `APP_SEARCH_COLLECTIONS_CLIENT_ONLY`: Search for related items on the collections pages client-side only. If not enabled, items will be searched for server-side too.
  * `APP_SEARCH_COLLECTIONS_DO_NOT_TRANSLATE`: Prevent translation of search results, i.e. related items, on the collections pages, even for the locales set in `APP_SEARCH_TRANSLATE_LOCALES.`
* SearchInterface has a new prop, `doNotTranslate`, which will prevent search translation from running even in the configured locales, and which CollectionPage will pass in based on `APP_SEARCH_COLLECTIONS_DO_NOT_TRANSLATE` env var
* In search plugin, stop looking at app config for translation, and instead just look at supplied options, for `translateLang` param, which SearchInterface now supplies
* Fix bug where search queries for facets would not include translation params, resulting in the number of items for the filter being out of sync with the number in the search results
  * NOTE: this fix is going to result in more translations being requested of the API...