### PR TITLE
feat: add configured recordApi to video manifest URL

### DIFF
--- a/packages/portal/src/pages/media/index.vue
+++ b/packages/portal/src/pages/media/index.vue
@@ -49,8 +49,10 @@
 
     computed: {
       manifest() {
-        return `${this.$config.europeana.apis.iiifPresentation.url}${this.id}/manifest?format=3`;
+        const recordEndpointParam = this.$config.europeana.apis.record.url ? '&recordApi=' + this.$config.europeana.apis.record.url.replace('/api/v2', '') : '';
+        return `${this.$config.europeana.apis.iiifPresentation.url}${this.id}/manifest?format=3${recordEndpointParam}`;
       },
+
       dashRequired() {
         return new WebResource({ ebucoreHasMimeType: this.mediaType }).requiresDashJS;
       }


### PR DESCRIPTION
to aid in previewing new content which is not yet available on the production API