### PR TITLE
feat: landing embed

### DIFF
--- a/packages/contentful/migrations/0104-create-embed-header-conent-type.cjs
+++ b/packages/contentful/migrations/0104-create-embed-header-conent-type.cjs
@@ -1,0 +1,84 @@
+module.exports = async function(migration) {
+  // Create embedWithHeader content type
+
+  const embedWithHeader = migration
+    .createContentType('embedWithHeader')
+    .name('Embed with header')
+    .description('Section with a header (background image, title and text) and an embed')
+    .displayField('name');
+
+  embedWithHeader
+    .createField('name')
+    .name('Name')
+    .type('Symbol')
+    .localized(true)
+    .required(true)
+    .validations([
+      {
+        unique: true
+      }
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  embedWithHeader
+    .createField('text')
+    .name('Text')
+    .type('Text')
+    .localized(true)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  embedWithHeader.changeFieldControl('text', 'builtin', 'markdown', {
+    helpText: 'Text to accompany embed. Currently only used for the embed on Landing pages.'
+  });
+
+  embedWithHeader
+    .createField('image')
+    .name('Background image')
+    .type('Link')
+    .localized(false)
+    .required(false)
+    .validations([
+      {
+        linkContentType: ['imageWithAttribution']
+      }
+    ])
+    .disabled(false)
+    .omitted(false)
+    .linkType('Entry');
+
+  embedWithHeader
+    .createField('embed')
+    .name('Embed')
+    .type('Link')
+    .localized(false)
+    .required(false)
+    .validations([
+      {
+        linkContentType: ['embed']
+      }
+    ])
+    .disabled(false)
+    .omitted(false)
+    .linkType('Entry');
+
+  const landingPage = migration
+    .editContentType('landingPage');
+
+  landingPage
+    .editField('hasPart')
+    .items({
+      type: 'Link',
+
+      validations: [
+        {
+          linkContentType: ['infoCardGroup', 'imageCardGroup', 'landingSubSection', 'embedWithHeader']
+        }
+      ],
+
+      linkType: 'Entry'
+    });
+};

--- a/packages/contentful/migrations/0104-create-embed-section-content-type.cjs
+++ b/packages/contentful/migrations/0104-create-embed-section-content-type.cjs
@@ -1,13 +1,13 @@
 module.exports = async function(migration) {
-  // Create embedWithHeader content type
+  // Create embedSection content type
 
-  const embedWithHeader = migration
-    .createContentType('embedWithHeader')
-    .name('Embed with header')
+  const embedSection = migration
+    .createContentType('embedSection')
+    .name('Embed section')
     .description('Section with a header (background image, title and text) and an embed')
     .displayField('name');
 
-  embedWithHeader
+  embedSection
     .createField('name')
     .name('Name')
     .type('Symbol')
@@ -21,7 +21,7 @@ module.exports = async function(migration) {
     .disabled(false)
     .omitted(false);
 
-  embedWithHeader
+  embedSection
     .createField('text')
     .name('Text')
     .type('Text')
@@ -31,11 +31,11 @@ module.exports = async function(migration) {
     .disabled(false)
     .omitted(false);
 
-  embedWithHeader.changeFieldControl('text', 'builtin', 'markdown', {
+  embedSection.changeFieldControl('text', 'builtin', 'markdown', {
     helpText: 'Text to accompany embed. Currently only used for the embed on Landing pages.'
   });
 
-  embedWithHeader
+  embedSection
     .createField('image')
     .name('Background image')
     .type('Link')
@@ -50,7 +50,7 @@ module.exports = async function(migration) {
     .omitted(false)
     .linkType('Entry');
 
-  embedWithHeader
+  embedSection
     .createField('embed')
     .name('Embed')
     .type('Link')
@@ -75,7 +75,7 @@ module.exports = async function(migration) {
 
       validations: [
         {
-          linkContentType: ['infoCardGroup', 'imageCardGroup', 'landingSubSection', 'embedWithHeader']
+          linkContentType: ['infoCardGroup', 'imageCardGroup', 'landingSubSection', 'embedSection']
         }
       ],
 

--- a/packages/contentful/migrations/0105-link-to-hash-fragment.cjs
+++ b/packages/contentful/migrations/0105-link-to-hash-fragment.cjs
@@ -1,0 +1,14 @@
+module.exports = function(migration) {
+  const link = migration.editContentType('link');
+  link
+    .editField('url')
+    .validations([
+      {
+        regexp: {
+          pattern:
+            '^(((ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?)|(\/|\/([\w#!:.?+=&%@!\-\/])*))|(#[\w!:.?+=&%@!\-\/]+)$'
+        },
+        message: 'Must be a URL, a URL path starting with "/", or an inline anchor starting with "#"'
+      }
+    ]);
+};

--- a/packages/portal/src/components/landing/LandingEmbed.vue
+++ b/packages/portal/src/components/landing/LandingEmbed.vue
@@ -1,26 +1,46 @@
 <template>
-  <b-container>
-    <div class="header mx-auto">
-      <h2>
-        {{ title }}
-      </h2>
-      <!-- eslint-disable vue/no-v-html -->
-      <div
-        v-if="text"
-        class="text mb-3"
-        v-html="parseMarkdownHtml(text)"
-      />
-    <!-- eslint-enable vue/no-v-html -->
+  <div>
+    <div
+      class="header responsive-backround-image"
+      :style="imageCSSVars"
+    >
+      <b-container>
+        <b-col class="header-content col-lg-8 text-center mx-auto">
+          <h2>
+            {{ title }}
+          </h2>
+          <!-- eslint-disable vue/no-v-html -->
+          <div
+            v-if="text"
+            class="text mb-3"
+            v-html="parseMarkdownHtml(text)"
+          />
+          <!-- eslint-enable vue/no-v-html -->
+        </b-col>
+      </b-container>
     </div>
-    <EmbedHTML
-      :html="embed.embed"
-    />
-  </b-container>
+    <b-container>
+      <EmbedHTML
+        :html="embed.embed"
+      />
+    </b-container>
+  </div>
 </template>
 
 <script>
   import parseMarkdownHtmlMixin from '@/mixins/parseMarkdownHtml';
   import EmbedHTML from '@/components/embed/EmbedHTML';
+
+  const SRCSET_PRESETS = {
+    small: { w: 576, h: 360, fit: 'fill' },
+    medium: { w: 768, h: 270, fit: 'fill' },
+    large: { w: 992, h: 480, fit: 'fill' },
+    xl: { w: 1200, h: 480, fit: 'fill' },
+    xxl: { w: 1440, h: 480, fit: 'fill' },
+    xxxl: { w: 1920, h: 480, fit: 'fill' },
+    wqhd: { w: 2560, h: 480, fit: 'fill' },
+    '4k': { w: 3840, h: 480, fit: 'fill' }
+  };
 
   export default {
     name: 'LandingEmbed',
@@ -48,6 +68,67 @@
         type: Object,
         default: null
       }
+    },
+
+    computed: {
+      imageCSSVars() {
+        return this.backgroundImage?.image &&
+          this.$contentful.assets.responsiveBackgroundImageCSSVars(
+            this.backgroundImage.image, SRCSET_PRESETS);
+      }
     }
   };
 </script>
+
+<style lang="scss" scoped>
+  @import '@europeana/style/scss/variables';
+  @import '@europeana/style/scss/responsive-background-image';
+
+  .header {
+    color: $white;
+    background-size: cover;
+    background-repeat: no-repeat;
+    position: relative;
+    padding: 3.5rem 0;
+
+    @media (min-width: $bp-medium) {
+      padding: 4rem 0 17rem;
+    }
+
+    &::before {
+      content: '';
+      left: 0;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      background-image: linear-gradient(0deg, #0b60aa, #0b60aa);
+      mix-blend-mode: multiply;
+      position: absolute;
+    }
+
+    .container {
+      position: relative; // Prevents blending with the background
+    }
+
+    .header-content {
+      @media (min-width: $bp-xxl) {
+        max-width: $max-text-column-width;
+      }
+    }
+
+    h2 {
+      font-family: $font-family-ubuntu;
+      font-size: $font-size-large;
+      font-weight: 500;
+
+      @media (min-width: $bp-medium) {
+        font-size: $font-size-xl;
+      }
+
+      @media (min-width: $bp-4k) {
+        font-size: $font-size-xl-4k;
+      }
+    }
+  }
+
+</style>

--- a/packages/portal/src/components/landing/LandingEmbed.vue
+++ b/packages/portal/src/components/landing/LandingEmbed.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="landing-embed">
+  <div
+    :id="containerId"
+    class="landing-embed"
+  >
     <div
       class="header responsive-backround-image"
       :style="imageCSSVars"
@@ -31,6 +34,7 @@
 </template>
 
 <script>
+  import kebabCase from 'lodash/kebabCase';
   import parseMarkdownHtmlMixin from '@/mixins/parseMarkdownHtml';
   import EmbedHTML from '@/components/embed/EmbedHTML';
 
@@ -71,6 +75,12 @@
         type: Object,
         default: null
       }
+    },
+
+    data() {
+      return {
+        containerId: kebabCase(this.title)
+      };
     },
 
     computed: {

--- a/packages/portal/src/components/landing/LandingEmbed.vue
+++ b/packages/portal/src/components/landing/LandingEmbed.vue
@@ -100,6 +100,7 @@
   .landing-embed {
     border-bottom: 1px solid $white;
   }
+
   .header {
     color: $white;
     background-size: cover;
@@ -148,11 +149,15 @@
   }
 
   .embed-container {
-    max-width: $max-text-column-width;
-
     @media (min-width: $bp-medium) {
       margin-top: -13rem;
       position: relative;
+    }
+
+    ::v-deep iframe {
+      max-width: 920px;
+      width: 100%;
+      min-height: 1200px;
     }
   }
 

--- a/packages/portal/src/components/landing/LandingEmbed.vue
+++ b/packages/portal/src/components/landing/LandingEmbed.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="landing-embed">
     <div
       class="header responsive-backround-image"
       :style="imageCSSVars"
@@ -19,7 +19,10 @@
         </b-col>
       </b-container>
     </div>
-    <b-container>
+    <b-container
+      v-if="embed"
+      class="embed-container"
+    >
       <EmbedHTML
         :html="embed.embed"
       />
@@ -84,6 +87,9 @@
   @import '@europeana/style/scss/variables';
   @import '@europeana/style/scss/responsive-background-image';
 
+  .landing-embed {
+    border-bottom: 1px solid $white;
+  }
   .header {
     color: $white;
     background-size: cover;
@@ -128,6 +134,15 @@
       @media (min-width: $bp-4k) {
         font-size: $font-size-xl-4k;
       }
+    }
+  }
+
+  .embed-container {
+    max-width: $max-text-column-width;
+
+    @media (min-width: $bp-medium) {
+      margin-top: -13rem;
+      position: relative;
     }
   }
 

--- a/packages/portal/src/components/landing/LandingEmbed.vue
+++ b/packages/portal/src/components/landing/LandingEmbed.vue
@@ -1,0 +1,53 @@
+<template>
+  <b-container>
+    <div class="header mx-auto">
+      <h2>
+        {{ title }}
+      </h2>
+      <!-- eslint-disable vue/no-v-html -->
+      <div
+        v-if="text"
+        class="text mb-3"
+        v-html="parseMarkdownHtml(text)"
+      />
+    <!-- eslint-enable vue/no-v-html -->
+    </div>
+    <EmbedHTML
+      :html="embed.embed"
+    />
+  </b-container>
+</template>
+
+<script>
+  import parseMarkdownHtmlMixin from '@/mixins/parseMarkdownHtml';
+  import EmbedHTML from '@/components/embed/EmbedHTML';
+
+  export default {
+    name: 'LandingEmbed',
+
+    components: {
+      EmbedHTML
+    },
+
+    mixins: [parseMarkdownHtmlMixin],
+
+    props: {
+      title: {
+        type: String,
+        default: null
+      },
+      text: {
+        type: String,
+        default: null
+      },
+      backgroundImage: {
+        type: Object,
+        default: null
+      },
+      embed: {
+        type: Object,
+        default: null
+      }
+    }
+  };
+</script>

--- a/packages/portal/src/components/landing/LandingHero.vue
+++ b/packages/portal/src/components/landing/LandingHero.vue
@@ -39,6 +39,17 @@
   import SmartLink from '@/components/generic/SmartLink';
   import parseMarkdownHtmlMixin from '@/mixins/parseMarkdownHtml';
 
+  const SRCSET_PRESETS = {
+    small: { w: 576, h: 265, fit: 'fill' },
+    medium: { w: 768, h: 265, fit: 'fill' },
+    large: { w: 591, h: 600, fit: 'fill' },
+    xl: { w: 695, h: 580, fit: 'fill' },
+    xxl: { w: 815, h: 550, fit: 'fill' },
+    xxxl: { w: 1074, h: 550, fit: 'fill' },
+    wqhd: { w: 1432, h: 800, fit: 'fill' },
+    '4k': { w: 2148, h: 800, fit: 'fill' }
+  };
+
   export default {
     name: 'LandingHero',
 
@@ -85,17 +96,7 @@
       imageCSSVars() {
         return this.heroImage?.image &&
           this.$contentful.assets.responsiveBackgroundImageCSSVars(
-            this.heroImage.image,
-            {
-              small: { w: 576, h: 265, fit: 'fill' },
-              medium: { w: 768, h: 265, fit: 'fill' },
-              large: { w: 591, h: 600, fit: 'fill' },
-              xl: { w: 695, h: 580, fit: 'fill' },
-              xxl: { w: 815, h: 550, fit: 'fill' },
-              xxxl: { w: 1074, h: 550, fit: 'fill' },
-              wqhd: { w: 1432, h: 800, fit: 'fill' },
-              '4k': { w: 2148, h: 800, fit: 'fill' }
-            }
+            this.heroImage.image, SRCSET_PRESETS
           );
       }
     }

--- a/packages/portal/src/components/landing/LandingImageCardGroup.vue
+++ b/packages/portal/src/components/landing/LandingImageCardGroup.vue
@@ -2,7 +2,7 @@
   <div class="image-card-group">
     <div class="header pt-5 pb-5">
       <b-container>
-        <div class="header-content text-center mx-auto">
+        <b-col class="header-content col-lg-8 text-center mx-auto">
           <h2>
             {{ title }}
           </h2>
@@ -13,7 +13,7 @@
             v-html="parseMarkdownHtml(text)"
           />
         <!-- eslint-enable vue/no-v-html -->
-        </div>
+        </b-col>
       </b-container>
     </div>
     <b-container>
@@ -86,7 +86,9 @@
   }
 
   .header-content {
-    max-width: $max-text-column-width;
+    @media (min-width: $bp-xxl) {
+      max-width: $max-text-column-width;
+    }
   }
 </style>
 

--- a/packages/portal/src/components/landing/LandingInfoCardGroup.vue
+++ b/packages/portal/src/components/landing/LandingInfoCardGroup.vue
@@ -1,6 +1,6 @@
 <template>
   <b-container class="text-center">
-    <div class="header mx-auto pb-1">
+    <b-col class="header col-lg-8 text-center mx-auto pb-1">
       <h2>
         {{ title }}
       </h2>
@@ -11,7 +11,7 @@
         v-html="parseMarkdownHtml(text)"
       />
     <!-- eslint-enable vue/no-v-html -->
-    </div>
+    </b-col>
     <div
       v-if="infoCards.length"
       class="d-lg-inline-flex mx-auto"
@@ -76,7 +76,9 @@
   }
 
   .header {
-    max-width: $max-text-column-width;
+    @media (min-width: $bp-xxl) {
+      max-width: $max-text-column-width;
+    }
 
     h2 {
       font-family: $font-family-ubuntu;

--- a/packages/portal/src/components/landing/LandingPage.vue
+++ b/packages/portal/src/components/landing/LandingPage.vue
@@ -29,6 +29,13 @@
         :title="section.name"
         :text="section.text"
       />
+      <LandingEmbed
+        v-if="contentType(section, 'EmbedWithHeader')"
+        :title="section.name"
+        :text="section.text"
+        :background-image="section.image"
+        :embed="section.embed"
+      />
     </div>
   </div>
 </template>
@@ -43,7 +50,8 @@
       LandingHero,
       LandingInfoCardGroup: () => import('@/components/landing/LandingInfoCardGroup'),
       LandingImageCardGroup: () => import('@/components/landing/LandingImageCardGroup'),
-      LandingSubSection: () => import('@/components/landing/LandingSubSection')
+      LandingSubSection: () => import('@/components/landing/LandingSubSection'),
+      LandingEmbed: () => import('@/components/landing/LandingEmbed')
     },
 
     props: {

--- a/packages/portal/src/components/landing/LandingPage.vue
+++ b/packages/portal/src/components/landing/LandingPage.vue
@@ -31,7 +31,7 @@
         :sections="section.hasPartCollection && section.hasPartCollection.items"
       />
       <LandingEmbed
-        v-if="contentType(section, 'EmbedWithHeader')"
+        v-if="contentType(section, 'EmbedSection')"
         :title="section.name"
         :text="section.text"
         :background-image="section.image"

--- a/packages/portal/src/modules/contentful/queries/browse-landing-static-page.graphql
+++ b/packages/portal/src/modules/contentful/queries/browse-landing-static-page.graphql
@@ -215,7 +215,7 @@ query BrowseLandingStaticPage(
               }
             }
           }
-          ... on EmbedWithHeader {
+          ... on EmbedSection {
             name
             text
             image {

--- a/packages/portal/src/modules/contentful/queries/browse-landing-static-page.graphql
+++ b/packages/portal/src/modules/contentful/queries/browse-landing-static-page.graphql
@@ -215,16 +215,16 @@ query BrowseLandingStaticPage(
               }
             }
           }
-          ... on EmbedWithHeader {
-            name
-            text
-            image {
-              ...imageWithAttributionFields
-            }
-            embed {
-              embed
-            }
-          }
+          # ... on EmbedWithHeader {
+          #   name
+          #   text
+          #   image {
+          #     ...imageWithAttributionFields
+          #   }
+          #   embed {
+          #     embed
+          #   }
+          # }
         }
       }
     }

--- a/packages/portal/src/modules/contentful/queries/browse-landing-static-page.graphql
+++ b/packages/portal/src/modules/contentful/queries/browse-landing-static-page.graphql
@@ -215,6 +215,16 @@ query BrowseLandingStaticPage(
               }
             }
           }
+          ... on EmbedWithHeader {
+            name
+            text
+            image {
+              ...imageWithAttributionFields
+            }
+            embed {
+              embed
+            }
+          }
         }
       }
     }

--- a/packages/portal/src/modules/contentful/queries/browse-landing-static-page.graphql
+++ b/packages/portal/src/modules/contentful/queries/browse-landing-static-page.graphql
@@ -215,16 +215,16 @@ query BrowseLandingStaticPage(
               }
             }
           }
-          # ... on EmbedWithHeader {
-          #   name
-          #   text
-          #   image {
-          #     ...imageWithAttributionFields
-          #   }
-          #   embed {
-          #     embed
-          #   }
-          # }
+          ... on EmbedWithHeader {
+            name
+            text
+            image {
+              ...imageWithAttributionFields
+            }
+            embed {
+              embed
+            }
+          }
         }
       }
     }

--- a/packages/portal/tests/size/.size-limit.json
+++ b/packages/portal/tests/size/.size-limit.json
@@ -19,7 +19,7 @@
   {
     "name": "portal.js server",
     "running": false,
-    "limit": "835 KB",
+    "limit": "840 KB",
     "path": [
       ".nuxt/dist/server/*.js"
     ]

--- a/packages/portal/tests/unit/components/landing/LandingEmbed.spec.js
+++ b/packages/portal/tests/unit/components/landing/LandingEmbed.spec.js
@@ -18,12 +18,24 @@ const factory = (propsData) => shallowMount(LandingEmbed, {
 });
 
 describe('components/landing/LandingEmbed', () => {
-  describe('imageCSSVars', () => {
-    describe('when there is a background image available', () => {
-      it('returns background style definitions', () => {
-        const wrapper = factory({ backgroundImage: { image: { url: 'https://www.europeana.eu/example.jpg' } } });
+  describe('template', () => {
+    it('has a container ID derived from the title', () => {
+      const wrapper = factory({ title: 'Embed this' });
 
-        expect(wrapper.vm.imageCSSVars).toBeTruthy();
+      const containerId = wrapper.find('.landing-embed').attributes('id');
+
+      expect(containerId).toBe('embed-this');
+    });
+  });
+
+  describe('computed', () => {
+    describe('imageCSSVars', () => {
+      describe('when there is a background image available', () => {
+        it('returns background style definitions', () => {
+          const wrapper = factory({ backgroundImage: { image: { url: 'https://www.europeana.eu/example.jpg' } } });
+
+          expect(wrapper.vm.imageCSSVars).toBeTruthy();
+        });
       });
     });
   });

--- a/packages/portal/tests/unit/components/landing/LandingEmbed.spec.js
+++ b/packages/portal/tests/unit/components/landing/LandingEmbed.spec.js
@@ -1,0 +1,30 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+
+import LandingEmbed from '@/components/landing/LandingEmbed.vue';
+
+const localVue = createLocalVue();
+
+const factory = (propsData) => shallowMount(LandingEmbed, {
+  localVue,
+  propsData,
+  mocks: {
+    $contentful: {
+      assets: {
+        responsiveBackgroundImageCSSVars: (img, sizes) => Object.keys(sizes)
+      }
+    }
+  },
+  stubs: ['b-container', 'b-col']
+});
+
+describe('components/landing/LandingEmbed', () => {
+  describe('imageCSSVars', () => {
+    describe('when there is a background image available', () => {
+      it('returns background style definitions', () => {
+        const wrapper = factory({ backgroundImage: { image: { url: 'https://www.europeana.eu/example.jpg' } } });
+
+        expect(wrapper.vm.imageCSSVars).toBeTruthy();
+      });
+    });
+  });
+});

--- a/packages/portal/tests/unit/components/landing/LandingImageCardGroup.spec.js
+++ b/packages/portal/tests/unit/components/landing/LandingImageCardGroup.spec.js
@@ -7,7 +7,7 @@ const localVue = createLocalVue();
 const factory = (propsData) => shallowMount(LandingImageCardGroup, {
   localVue,
   propsData,
-  stubs: ['b-container']
+  stubs: ['b-container', 'b-col']
 });
 
 describe('components/landing/LandingImageCardGroup', () => {

--- a/packages/portal/tests/unit/components/landing/LandingInfoCardGroup.spec.js
+++ b/packages/portal/tests/unit/components/landing/LandingInfoCardGroup.spec.js
@@ -7,7 +7,7 @@ const localVue = createLocalVue();
 const factory = (propsData) => shallowMount(LandingInfoCardGroup, {
   localVue,
   propsData,
-  stubs: ['b-container']
+  stubs: ['b-container', 'b-col']
 });
 
 describe('components/landing/LandingInfoCardGroup', () => {


### PR DESCRIPTION
- Migration to create `embedSection` content type to be able to create a section with a title, text and background image to accompany an embed
- Adds new component `LandingEmbed`
- Use `b-col` for header sections to have smaller, better readable text columns on desktop.