### PR TITLE
feat: fetch multiple cache entries

### DIFF
--- a/packages/portal/src/components/browse/BrowseAutomatedCardGroup.vue
+++ b/packages/portal/src/components/browse/BrowseAutomatedCardGroup.vue
@@ -180,11 +180,12 @@
         if (process.server) {
           return import('@/server-middleware/api/cache/index.js')
             .then(module => {
-              return module.cached(this.key, this.$config.redis);
+              return module.cached(this.key, this.$config.redis)
+                .then((response) => response[this.key]);
             });
         } else {
           return this.$axios.get(`/_api/cache/${this.key}`, { baseURL: window.location.origin })
-            .then((response) => response.data);
+            .then((response) => response.data[this.key]);
         }
       },
       async fetchContentfulData() {

--- a/packages/portal/src/components/entity/EntityTable.vue
+++ b/packages/portal/src/components/entity/EntityTable.vue
@@ -104,7 +104,7 @@
     async fetch() {
       try {
         const response = await this.$axios.get(this.apiEndpoint, { baseURL: window.location.origin });
-        let collections = response.data;
+        let collections = response.data[this.cacheKey];
         if (this.type === 'organisations') {
           collections = collections.map(this.organisationData);
         }
@@ -117,10 +117,13 @@
     fetchOnServer: false,
     computed: {
       apiEndpoint() {
+        return `/_api/cache/${this.cacheKey}`;
+      },
+      cacheKey() {
         // For organisations, get unlocalised labels, for both English and native.
         return this.type === 'organisations' ?
-          '/_api/cache/collections/organisations' :
-          `/_api/cache/${this.$i18n.locale}/collections/${this.type}`;
+          'collections/organisations' :
+          `${this.$i18n.locale}/collections/${this.type}`;
       }
     },
     methods: {

--- a/packages/portal/src/server-middleware/api/cache/index.js
+++ b/packages/portal/src/server-middleware/api/cache/index.js
@@ -3,27 +3,28 @@ import { errorHandler } from '../index.js';
 
 const cacheKey = (id) => `@europeana:portal.js:${id.replace(/\//g, ':')}`;
 
-export const cached = (id, config = {}, options = {}) => {
-  const defaults = { parse: true };
-  const settings = { ...defaults, ...options };
-
+export const cached = async(ids, config = {}) => {
   if (!config.url) {
     return Promise.reject(new Error('No cache configured.'));
   }
   const redisClient = createRedisClient(config);
 
-  const key = cacheKey(id);
+  const values = {};
+  for (const id of [].concat(ids)) {
+    const key = cacheKey(id);
+    const value = await redisClient.getAsync(key);
+    values[id] = JSON.parse(value);
+  }
 
-  return redisClient.getAsync(key)
-    .then(value => settings.parse ? JSON.parse(value) : value)
-    .then(body => {
-      redisClient.quitAsync();
-      return body;
-    });
+  redisClient.quitAsync();
+
+  return values;
 };
 
-export default (id, config = {}) => (req, res) => {
-  return cached(id, config, { parse: false })
+export default (config = {}) => (req, res) => {
+  const ids = req.params[0] ? req.params[0] : req.query.id;
+
+  return cached(ids, config)
     .then(data => {
       res.set('Content-Type', 'application/json');
       res.send(data);

--- a/packages/portal/src/server-middleware/api/index.js
+++ b/packages/portal/src/server-middleware/api/index.js
@@ -33,7 +33,9 @@ import debugMemoryUsage from './debug/memory-usage.js';
 app.get('/debug/memory-usage', debugMemoryUsage);
 
 import cache from './cache/index.js';
-app.get('/cache/*', (req, res) => cache(req.params[0], runtimeConfig.redis)(req, res));
+const cacheMiddleware = (req, res) => cache(runtimeConfig.redis)(req, res);
+app.get('/cache', cacheMiddleware);
+app.get('/cache/*', cacheMiddleware);
 
 import jiraServiceDeskFeedback from './jira-service-desk/feedback.js';
 app.post('/jira-service-desk/feedback', (req, res) => jiraServiceDeskFeedback(runtimeConfig.jira)(req, res));

--- a/packages/portal/tests/unit/components/browse/BrowseAutomatedCardGroup.spec.js
+++ b/packages/portal/tests/unit/components/browse/BrowseAutomatedCardGroup.spec.js
@@ -151,7 +151,9 @@ describe('components/browse/BrowseAutomatedCardGroup', () => {
     describe('when section is cached', () => {
       const propsData = { sectionType: FEATURED_TOPICS };
       beforeEach(() => {
-        $axiosGetStub.withArgs('/_api/cache/en/collections/topics/featured').resolves({ data: entries.featuredTopics });
+        $axiosGetStub.withArgs('/_api/cache/en/collections/topics/featured').resolves(
+          { data: { 'en/collections/topics/featured': entries.featuredTopics } }
+        );
       });
       afterEach(() => {
         $axiosGetStub.reset();

--- a/packages/portal/tests/unit/components/entity/EntityTable.spec.js
+++ b/packages/portal/tests/unit/components/entity/EntityTable.spec.js
@@ -49,7 +49,7 @@ const organisations = [
 describe('components/entity/EntityTable', () => {
   describe('fetch()', () => {
     beforeEach(() => {
-      $axiosGetStub.withArgs(middlewarePath).resolves({ data: collections });
+      $axiosGetStub.withArgs(middlewarePath).resolves({ data: { 'collections/organisations': collections } });
     });
 
     afterEach(() => {

--- a/packages/portal/tests/unit/server-middleware/api/cache/index.spec.js
+++ b/packages/portal/tests/unit/server-middleware/api/cache/index.spec.js
@@ -15,6 +15,7 @@ const cached = JSON.stringify([
   { id: '1' },
   { id: '2' }
 ]);
+const expressReq = { params: [id], query: {} };
 
 const redisClientStub = {
   getAsync: sinon.stub().resolves(cached),
@@ -31,20 +32,20 @@ describe('server-middleware/api/cache/index', () => {
   });
 
   it('fetches from the cache, with app namespace', async() => {
-    await serverMiddleware(id, config)({}, expressResStub);
+    await serverMiddleware(config)(expressReq, expressResStub);
 
     expect(redisClientStub.getAsync.calledWith(`@europeana:portal.js:${id}`)).toBe(true);
   });
 
   it('responds with JSON', async() => {
-    await serverMiddleware(id, config)({}, expressResStub);
+    await serverMiddleware(config)(expressReq, expressResStub);
 
     expect(expressResStub.set.calledWith('Content-Type', 'application/json')).toBe(true);
-    expect(expressResStub.send.calledWith(cached)).toBe(true);
+    expect(expressResStub.send.calledWith({ [id]: JSON.parse(cached) })).toBe(true);
   });
 
   it('quits the Redis connection', async() => {
-    await serverMiddleware(id, config)({}, expressResStub);
+    await serverMiddleware(config)(expressReq, expressResStub);
 
     expect(redisClientStub.quitAsync.called).toBe(true);
   });


### PR DESCRIPTION
* Extends cache server middleware to support retrieval of multiple cache entries in one request, by requesting `/_api/cache`, with one or more `id` query parameters, e.g. `/_api/cache?id=items/type-counts&id=items/recent`
* Keeps support of individual cache entries via e.g. `/_api/cache/items/recent`
* Cache server middleware responses are now always objects with each property keyed by the ID