### PR TITLE
feat: landing page image card group

### DIFF
--- a/packages/portal/src/components/authored/AuthoredHead.vue
+++ b/packages/portal/src/components/authored/AuthoredHead.vue
@@ -38,7 +38,7 @@
         cols="12"
         class="col-lg-8"
       >
-        <ImageWithAttribution
+        <ImageWithAttributionContainer
           v-if="heroImage"
           :src="heroImage.url"
           :content-type="heroImage.contentType"
@@ -58,7 +58,7 @@
     name: 'AuthoredHead',
 
     components: {
-      ImageWithAttribution: () => import('../../components/image/ImageWithAttribution')
+      ImageWithAttributionContainer: () => import('../../components/image/ImageWithAttributionContainer')
     },
 
     props: {

--- a/packages/portal/src/components/browse/BrowseSections.vue
+++ b/packages/portal/src/components/browse/BrowseSections.vue
@@ -35,7 +35,7 @@
         :right-image-width="imageCompareImage(section, 1) ? imageCompareImage(section, 1).width : null"
         :right-image-height="imageCompareImage(section, 1) ? imageCompareImage(section, 1).height : null"
       />
-      <ImageWithAttribution
+      <ImageWithAttributionContainer
         v-else-if="contentType(section, 'ImageWithAttribution')"
         :src="section.image ? section.image.url : null"
         :content-type="section.image ? section.image.contentType : null"
@@ -77,7 +77,7 @@
       ContentRichText: () => import('../content/ContentRichText'),
       EmbedHTML: () => import('../embed/EmbedHTML'),
       ImageComparisonSlider: () => import('../image/ImageComparisonSlider'),
-      ImageWithAttribution: () => import('../image/ImageWithAttribution')
+      ImageWithAttributionContainer: () => import('../image/ImageWithAttributionContainer')
     },
 
     props: {

--- a/packages/portal/src/components/generic/StackedCardsSwiper.vue
+++ b/packages/portal/src/components/generic/StackedCardsSwiper.vue
@@ -70,6 +70,17 @@
   import swiperMixin from '@/mixins/swiper';
   import { EffectCoverflow, Keyboard, Lazy } from 'swiper';
 
+  const SRCSET_PRESETS = {
+    small: { w: 245, h: 440, fit: 'fill' },
+    medium: { w: 260, h: 420, fit: 'fill' },
+    large: { w: 280, h: 400, fit: 'fill' },
+    xl: { w: 300, h: 400, fit: 'fill' },
+    xxl: { w: 320, h: 370, fit: 'fill' },
+    xxxl: { w: 355, h: 345, fit: 'fill' },
+    wqhd: { w: 405, h: 323, fit: 'fill' },
+    '4k': { w: 480, h: 470, fit: 'fill' }
+  };
+
   export default {
     name: 'StackedCardsSwiper',
 
@@ -168,17 +179,7 @@
         }
       },
       imageSrcset(image) {
-        return this.$contentful.assets.responsiveImageSrcset(image,
-                                                             {
-                                                               small: { w: 245, h: 440, fit: 'fill' },
-                                                               medium: { w: 260, h: 420, fit: 'fill' },
-                                                               large: { w: 280, h: 400, fit: 'fill' },
-                                                               xl: { w: 300, h: 400, fit: 'fill' },
-                                                               xxl: { w: 320, h: 370, fit: 'fill' },
-                                                               xxxl: { w: 355, h: 345, fit: 'fill' },
-                                                               wqhd: { w: 405, h: 323, fit: 'fill' },
-                                                               '4k': { w: 480, h: 470, fit: 'fill' }
-                                                             });
+        return this.$contentful.assets.responsiveImageSrcset(image, SRCSET_PRESETS);
       }
     }
   };

--- a/packages/portal/src/components/generic/StackedCardsSwiper.vue
+++ b/packages/portal/src/components/generic/StackedCardsSwiper.vue
@@ -143,7 +143,7 @@
           '(max-width: 991px) 280px',
           '(max-width: 1199px) 300px',
           '(max-width: 1439px) 320px',
-          '(max-width: 3839px) 355px',
+          '(max-width: 3019px) 355px',
           '480px'
         ].join(',')
       };

--- a/packages/portal/src/components/image/ImageOptimised.vue
+++ b/packages/portal/src/components/image/ImageOptimised.vue
@@ -6,6 +6,8 @@
     :blank-width="optimisedWidth"
     :blank-height="optimisedHeight"
     :alt="alt"
+    :srcset="imageSrcset"
+    :sizes="imageSizes"
   />
   <b-img
     v-else
@@ -13,6 +15,8 @@
     :width="optimisedWidth"
     :height="optimisedHeight"
     :alt="alt"
+    :srcset="imageSrcset"
+    :sizes="imageSizes"
   />
 </template>
 
@@ -53,6 +57,14 @@
       lazy: {
         type: Boolean,
         default: true
+      },
+      imageSrcset: {
+        type: String,
+        default: null
+      },
+      imageSizes: {
+        type: String,
+        default: null
       }
     },
 

--- a/packages/portal/src/components/image/ImageWithAttribution.vue
+++ b/packages/portal/src/components/image/ImageWithAttribution.vue
@@ -7,8 +7,10 @@
       :height="height"
       :alt="alt"
       :content-type="contentType"
-      :max-width="1100"
+      :max-width="maxWidth"
       data-qa="image"
+      :image-srcset="imageSrcset"
+      :image-sizes="imageSizes"
     />
     <AttributionToggle
       :attribution="attribution"
@@ -53,6 +55,18 @@
       attribution: {
         type: Object,
         required: true
+      },
+      maxWidth: {
+        type: Number,
+        default: 1100
+      },
+      imageSrcset: {
+        type: String,
+        default: null
+      },
+      imageSizes: {
+        type: String,
+        default: null
       }
     }
   };

--- a/packages/portal/src/components/image/ImageWithAttribution.vue
+++ b/packages/portal/src/components/image/ImageWithAttribution.vue
@@ -1,32 +1,19 @@
 <template>
-  <b-container
-    fluid
-    class="image-wrapper"
-  >
-    <b-jumbotron
-      fluid
-      text-variant="white"
-      class="mt-0"
-      :class="hero ? 'hero' : ''"
-      @click="!citeCollapsed ? toggleCite : null"
-    >
-      <figure>
-        <ImageOptimised
-          v-if="src"
-          :src="src"
-          :width="width"
-          :height="height"
-          :alt="alt"
-          :content-type="contentType"
-          :max-width="1100"
-          data-qa="image"
-        />
-        <AttributionToggle
-          :attribution="attribution"
-        />
-      </figure>
-    </b-jumbotron>
-  </b-container>
+  <figure>
+    <ImageOptimised
+      v-if="src"
+      :src="src"
+      :width="width"
+      :height="height"
+      :alt="alt"
+      :content-type="contentType"
+      :max-width="1100"
+      data-qa="image"
+    />
+    <AttributionToggle
+      :attribution="attribution"
+    />
+  </figure>
 </template>
 
 <script>
@@ -42,14 +29,6 @@
     },
 
     props: {
-      header: {
-        type: String,
-        default: ''
-      },
-      lead: {
-        type: String,
-        default: ''
-      },
       src: {
         type: String,
         required: true,
@@ -67,10 +46,6 @@
         type: String,
         default: ''
       },
-      name: {
-        type: String,
-        default: null
-      },
       contentType: {
         type: String,
         default: null
@@ -78,76 +53,18 @@
       attribution: {
         type: Object,
         required: true
-      },
-      hero: {
-        type: Boolean,
-        default: false
       }
     }
   };
 </script>
 
 <style lang="scss" scoped>
-  @import '@europeana/style/scss/variables';
+figure {
+  overflow: hidden;
 
-  .image-wrapper {
-    padding: 0;
+  img {
+    width: 100%;
+    object-fit: cover;
   }
-
-  .jumbotron {
-    height: auto;
-    background: $white;
-
-    @media (min-width: $bp-medium) {
-      margin-left: -1rem;
-      margin-right: -1rem;
-    }
-
-    @media (min-width: $bp-large) {
-      margin-left: -3rem;
-      margin-right: -3rem;
-    }
-
-    &::before {
-      display: none;
-    }
-
-    figure {
-      overflow: hidden;
-
-      img {
-        width: 100%;
-        object-fit: cover;
-      }
-    }
-
-    &.hero {
-      min-height: initial;
-
-      figure {
-        height: 0;
-        padding-top: 56.25%;
-        position: relative;
-        margin: 0;
-        display: flex;
-        justify-content: center;
-        width: 100%;
-
-        img {
-          position: absolute;
-          top: 0;
-          left: 0;
-          height: 100%;
-          object-fit: cover;
-          width: 100%;
-        }
-      }
-    }
-
-    .container {
-      max-width: none;
-      justify-content: center;
-      align-items: center;
-    }
-  }
+}
 </style>

--- a/packages/portal/src/components/image/ImageWithAttributionContainer.vue
+++ b/packages/portal/src/components/image/ImageWithAttributionContainer.vue
@@ -1,0 +1,123 @@
+<template>
+  <b-container
+    fluid
+    class="image-wrapper"
+  >
+    <b-jumbotron
+      fluid
+      text-variant="white"
+      class="mt-0"
+      :class="hero ? 'hero' : ''"
+      @click="!citeCollapsed ? toggleCite : null"
+    >
+      <ImageWithAttribution
+        :src="src"
+        :width="width"
+        :height="height"
+        :alt="alt"
+        :content-type="contentType"
+        :attribution="attribution"
+      />
+    </b-jumbotron>
+  </b-container>
+</template>
+
+<script>
+  import ImageWithAttribution from './ImageWithAttribution';
+
+  export default {
+    name: 'ImageWithAttributionContainer',
+
+    components: {
+      ImageWithAttribution
+    },
+
+    props: {
+      src: {
+        type: String,
+        required: true,
+        default: null
+      },
+      width: {
+        type: Number,
+        default: 550
+      },
+      height: {
+        type: Number,
+        default: 790
+      },
+      alt: {
+        type: String,
+        default: ''
+      },
+      contentType: {
+        type: String,
+        default: null
+      },
+      attribution: {
+        type: Object,
+        required: true
+      },
+      hero: {
+        type: Boolean,
+        default: false
+      }
+    }
+  };
+</script>
+
+<style lang="scss" scoped>
+  @import '@europeana/style/scss/variables';
+
+  .image-wrapper {
+    padding: 0;
+  }
+
+  .jumbotron {
+    height: auto;
+    background: $white;
+
+    @media (min-width: $bp-medium) {
+      margin-left: -1rem;
+      margin-right: -1rem;
+    }
+
+    @media (min-width: $bp-large) {
+      margin-left: -3rem;
+      margin-right: -3rem;
+    }
+
+    &::before {
+      display: none;
+    }
+
+    &.hero {
+      min-height: initial;
+
+      ::v-deep figure {
+        height: 0;
+        padding-top: 56.25%;
+        position: relative;
+        margin: 0;
+        display: flex;
+        justify-content: center;
+        width: 100%;
+
+        img {
+          position: absolute;
+          top: 0;
+          left: 0;
+          height: 100%;
+          object-fit: cover;
+          width: 100%;
+        }
+      }
+    }
+
+    .container {
+      max-width: none;
+      justify-content: center;
+      align-items: center;
+    }
+  }
+</style>

--- a/packages/portal/src/components/landing/LandingImageCard.vue
+++ b/packages/portal/src/components/landing/LandingImageCard.vue
@@ -3,18 +3,19 @@
     class="image-card"
   >
     <div
-      v-if="card.image"
+      v-if="cardImageWithAttribution"
       class="image-wrapper d-flex flex-end justify-content-center mb-2"
     >
-      <ImageOptimised
+      <ImageWithAttribution
         class="image"
-        :alt="card.image.description"
-        :src="card.image.url"
-        :width="card.image.width"
-        :height="card.image.height"
-        :content-type="card.image.contentType"
-        :max-width="1100"
-        :lazy="true"
+        :alt="cardImageWithAttribution.image.description"
+        :src="cardImageWithAttribution.image.url"
+        :width="612"
+        :height="365"
+        :content-type="cardImageWithAttribution.image.contentType"
+        :attribution="cardImageWithAttribution"
+        :image-srcset="imageSrcset(cardImageWithAttribution.image)"
+        :image-sizes="imageSizes"
       />
     </div>
     <h3 class="title mb-2">
@@ -23,21 +24,22 @@
     <!-- eslint-disable vue/no-v-html -->
     <div
       class="text"
-      v-html="html(card.text)"
+      v-html="parseMarkdownHtml(card.text)"
     />
     <!-- eslint-enable vue/no-v-html -->
   </div>
 </template>
 
 <script>
-  // TODO: Replace with mixin
-  import { marked } from 'marked';
+  import parseMarkdownHtmlMixin from '@/mixins/parseMarkdownHtml';
 
   export default {
     name: 'LandingImageCard',
     components: {
-      ImageOptimised: () => import('@/components/image/ImageOptimised')
+      ImageWithAttribution: () => import('@/components/image/ImageWithAttribution')
     },
+
+    mixins: [parseMarkdownHtmlMixin],
 
     props: {
       /**
@@ -49,10 +51,38 @@
       }
     },
 
+    data() {
+      return {
+        imageSizes: [
+          '(max-width: 575px) 545px',
+          '(max-width: 767px) 360px',
+          '(max-width: 991px) 480px',
+          '(max-width: 1199px) 570px',
+          '(max-width: 3839px) 612px',
+          '918px'
+        ].join(',')
+      };
+    },
+
+    computed: {
+      cardImageWithAttribution() {
+        return this.card.image;
+      }
+    },
+
     methods: {
-      // TODO: Replace with mixin
-      html(text) {
-        return text ? marked.parse(text) : text;
+      imageSrcset(image) {
+        return this.$contentful.assets.responsiveImageSrcset(image,
+                                                             {
+                                                               small: { w: 545, h: 270, fit: 'fill' },
+                                                               medium: { w: 360, h: 216, fit: 'fill' },
+                                                               large: { w: 480, h: 288, fit: 'fill' },
+                                                               xl: { w: 570, h: 342, fit: 'fill' },
+                                                               xxl: { w: 612, h: 367, fit: 'fill' },
+                                                               xxxl: { w: 612, h: 367, fit: 'fill' },
+                                                               wqhd: { w: 612, h: 367, fit: 'fill' },
+                                                               '4k': { w: 918, h: 551, fit: 'fill' }
+                                                             });
       }
     }
   };

--- a/packages/portal/src/components/landing/LandingImageCard.vue
+++ b/packages/portal/src/components/landing/LandingImageCard.vue
@@ -1,0 +1,112 @@
+<template>
+  <div
+    class="image-card"
+  >
+    <div
+      v-if="card.image"
+      class="image-wrapper d-flex flex-end justify-content-center mb-2"
+    >
+      <ImageOptimised
+        class="image"
+        :alt="card.image.description"
+        :src="card.image.url"
+        :width="card.image.width"
+        :height="card.image.height"
+        :content-type="card.image.contentType"
+        :max-width="1100"
+        :lazy="true"
+      />
+    </div>
+    <h3 class="title mb-2">
+      {{ card.name }}
+    </h3>
+    <!-- eslint-disable vue/no-v-html -->
+    <div
+      class="text"
+      v-html="html(card.text)"
+    />
+    <!-- eslint-enable vue/no-v-html -->
+  </div>
+</template>
+
+<script>
+  // TODO: Replace with mixin
+  import { marked } from 'marked';
+
+  export default {
+    name: 'LandingImageCard',
+    components: {
+      ImageOptimised: () => import('@/components/image/ImageOptimised')
+    },
+
+    props: {
+      /**
+       * Image card
+       */
+      card: {
+        type: Object,
+        default: null
+      }
+    },
+
+    methods: {
+      // TODO: Replace with mixin
+      html(text) {
+        return text ? marked.parse(text) : text;
+      }
+    }
+  };
+  </script>
+
+<style lang="scss" scoped>
+@import '@europeana/style/scss/variables';
+// .image-card {
+//   max-width: 310px;
+//   margin-left: auto;
+//   margin-right: auto;
+//   @media (min-width: $bp-large) {
+//     margin-left: 2rem;
+//     margin-right: 2rem;
+//   }
+//   @media (min-width: $bp-4k) {
+//     max-width: calc(1.5 * 310px);
+//     margin-left: 3rem;
+//     margin-right: 3rem;
+//   }
+//   .image-wrapper {
+//     height: 80px;
+//     @media (min-width: $bp-large) {
+//       height: 111px;
+//     }
+//   }
+//   .image {
+//     max-height: 100%;
+//     margin: auto auto 0 auto;
+//   }
+//   .title {
+//     color: $mediumgrey;
+//     font-family: $font-family-ubuntu;
+//     font-weight: 500;
+//     text-transform: uppercase;
+//   }
+//   .text {
+//     font-weight: 500;
+//     color: $mediumgrey;
+//     margin-bottom: 2rem;
+//   }
+// }
+</style>
+
+<docs lang="md">
+  ```jsx
+    <LandingImageCard
+      :card="{
+        __typename: 'ImageCard',
+        name: 'Usage statistics',
+        text: 'Europeana’s usage statistics reports tell you how your data is being accessed and reused on Europeana.eu, empowering you __to measure__ the positive __impact__ of sharing your collections.',
+      image: { url: 'https://images.ctfassets.net/i01duvb6kq77/cjliScwekoFTMkuD4XGHI/7831ed1ea5942256bca70542e7db0739/noun-stats-5341287_1.svg',
+      contentType: 'image/svg+xml', description: '', width: 111, height: 111 }
+    }"
+    />
+  ```
+</docs>

--- a/packages/portal/src/components/landing/LandingImageCard.vue
+++ b/packages/portal/src/components/landing/LandingImageCard.vue
@@ -35,6 +35,17 @@
 <script>
   import parseMarkdownHtmlMixin from '@/mixins/parseMarkdownHtml';
 
+  const SRCSET_PRESETS = {
+    small: { w: 545, h: 270, fit: 'fill' },
+    medium: { w: 510, h: 306, fit: 'fill' },
+    large: { w: 510, h: 306, fit: 'fill' },
+    xl: { w: 570, h: 342, fit: 'fill' },
+    xxl: { w: 612, h: 367, fit: 'fill' },
+    xxxl: { w: 612, h: 367, fit: 'fill' },
+    wqhd: { w: 612, h: 367, fit: 'fill' },
+    '4k': { w: 918, h: 551, fit: 'fill' }
+  };
+
   export default {
     name: 'LandingImageCard',
     components: {
@@ -73,17 +84,7 @@
 
     methods: {
       imageSrcset(image) {
-        return this.$contentful.assets.responsiveImageSrcset(image,
-                                                             {
-                                                               small: { w: 545, h: 270, fit: 'fill' },
-                                                               medium: { w: 510, h: 306, fit: 'fill' },
-                                                               large: { w: 510, h: 306, fit: 'fill' },
-                                                               xl: { w: 570, h: 342, fit: 'fill' },
-                                                               xxl: { w: 612, h: 367, fit: 'fill' },
-                                                               xxxl: { w: 612, h: 367, fit: 'fill' },
-                                                               wqhd: { w: 612, h: 367, fit: 'fill' },
-                                                               '4k': { w: 918, h: 551, fit: 'fill' }
-                                                             });
+        return this.$contentful.assets.responsiveImageSrcset(image, SRCSET_PRESETS);
       }
     }
   };

--- a/packages/portal/src/components/landing/LandingImageCard.vue
+++ b/packages/portal/src/components/landing/LandingImageCard.vue
@@ -1,10 +1,10 @@
 <template>
   <div
-    class="image-card"
+    class="image-card d-lg-flex mx-auto"
   >
     <div
       v-if="cardImageWithAttribution"
-      class="image-wrapper d-flex flex-end justify-content-center mb-2"
+      class="image-wrapper mb-3 mb-lg-0"
     >
       <ImageWithAttribution
         class="image"
@@ -18,15 +18,17 @@
         :image-sizes="imageSizes"
       />
     </div>
-    <h3 class="title mb-2">
-      {{ card.name }}
-    </h3>
-    <!-- eslint-disable vue/no-v-html -->
-    <div
-      class="text"
-      v-html="parseMarkdownHtml(card.text)"
-    />
+    <div class="text-wrapper">
+      <h3 class="title mb-2">
+        {{ card.name }}
+      </h3>
+      <!-- eslint-disable vue/no-v-html -->
+      <div
+        class="text"
+        v-html="parseMarkdownHtml(card.text)"
+      />
     <!-- eslint-enable vue/no-v-html -->
+    </div>
   </div>
 </template>
 
@@ -54,11 +56,10 @@
     data() {
       return {
         imageSizes: [
-          '(max-width: 575px) 545px',
-          '(max-width: 767px) 360px',
-          '(max-width: 991px) 480px',
-          '(max-width: 1199px) 570px',
-          '(max-width: 3839px) 612px',
+          '(max-width: 575px) 545px', // bp-small
+          '(max-width: 991px) 510px', // bp-large
+          '(max-width: 1199px) 570px', // bp-xl
+          '(max-width: 3019px) 612px', // bp-4k
           '918px'
         ].join(',')
       };
@@ -75,8 +76,8 @@
         return this.$contentful.assets.responsiveImageSrcset(image,
                                                              {
                                                                small: { w: 545, h: 270, fit: 'fill' },
-                                                               medium: { w: 360, h: 216, fit: 'fill' },
-                                                               large: { w: 480, h: 288, fit: 'fill' },
+                                                               medium: { w: 510, h: 306, fit: 'fill' },
+                                                               large: { w: 510, h: 306, fit: 'fill' },
                                                                xl: { w: 570, h: 342, fit: 'fill' },
                                                                xxl: { w: 612, h: 367, fit: 'fill' },
                                                                xxxl: { w: 612, h: 367, fit: 'fill' },
@@ -89,42 +90,77 @@
   </script>
 
 <style lang="scss" scoped>
-@import '@europeana/style/scss/variables';
-// .image-card {
-//   max-width: 310px;
-//   margin-left: auto;
-//   margin-right: auto;
-//   @media (min-width: $bp-large) {
-//     margin-left: 2rem;
-//     margin-right: 2rem;
-//   }
-//   @media (min-width: $bp-4k) {
-//     max-width: calc(1.5 * 310px);
-//     margin-left: 3rem;
-//     margin-right: 3rem;
-//   }
-//   .image-wrapper {
-//     height: 80px;
-//     @media (min-width: $bp-large) {
-//       height: 111px;
-//     }
-//   }
-//   .image {
-//     max-height: 100%;
-//     margin: auto auto 0 auto;
-//   }
-//   .title {
-//     color: $mediumgrey;
-//     font-family: $font-family-ubuntu;
-//     font-weight: 500;
-//     text-transform: uppercase;
-//   }
-//   .text {
-//     font-weight: 500;
-//     color: $mediumgrey;
-//     margin-bottom: 2rem;
-//   }
-// }
+  @import '@europeana/style/scss/variables';
+
+  .image-card {
+    margin-bottom: 2.375rem;
+
+    @media (min-width: $bp-medium) {
+      max-width: 510px;
+    }
+
+    @media (min-width: $bp-large) {
+      max-width: 1250px;
+      margin-bottom: 4.625rem;
+
+      &:nth-child(even) {
+        .text-wrapper {
+          order: -1;
+          padding: 5rem 3.625rem 5rem 6rem;
+          clip-path: polygon(95px 0, 100% 0, 100% 100%, 0 100%, 0 calc(100% - 209px));
+        }
+      }
+    }
+
+    @media (min-width: $bp-4k) {
+      max-width: calc(1.5 * 1250px);
+    }
+
+    .image-wrapper {
+      @media (min-width: $bp-large) {
+        flex: 0 0 49%;
+      }
+    }
+
+    .text-wrapper {
+      @media (min-width: $bp-large) {
+        flex: 0 0 51%;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        background-color: $white;
+        padding: 5rem 6rem 5rem 3.625rem;
+        clip-path: polygon(0% 0%, calc(100% - 95px) 0, 100% calc(100% - 209px), 100% 100%, 0 100%);
+      }
+    }
+
+    ::v-deep figure {
+      margin: 0;
+      height: 100%;
+
+      img {
+        height: 100%;
+      }
+    }
+
+    .title {
+      font-size: $font-size-base;
+      font-family: $font-family-ubuntu;
+      font-weight: 700;
+
+      @media (min-width: $bp-medium) {
+        font-size: $font-size-large;
+      }
+
+      @media (min-width: $bp-4k) {
+        font-size: $font-size-large-4k;
+      }
+    }
+
+    .text {
+      color: $mediumgrey;
+    }
+  }
 </style>
 
 <docs lang="md">

--- a/packages/portal/src/components/landing/LandingImageCard.vue
+++ b/packages/portal/src/components/landing/LandingImageCard.vue
@@ -3,7 +3,7 @@
     class="image-card d-lg-flex mx-auto"
   >
     <div
-      v-if="cardImageWithAttribution"
+      v-if="cardImageWithAttribution && cardImageWithAttribution.image"
       class="image-wrapper mb-3 mb-lg-0"
     >
       <ImageWithAttribution
@@ -165,14 +165,25 @@
 
 <docs lang="md">
   ```jsx
-    <LandingImageCard
-      :card="{
-        __typename: 'ImageCard',
-        name: 'Usage statistics',
-        text: 'Europeana’s usage statistics reports tell you how your data is being accessed and reused on Europeana.eu, empowering you __to measure__ the positive __impact__ of sharing your collections.',
-      image: { url: 'https://images.ctfassets.net/i01duvb6kq77/cjliScwekoFTMkuD4XGHI/7831ed1ea5942256bca70542e7db0739/noun-stats-5341287_1.svg',
-      contentType: 'image/svg+xml', description: '', width: 111, height: 111 }
-    }"
-    />
+    <div style="background-color: #ededed; margin: -16px; padding: 16px;">
+      <LandingImageCard
+        :card="{
+          __typename: 'ImageCard',
+          name: 'Card title',
+          text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+          image: {
+            name: 'Eight plants, including two orchids, a crocus and some tulips: flowering stems. Coloured etching, c.1837.',
+            creator: 'Undefined',
+            provider: 'Wellcome Collection',
+            license: 'http://creativecommons.org/licenses/by/4.0/',
+            url: 'http://data.europeana.eu/item/9200579/hxf3z8ek',
+            image: { url: 'https://images.ctfassets.net/i01duvb6kq77/1l8m0GQ9crP6zvts5zWYos/0006db953cc9a8a08a064c141cd78777/feature_botanical-illustrations.jpg',
+            contentType: 'image/jpeg',
+            description: 'colour illustration of a bunch of colourful flowers in yellow, red, orange',
+            width: 830, height: 470 }
+          }
+        }"
+      />
+    </div>
   ```
 </docs>

--- a/packages/portal/src/components/landing/LandingImageCardGroup.vue
+++ b/packages/portal/src/components/landing/LandingImageCardGroup.vue
@@ -1,0 +1,117 @@
+<template>
+  <div>
+    <div class="header pt-5 pb-5">
+      <b-container class="text-center">
+        <div class="header-content mx-auto">
+          <h2>
+            {{ title }}
+          </h2>
+          <!-- eslint-disable vue/no-v-html -->
+          <div
+            v-if="text"
+            class="mb-3"
+            v-html="html(text)"
+          />
+        <!-- eslint-enable vue/no-v-html -->
+        </div>
+      </b-container>
+    </div>
+    <!-- <b-container class="text-center">
+      <div
+        v-if="imageCards.length"
+      >
+        <LandingImageCard
+          v-for="(card, index) in imageCards"
+          :key="index"
+          class="image-card"
+          :card="card"
+        />
+      </div>
+    </b-container> -->
+  </div>
+</template>
+
+<script>
+  // TODO: Replace with mixin
+  import { marked } from 'marked';
+
+  export default {
+    name: 'LandingImageCardGroup',
+    components: {
+      // LandingImageCard: () => import('@/components/landing/LandingImageCard')
+    },
+
+    props: {
+      /**
+       * H2 title to display above the image cards
+       */
+      title: {
+        type: String,
+        default: null
+      },
+      /**
+       * Text to display under title and above the image cards
+       */
+      text: {
+        type: String,
+        default: null
+      },
+      /**
+       * List of image cards
+       */
+      imageCards: {
+        type: Array,
+        default: () => []
+      }
+    },
+
+    methods: {
+      // TODO: Replace with mixin
+      html(text) {
+        return text ? marked.parse(text) : text;
+      }
+    }
+  };
+</script>
+
+<style lang="scss" scoped>
+@import '@europeana/style/scss/variables';
+
+.header {
+  background-color: $blue;
+  color: $white;
+}
+
+.header-content {
+  max-width: $max-text-column-width;
+}
+</style>
+
+<docs lang="md">
+  ```jsx
+    <LandingImageCardGroup
+      title="This is a title for an image card group"
+      text="A __description__ what this section is all about"
+      :image-cards="[ {
+        __typename: 'ImageCard',
+        name: 'Usage statistics',
+        text: 'Europeana’s usage statistics reports tell you how your data is being accessed and reused on Europeana.eu, empowering you __to measure__ the positive __impact__ of sharing your collections.',
+      image: { url: 'https://images.ctfassets.net/i01duvb6kq77/cjliScwekoFTMkuD4XGHI/7831ed1ea5942256bca70542e7db0739/noun-stats-5341287_1.svg',
+      contentType: 'image/svg+xml', description: '', width: 111, height: 111 }
+    }, {
+      __typename: 'ImageCard',
+    name: 'Usage statistics',
+      text: 'Europeana’s usage statistics reports tell you how your data is being accessed and reused on Europeana.eu, empowering you __to measure__ the positive __impact__ of sharing your collections.',
+      image: { url: 'https://images.ctfassets.net/i01duvb6kq77/cjliScwekoFTMkuD4XGHI/7831ed1ea5942256bca70542e7db0739/noun-stats-5341287_1.svg',
+      contentType: 'image/svg+xml', description: '', width: 111, height: 111 }
+    },
+      {
+        __typename: 'ImageCard',
+        name: 'Usage statistics',
+        text: 'Europeana’s usage statistics reports tell you how your data is being accessed and reused on Europeana.eu, empowering you __to measure__ the positive __impact__ of sharing your collections.',
+        image: { url: 'https://images.ctfassets.net/i01duvb6kq77/cjliScwekoFTMkuD4XGHI/7831ed1ea5942256bca70542e7db0739/noun-stats-5341287_1.svg',
+        contentType: 'image/svg+xml', description: '', width: 111, height: 111 }
+      } ]"
+    />
+  ```
+</docs>

--- a/packages/portal/src/components/landing/LandingImageCardGroup.vue
+++ b/packages/portal/src/components/landing/LandingImageCardGroup.vue
@@ -10,7 +10,7 @@
           <div
             v-if="text"
             class="mb-3"
-            v-html="html(text)"
+            v-html="parseMarkdownHtml(text)"
           />
         <!-- eslint-enable vue/no-v-html -->
         </div>
@@ -32,14 +32,15 @@
 </template>
 
 <script>
-  // TODO: Replace with mixin
-  import { marked } from 'marked';
+  import parseMarkdownHtmlMixin from '@/mixins/parseMarkdownHtml';
 
   export default {
     name: 'LandingImageCardGroup',
     components: {
       LandingImageCard: () => import('@/components/landing/LandingImageCard')
     },
+
+    mixins: [parseMarkdownHtmlMixin],
 
     props: {
       /**
@@ -62,13 +63,6 @@
       imageCards: {
         type: Array,
         default: () => []
-      }
-    },
-
-    methods: {
-      // TODO: Replace with mixin
-      html(text) {
-        return text ? marked.parse(text) : text;
       }
     }
   };

--- a/packages/portal/src/components/landing/LandingImageCardGroup.vue
+++ b/packages/portal/src/components/landing/LandingImageCardGroup.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="image-card-group">
     <div class="header pt-5 pb-5">
       <b-container>
         <div class="header-content text-center mx-auto">
@@ -23,7 +23,6 @@
         <LandingImageCard
           v-for="(card, index) in imageCards"
           :key="index"
-          class="image-card"
           :card="card"
         />
       </div>
@@ -69,16 +68,26 @@
 </script>
 
 <style lang="scss" scoped>
-@import '@europeana/style/scss/variables';
+  @import '@europeana/style/scss/variables';
 
-.header {
-  background-color: $blue;
-  color: $white;
-}
+  .image-card-group {
+    background-color: $bodygrey;
+    border-bottom: 1px solid $bodygrey;
+  }
 
-.header-content {
-  max-width: $max-text-column-width;
-}
+  .header {
+    background-color: $blue;
+    color: $white;
+    margin-bottom: 2.5rem;
+
+    @media (min-width: $bp-large) {
+      margin-bottom: 4.625rem;
+    }
+  }
+
+  .header-content {
+    max-width: $max-text-column-width;
+  }
 </style>
 
 <docs lang="md">

--- a/packages/portal/src/components/landing/LandingImageCardGroup.vue
+++ b/packages/portal/src/components/landing/LandingImageCardGroup.vue
@@ -95,26 +95,52 @@
     <LandingImageCardGroup
       title="This is a title for an image card group"
       text="A __description__ what this section is all about"
-      :image-cards="[ {
+      :image-cards="[{
         __typename: 'ImageCard',
-        name: 'Usage statistics',
-        text: 'Europeana’s usage statistics reports tell you how your data is being accessed and reused on Europeana.eu, empowering you __to measure__ the positive __impact__ of sharing your collections.',
-      image: { url: 'https://images.ctfassets.net/i01duvb6kq77/cjliScwekoFTMkuD4XGHI/7831ed1ea5942256bca70542e7db0739/noun-stats-5341287_1.svg',
-      contentType: 'image/svg+xml', description: '', width: 111, height: 111 }
-    }, {
-      __typename: 'ImageCard',
-    name: 'Usage statistics',
-      text: 'Europeana’s usage statistics reports tell you how your data is being accessed and reused on Europeana.eu, empowering you __to measure__ the positive __impact__ of sharing your collections.',
-      image: { url: 'https://images.ctfassets.net/i01duvb6kq77/cjliScwekoFTMkuD4XGHI/7831ed1ea5942256bca70542e7db0739/noun-stats-5341287_1.svg',
-      contentType: 'image/svg+xml', description: '', width: 111, height: 111 }
-    },
-      {
+        name: 'Card title',
+        text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+        image: {
+          name: 'Eight plants, including two orchids, a crocus and some tulips: flowering stems. Coloured etching, c.1837.',
+          creator: null,
+          provider: 'Wellcome Collection',
+          license: 'http://creativecommons.org/licenses/by/4.0/',
+          url: 'http://data.europeana.eu/item/9200579/hxf3z8ek',
+          image: { url: 'https://images.ctfassets.net/i01duvb6kq77/1l8m0GQ9crP6zvts5zWYos/0006db953cc9a8a08a064c141cd78777/feature_botanical-illustrations.jpg',
+          contentType: 'image/jpeg',
+          description: 'colour illustration of a bunch of colourful flowers in yellow, red, orange',
+          width: 830, height: 470 }
+        }
+      }, {
         __typename: 'ImageCard',
-        name: 'Usage statistics',
-        text: 'Europeana’s usage statistics reports tell you how your data is being accessed and reused on Europeana.eu, empowering you __to measure__ the positive __impact__ of sharing your collections.',
-        image: { url: 'https://images.ctfassets.net/i01duvb6kq77/cjliScwekoFTMkuD4XGHI/7831ed1ea5942256bca70542e7db0739/noun-stats-5341287_1.svg',
-        contentType: 'image/svg+xml', description: '', width: 111, height: 111 }
-      } ]"
+        name: 'Card title',
+        text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+        image: {
+          name: 'Eight plants, including two orchids, a crocus and some tulips: flowering stems. Coloured etching, c.1837.',
+          creator: null,
+          provider: 'Wellcome Collection',
+          license: 'http://creativecommons.org/licenses/by/4.0/',
+          url: 'http://data.europeana.eu/item/9200579/hxf3z8ek',
+          image: { url: 'https://images.ctfassets.net/i01duvb6kq77/1l8m0GQ9crP6zvts5zWYos/0006db953cc9a8a08a064c141cd78777/feature_botanical-illustrations.jpg',
+          contentType: 'image/jpeg',
+          description: 'colour illustration of a bunch of colourful flowers in yellow, red, orange',
+          width: 830, height: 470 }
+        }
+      }, {
+        __typename: 'ImageCard',
+        name: 'Card title',
+        text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+        image: {
+          name: 'Eight plants, including two orchids, a crocus and some tulips: flowering stems. Coloured etching, c.1837.',
+          creator: null,
+          provider: 'Wellcome Collection',
+          license: 'http://creativecommons.org/licenses/by/4.0/',
+          url: 'http://data.europeana.eu/item/9200579/hxf3z8ek',
+          image: { url: 'https://images.ctfassets.net/i01duvb6kq77/1l8m0GQ9crP6zvts5zWYos/0006db953cc9a8a08a064c141cd78777/feature_botanical-illustrations.jpg',
+          contentType: 'image/jpeg',
+          description: 'colour illustration of a bunch of colourful flowers in yellow, red, orange',
+          width: 830, height: 470 }
+        }
+      }]"
     />
   ```
 </docs>

--- a/packages/portal/src/components/landing/LandingImageCardGroup.vue
+++ b/packages/portal/src/components/landing/LandingImageCardGroup.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
     <div class="header pt-5 pb-5">
-      <b-container class="text-center">
-        <div class="header-content mx-auto">
+      <b-container>
+        <div class="header-content text-center mx-auto">
           <h2>
             {{ title }}
           </h2>
@@ -16,7 +16,7 @@
         </div>
       </b-container>
     </div>
-    <!-- <b-container class="text-center">
+    <b-container>
       <div
         v-if="imageCards.length"
       >
@@ -27,7 +27,7 @@
           :card="card"
         />
       </div>
-    </b-container> -->
+    </b-container>
   </div>
 </template>
 
@@ -38,7 +38,7 @@
   export default {
     name: 'LandingImageCardGroup',
     components: {
-      // LandingImageCard: () => import('@/components/landing/LandingImageCard')
+      LandingImageCard: () => import('@/components/landing/LandingImageCard')
     },
 
     props: {

--- a/packages/portal/src/components/landing/LandingInfoCard.vue
+++ b/packages/portal/src/components/landing/LandingInfoCard.vue
@@ -106,7 +106,7 @@
         __typename: 'InfoCard',
         name: 'Usage statistics',
         text: 'Europeana’s usage statistics reports tell you how your data is being accessed and reused on Europeana.eu, empowering you __to measure__ the positive __impact__ of sharing your collections.',
-      image: { url: 'https://images.ctfassets.net/i01duvb6kq77/cjliScwekoFTMkuD4XGHI/7831ed1ea5942256bca70542e7db0739/noun-stats-5341287_1.svg',
+      image: { url: 'https://images.ctfassets.net/i01duvb6kq77/2JsdSYTl8sz2KIJS0q4rB6/8ea1e1971ca439293da20b63de3bf4b2/Group.svg',
       contentType: 'image/svg+xml', description: '', width: 111, height: 111 }
     }"
     />

--- a/packages/portal/src/components/landing/LandingInfoCardGroup.vue
+++ b/packages/portal/src/components/landing/LandingInfoCardGroup.vue
@@ -89,20 +89,20 @@
         __typename: 'InfoCard',
         name: 'Usage statistics',
         text: 'Europeana’s usage statistics reports tell you how your data is being accessed and reused on Europeana.eu, empowering you __to measure__ the positive __impact__ of sharing your collections.',
-      image: { url: 'https://images.ctfassets.net/i01duvb6kq77/cjliScwekoFTMkuD4XGHI/7831ed1ea5942256bca70542e7db0739/noun-stats-5341287_1.svg',
+      image: { url: 'https://images.ctfassets.net/i01duvb6kq77/2JsdSYTl8sz2KIJS0q4rB6/8ea1e1971ca439293da20b63de3bf4b2/Group.svg',
       contentType: 'image/svg+xml', description: '', width: 111, height: 111 }
     }, {
       __typename: 'InfoCard',
     name: 'Usage statistics',
       text: 'Europeana’s usage statistics reports tell you how your data is being accessed and reused on Europeana.eu, empowering you __to measure__ the positive __impact__ of sharing your collections.',
-      image: { url: 'https://images.ctfassets.net/i01duvb6kq77/cjliScwekoFTMkuD4XGHI/7831ed1ea5942256bca70542e7db0739/noun-stats-5341287_1.svg',
+      image: { url: 'https://images.ctfassets.net/i01duvb6kq77/2JsdSYTl8sz2KIJS0q4rB6/8ea1e1971ca439293da20b63de3bf4b2/Group.svg',
       contentType: 'image/svg+xml', description: '', width: 111, height: 111 }
     },
       {
         __typename: 'InfoCard',
         name: 'Usage statistics',
         text: 'Europeana’s usage statistics reports tell you how your data is being accessed and reused on Europeana.eu, empowering you __to measure__ the positive __impact__ of sharing your collections.',
-        image: { url: 'https://images.ctfassets.net/i01duvb6kq77/cjliScwekoFTMkuD4XGHI/7831ed1ea5942256bca70542e7db0739/noun-stats-5341287_1.svg',
+        image: { url: 'https://images.ctfassets.net/i01duvb6kq77/2JsdSYTl8sz2KIJS0q4rB6/8ea1e1971ca439293da20b63de3bf4b2/Group.svg',
         contentType: 'image/svg+xml', description: '', width: 111, height: 111 }
       } ]"
     />

--- a/packages/portal/src/components/landing/LandingInfoCardGroup.vue
+++ b/packages/portal/src/components/landing/LandingInfoCardGroup.vue
@@ -19,7 +19,6 @@
       <LandingInfoCard
         v-for="(card, index) in infoCards"
         :key="index"
-        class="info-card"
         :card="card"
       />
     </div>
@@ -65,20 +64,20 @@
 </script>
 
 <style lang="scss" scoped>
-@import '@europeana/style/scss/variables';
+  @import '@europeana/style/scss/variables';
 
-.container {
-  padding-top: 4rem;
-  padding-bottom: 3rem;
+  .container {
+    padding-top: 4rem;
+    padding-bottom: 3rem;
 
-  @media (min-width: $bp-large) {
-    padding-top: 4.5rem;
+    @media (min-width: $bp-large) {
+      padding-top: 4.5rem;
+    }
   }
-}
 
-.header {
-  max-width: $max-text-column-width;
-}
+  .header {
+    max-width: $max-text-column-width;
+  }
 </style>
 
 <docs lang="md">

--- a/packages/portal/src/components/landing/LandingPage.vue
+++ b/packages/portal/src/components/landing/LandingPage.vue
@@ -8,6 +8,17 @@
       :cta="cta"
       :hero-image="primaryImageOfPage"
     />
+    <div
+      v-for="(section, index) in sections"
+      :key="index"
+    >
+      <LandingImageCardGroup
+        v-if="contentType(section, 'ImageCardGroup')"
+        :title="section.name"
+        :text="section.text"
+        :image-cards="section.hasPartCollection && section.hasPartCollection.items"
+      />
+    </div>
   </div>
 </template>
 
@@ -19,7 +30,8 @@
     name: 'LandingPage',
 
     components: {
-      LandingHero
+      LandingHero,
+      LandingImageCardGroup: () => import('@/components/landing/LandingImageCardGroup')
     },
 
     props: {
@@ -48,21 +60,36 @@
     methods: {
       html(text) {
         return text ? marked.parse(text) : text;
+      },
+      contentType(section, typeName) {
+        return section && (section['__typename'] === typeName);
       }
     }
   };
 </script>
 
 <style lang="scss" scoped>
-  @import '@europeana/style/scss/variables';
-  @import '@europeana/style/scss/mixins';
-  @import '@europeana/style/scss/transitions';
+@import '@europeana/style/scss/variables';
+@import '@europeana/style/scss/mixins';
+@import '@europeana/style/scss/transitions';
 
-  .page {
-    margin-top: -1rem;
+.page {
+  margin-top: -1rem;
 
+  @media (min-width: $bp-4k) {
+    margin-top: -1.5rem;
+  }
+
+  ::v-deep h2 {
+    font-family: $font-family-ubuntu;
+    font-size: $font-size-medium;
+    font-weight: 500;
+    @media (min-width: $bp-medium) {
+      font-size: $font-size-xl;
+    }
     @media (min-width: $bp-4k) {
-      margin-top: -1.5rem;
+      font-size: $font-size-xl-4k;
     }
   }
+}
 </style>

--- a/packages/portal/src/components/landing/LandingPage.vue
+++ b/packages/portal/src/components/landing/LandingPage.vue
@@ -72,26 +72,15 @@
 </script>
 
 <style lang="scss" scoped>
-@import '@europeana/style/scss/variables';
-@import '@europeana/style/scss/mixins';
-@import '@europeana/style/scss/transitions';
+  @import '@europeana/style/scss/variables';
+  @import '@europeana/style/scss/mixins';
+  @import '@europeana/style/scss/transitions';
 
-.page {
-  margin-top: -1rem;
+  .page {
+    margin-top: -1rem;
 
-  @media (min-width: $bp-4k) {
-    margin-top: -1.5rem;
-  }
-
-  ::v-deep h2 {
-    font-family: $font-family-ubuntu;
-    font-size: $font-size-medium;
-    font-weight: 500;
-    @media (min-width: $bp-medium) {
-      font-size: $font-size-xl;
-    }
     @media (min-width: $bp-4k) {
-      font-size: $font-size-xl-4k;
+      margin-top: -1.5rem;
     }
 
     ::v-deep h2 {
@@ -107,7 +96,5 @@
         font-size: $font-size-xl-4k;
       }
     }
-
   }
-}
 </style>

--- a/packages/portal/tests/size/.size-limit.json
+++ b/packages/portal/tests/size/.size-limit.json
@@ -19,7 +19,7 @@
   {
     "name": "portal.js server",
     "running": false,
-    "limit": "820 KB",
+    "limit": "830 KB",
     "path": [
       ".nuxt/dist/server/*.js"
     ]

--- a/packages/portal/tests/unit/components/landing/LandingImageCard.spec.js
+++ b/packages/portal/tests/unit/components/landing/LandingImageCard.spec.js
@@ -1,0 +1,34 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import sinon from 'sinon';
+
+import LandingImageCard from '@/components/landing/LandingImageCard.vue';
+
+const localVue = createLocalVue();
+
+const factory = (propsData) => shallowMount(LandingImageCard, {
+  localVue,
+  propsData,
+  mocks: {
+    $contentful: {
+      assets: {
+        responsiveImageSrcset: sinon.spy()
+      }
+    }
+  },
+  stubs: ['b-container']
+});
+
+describe('components/landing/LandingImageCard', () => {
+  it('uses responsive images', () => {
+    const title = 'Title for an image card';
+    const wrapper = factory({ card: { name: title,
+      image: {
+        image: {
+          url: 'https://www.example.eu/img.jpg',
+          contentType: 'image/jpeg'
+        }
+      } } });
+
+    expect(wrapper.vm.$contentful.assets.responsiveImageSrcset.called).toBe(true);
+  });
+});

--- a/packages/portal/tests/unit/components/landing/LandingImageCardGroup.spec.js
+++ b/packages/portal/tests/unit/components/landing/LandingImageCardGroup.spec.js
@@ -1,0 +1,22 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+
+import LandingImageCardGroup from '@/components/landing/LandingImageCardGroup.vue';
+
+const localVue = createLocalVue();
+
+const factory = (propsData) => shallowMount(LandingImageCardGroup, {
+  localVue,
+  propsData,
+  stubs: ['b-container']
+});
+
+describe('components/landing/LandingImageCardGroup', () => {
+  it('displays a title', () => {
+    const title = 'Title for an image card group';
+    const wrapper = factory({ title });
+
+    const titleElement = wrapper.find('h2');
+
+    expect(titleElement.text()).toBe(title);
+  });
+});

--- a/packages/styleguide/styleguide.root.js
+++ b/packages/styleguide/styleguide.root.js
@@ -93,6 +93,7 @@ Object.assign(Vue.prototype, {
     to: route => route,
     href: () => null
   },
+  localePath: () => '/',
   $path: () => {
     return '/';
   },


### PR DESCRIPTION
- Split `ImageWithAttribution` component into a container and sub component to reuse without the container + jumbotron wrappers
- Add `srcset` and `sizes` attributes to `ImageOptimised` to pass in responsive images
- Add new `LandingImageCard `and `LandingImageCardGroup` components