### PR TITLE
refactor: store preferred API base URLs

### DIFF
--- a/packages/portal/src/components/download/DownloadButton.vue
+++ b/packages/portal/src/components/download/DownloadButton.vue
@@ -54,7 +54,7 @@
         return !this.urlValidated && !this.validationNetworkError;
       },
       target() {
-        if (this.validationNetworkError || !this.url.startsWith(this.$config.europeana.apis.mediaProxy.url)) {
+        if (this.validationNetworkError || !this.url.startsWith(this.$store.state.apis.urls.mediaProxy)) {
           return '_blank';
         }
         return '_self';

--- a/packages/portal/src/components/search/SearchInterface.vue
+++ b/packages/portal/src/components/search/SearchInterface.vue
@@ -311,8 +311,7 @@
         const apiOptions = {};
 
         if (this.hasFulltextQa) {
-          // TODO: ensure this is aware of per-request fulltext url, e.g. from ingress headers
-          apiOptions.url = this.$config.europeana.apis.fulltext.url;
+          apiOptions.url = this.$store.state.apis.urls.fulltext;
         }
 
         if (this.translateLang) {

--- a/packages/portal/src/pages/media/index.vue
+++ b/packages/portal/src/pages/media/index.vue
@@ -49,9 +49,9 @@
 
     computed: {
       manifest() {
-        const manifestUrl = new URL(`/presentation${this.id}/manifest`, this.$config.europeana.apis.iiifPresentation.url);
+        const manifestUrl = new URL(`/presentation${this.id}/manifest`, this.$store.state.apis.urls.iiifPresentation);
         manifestUrl.searchParams.set('format', '3');
-        manifestUrl.searchParams.set('recordApi', new URL(this.$config.europeana.apis.record.url).origin);
+        manifestUrl.searchParams.set('recordApi', new URL(this.$store.state.apis.urls.record).origin);
         return manifestUrl.toString();
       },
 

--- a/packages/portal/src/plugins/apis.js
+++ b/packages/portal/src/plugins/apis.js
@@ -1,3 +1,4 @@
+import kebabCase from 'lodash/kebabCase.js';
 import snakeCase from 'lodash/snakeCase.js';
 
 import * as annotation from './europeana/annotation.js';
@@ -26,8 +27,8 @@ const apis = {
   thumbnail
 };
 
-const apiUrlFromRequestHeaders = (api, headers = {}) => {
-  return headers[`x-europeana-${api}-api-url`];
+const apiUrlFromRequestHeaders = (id, headers = {}) => {
+  return headers[`x-europeana-${kebabCase(id)}-api-url`];
 };
 
 export const storeModule = {

--- a/packages/portal/src/plugins/apis.js
+++ b/packages/portal/src/plugins/apis.js
@@ -100,7 +100,9 @@ export const publicPrivateRewriteOrigins = () => {
 
 export default (context, inject) => {
   context.store.registerModule(MODULE_NAME, storeModule);
-  context.store.commit('apis/init', context);
+  if (process.server) {
+    context.store.commit('apis/init', context);
+  }
 
   const plugin = Object.keys(apis).reduce((memo, id) => {
     if (apis[id].default) {

--- a/packages/portal/src/plugins/europeana/annotation.js
+++ b/packages/portal/src/plugins/europeana/annotation.js
@@ -4,7 +4,7 @@ export const BASE_URL = 'https://api.europeana.eu/annotation';
 export const AUTHENTICATING = true;
 
 export default (context = {}) => {
-  const $axios = createAxios({ id: 'annotation', baseURL: BASE_URL }, context);
+  const $axios = createAxios({ id: 'annotation' }, context);
 
   return {
     $axios,

--- a/packages/portal/src/plugins/europeana/entity-management.js
+++ b/packages/portal/src/plugins/europeana/entity-management.js
@@ -7,7 +7,7 @@ export const AUTHENTICATING = true;
 
 export default (context = {}) => {
   const $axios = createKeycloakAuthAxios(
-    { id: 'entityManagement', baseURL: BASE_URL, $axios: context.$axios },
+    { id: 'entityManagement', $axios: context.$axios },
     context
   );
 

--- a/packages/portal/src/plugins/europeana/entity.js
+++ b/packages/portal/src/plugins/europeana/entity.js
@@ -7,7 +7,7 @@ export const BASE_URL = 'https://api.europeana.eu/entity';
 export const AUTHENTICATING = true;
 
 export default (context = {}) => {
-  const $axios = createAxios({ id: 'entity', baseURL: BASE_URL }, context);
+  const $axios = createAxios({ id: 'entity' }, context);
 
   return {
     $axios,

--- a/packages/portal/src/plugins/europeana/recommendation.js
+++ b/packages/portal/src/plugins/europeana/recommendation.js
@@ -5,7 +5,7 @@ export const AUTHENTICATING = true;
 
 export default (context = {}) => {
   const $axios = createKeycloakAuthAxios(
-    { id: 'recommendation', baseURL: BASE_URL, $axios: context.$axios },
+    { id: 'recommendation', $axios: context.$axios },
     context
   );
 

--- a/packages/portal/src/plugins/europeana/record.js
+++ b/packages/portal/src/plugins/europeana/record.js
@@ -92,7 +92,7 @@ const proxyHasFallbackField = (proxy, fallbackProxy, field, targetLanguage) => {
 };
 
 export default (context = {}) => {
-  const $axios = createAxios({ id: 'record', baseURL: BASE_URL }, context);
+  const $axios = createAxios({ id: 'record' }, context);
 
   return {
     $axios,

--- a/packages/portal/src/plugins/europeana/search.js
+++ b/packages/portal/src/plugins/europeana/search.js
@@ -7,7 +7,6 @@ import pick from 'lodash/pick.js';
 import {
   apiError, createAxios, escapeLuceneSpecials, isLangMap, reduceLangMapsForLocale
 } from './utils.js';
-import { BASE_URL } from './record.js';
 import { truncate } from '../vue-filters.js';
 
 // Some facets do not support enquoting of their field values.
@@ -91,7 +90,7 @@ export function rangeFromQueryParam(paramValue) {
  */
 export default (context) => ($axios, params, options = {}) => {
   if (!$axios) {
-    $axios = createAxios({ id: 'record', baseURL: BASE_URL }, context);
+    $axios = createAxios({ id: 'record' }, context);
   }
 
   const localParams = { ...params };

--- a/packages/portal/src/plugins/europeana/set.js
+++ b/packages/portal/src/plugins/europeana/set.js
@@ -11,7 +11,7 @@ const setIdFromUri = (uri) => uri.split('/').pop();
 
 export default (context = {}) => {
   const $axios = createKeycloakAuthAxios(
-    { id: 'set', baseURL: BASE_URL, $axios: context.$axios },
+    { id: 'set', $axios: context.$axios },
     context
   );
 

--- a/packages/portal/src/plugins/europeana/thumbnail.js
+++ b/packages/portal/src/plugins/europeana/thumbnail.js
@@ -5,12 +5,11 @@
 
 import md5 from 'md5';
 
-import { preferredAPIBaseURL } from './utils.js';
-
 export const BASE_URL = 'https://api.europeana.eu/thumbnail/v3';
 
+// TODO: why does this get called multiple times on a single page load?
 export default (context = {}) => {
-  const baseUrl = preferredAPIBaseURL({ id: 'thumbnail', baseURL: BASE_URL }, context);
+  const baseUrl = context.store?.state?.apis?.urls?.thumbnail || BASE_URL;
   if (!baseUrl.endsWith('/v3')) {
     throw new Error('Only Thumbnail API v3 is supported for thumbnail URL generation.');
   }

--- a/packages/portal/src/plugins/europeana/utils.js
+++ b/packages/portal/src/plugins/europeana/utils.js
@@ -6,8 +6,8 @@ import locales from '../i18n/locales.js';
 import undefinedLocaleCodes from '../i18n/undefined.js';
 import { keycloakResponseErrorHandler } from './auth.js';
 
-export const createAxios = ({ id, baseURL, $axios } = {}, context = {}) => {
-  const axiosOptions = axiosInstanceOptions({ id, baseURL }, context);
+export const createAxios = ({ id, $axios } = {}, context = {}) => {
+  const axiosOptions = axiosInstanceOptions({ id }, context);
 
   const axiosInstance = ($axios || axios).create(axiosOptions);
 
@@ -19,8 +19,8 @@ export const createAxios = ({ id, baseURL, $axios } = {}, context = {}) => {
   return axiosInstance;
 };
 
-export const createKeycloakAuthAxios = ({ id, baseURL, $axios }, context) => {
-  const axiosInstance = createAxios({ id, baseURL, $axios }, context);
+export const createKeycloakAuthAxios = ({ id, $axios }, context) => {
+  const axiosInstance = createAxios({ id, $axios }, context);
 
   if (typeof axiosInstance.onResponseError === 'function') {
     axiosInstance.onResponseError(error => keycloakResponseErrorHandler(context, error));
@@ -29,31 +29,11 @@ export const createKeycloakAuthAxios = ({ id, baseURL, $axios }, context) => {
   return axiosInstance;
 };
 
-const storedAPIBaseURL = (store, id) => {
-  if (store?.state?.apis?.urls?.[id]) {
-    return store.state.apis.urls[id];
-  } else {
-    return null;
-  }
-};
-
-export const preferredAPIBaseURL = ({ id, baseURL }, { store, $config }) => {
-  return storedAPIBaseURL(store, id) || apiConfig($config, id).url || baseURL;
-};
-
-export const apiConfig = ($config, id) => {
-  if ($config?.europeana?.apis?.[id]) {
-    return $config.europeana.apis[id];
-  } else {
-    return {};
-  }
-};
-
-const axiosInstanceOptions = ({ id, baseURL }, { store, $config }) => {
-  const config = apiConfig($config, id);
+const axiosInstanceOptions = ({ id }, { store, $config }) => {
+  const config = $config?.europeana?.apis?.[id] || {};
 
   return {
-    baseURL: preferredAPIBaseURL({ id, baseURL }, { store, $config }),
+    baseURL: store?.state?.apis?.urls[id] || config.url,
     params: {
       wskey: config.key
     },

--- a/packages/portal/src/store/index.js
+++ b/packages/portal/src/store/index.js
@@ -7,7 +7,6 @@ export const actions = {
   async nuxtServerInit(store, context) {
     // TODO: ideally the contentful module would run this itself...
     store.commit('contentful/setAcceptedMediaTypes', context.req);
-    store.commit('apis/init', context);
     context.$cookies && store.commit('search/setView', context.$cookies.get('searchResultsView'));
   }
 };

--- a/packages/portal/src/store/index.js
+++ b/packages/portal/src/store/index.js
@@ -7,6 +7,7 @@ export const actions = {
   async nuxtServerInit(store, context) {
     // TODO: ideally the contentful module would run this itself...
     store.commit('contentful/setAcceptedMediaTypes', context.req);
+    store.commit('apis/init', context);
     context.$cookies && store.commit('search/setView', context.$cookies.get('searchResultsView'));
   }
 };

--- a/packages/portal/tests/unit/components/download/DownloadButton.spec.js
+++ b/packages/portal/tests/unit/components/download/DownloadButton.spec.js
@@ -14,7 +14,7 @@ const factory = ({ propsData = {}, data = {}, mocks = {} } = {}) => {
     data: () => ({ ...data }),
     mocks: {
       $apm: { captureError: sinon.spy() },
-      $config: { europeana: { apis: { mediaProxy: { url: 'https://proxy.europeana.eu' } } } },
+      $store: { state: { apis: { urls: { mediaProxy: 'https://proxy.europeana.eu' } } } },
       $matomo: { trackEvent: sinon.spy() },
       $t: (key) => key,
       ...mocks

--- a/packages/portal/tests/unit/components/search/SearchInterface.spec.js
+++ b/packages/portal/tests/unit/components/search/SearchInterface.spec.js
@@ -42,16 +42,7 @@ const factory = ({ $fetchState = {}, mocks = {}, propsData = {}, data = {} } = {
     $i18n: {
       locale: 'en'
     },
-    $config: {
-      europeana: {
-        apis: {
-          fulltext: {
-            url: 'https://newspapers.eanadev.org/api/v2'
-          }
-        }
-      },
-      ...mocks.$config
-    },
+    $config: mocks.$config,
     ...mocks,
     $store: {
       commit: sinon.spy(),
@@ -61,6 +52,11 @@ const factory = ({ $fetchState = {}, mocks = {}, propsData = {}, data = {} } = {
         ...mocks.$store?.getters
       },
       state: {
+        apis: {
+          urls: {
+            fulltext: 'https://newspapers.eanadev.org/api/v2'
+          }
+        },
         entity: {
           entity: {}
         },

--- a/packages/portal/tests/unit/pages/media/index.spec.js
+++ b/packages/portal/tests/unit/pages/media/index.spec.js
@@ -18,14 +18,12 @@ const factory = ({ data = {} } = {}) => shallowMountNuxt(page, {
         mediaType: data.mediaType || 'video/mpeg'
       }
     },
-    $config: {
-      europeana: {
+    $store: {
+      state: {
         apis: {
-          iiifPresentation: {
-            url: 'https://iiifpresentation.eanadev.org/'
-          },
-          record: {
-            url: 'https://api.eanadev.org/record'
+          urls: {
+            iiifPresentation: 'https://iiifpresentation.eanadev.org/',
+            record: 'https://api.eanadev.org/record'
           }
         }
       }

--- a/packages/portal/tests/unit/plugins/apis.spec.js
+++ b/packages/portal/tests/unit/plugins/apis.spec.js
@@ -1,9 +1,5 @@
 import * as plugin from '@/plugins/apis';
 
-import sinon from 'sinon';
-
-const inject = sinon.spy();
-
 describe('plugins/apis', () => {
   let envWas;
   beforeAll(() => {
@@ -185,34 +181,21 @@ describe('plugins/apis', () => {
   });
 
   describe('store module', () => {
-    let storeModule;
-
-    beforeAll(async() => {
-      await plugin.default({
-        app: {},
-        store: {
-          registerModule: sinon.spy((name, module) => {
-            storeModule = module;
-          })
-        }
-      }, inject);
-    });
-
     describe('mutations', () => {
       describe('init', () => {
         it('sets URLs for APIs from request headers', () => {
+          const storeState = plugin.storeModule.state();
           const headers = {
             'x-europeana-annotation-api-url': 'https://annotation.example.org',
             'x-europeana-entity-api-url': 'https://entity.example.org',
             'x-europeana-record-api-url': 'https://record.example.org'
           };
-          const state = storeModule.state();
 
-          storeModule.mutations.init(state, { $config: { europeana: { apis: {} } }, req: { headers } });
+          plugin.storeModule.mutations.init(storeState, { $config: { europeana: { apis: {} } }, req: { headers } });
 
-          expect(state.urls.annotation).toEqual('https://annotation.example.org');
-          expect(state.urls.entity).toEqual('https://entity.example.org');
-          expect(state.urls.record).toEqual('https://record.example.org');
+          expect(storeState.urls.annotation).toEqual('https://annotation.example.org');
+          expect(storeState.urls.entity).toEqual('https://entity.example.org');
+          expect(storeState.urls.record).toEqual('https://record.example.org');
         });
       });
     });

--- a/packages/portal/tests/unit/plugins/apis.spec.js
+++ b/packages/portal/tests/unit/plugins/apis.spec.js
@@ -187,14 +187,14 @@ describe('plugins/apis', () => {
           const storeState = plugin.storeModule.state();
           const headers = {
             'x-europeana-annotation-api-url': 'https://annotation.example.org',
-            'x-europeana-entity-api-url': 'https://entity.example.org',
+            'x-europeana-entity-management-api-url': 'https://entity-mgmt.example.org',
             'x-europeana-record-api-url': 'https://record.example.org'
           };
 
           plugin.storeModule.mutations.init(storeState, { $config: { europeana: { apis: {} } }, req: { headers } });
 
           expect(storeState.urls.annotation).toEqual('https://annotation.example.org');
-          expect(storeState.urls.entity).toEqual('https://entity.example.org');
+          expect(storeState.urls.entityManagement).toEqual('https://entity-mgmt.example.org');
           expect(storeState.urls.record).toEqual('https://record.example.org');
         });
       });

--- a/packages/portal/tests/unit/plugins/europeana/annotation.spec.js
+++ b/packages/portal/tests/unit/plugins/europeana/annotation.spec.js
@@ -2,6 +2,8 @@ import nock from 'nock';
 
 import annotation, { BASE_URL } from '@/plugins/europeana/annotation';
 
+const store = { state: { apis: { urls: { annotation: BASE_URL } } } };
+
 describe('plugins/europeana/entity', () => {
   afterEach(() => {
     nock.cleanAll();
@@ -17,7 +19,7 @@ describe('plugins/europeana/entity', () => {
         })
         .reply(200, {});
 
-      await annotation().search({ query: apiQuery });
+      await annotation({ store }).search({ query: apiQuery });
 
       expect(nock.isDone()).toBe(true);
     });

--- a/packages/portal/tests/unit/plugins/europeana/entity-management.spec.js
+++ b/packages/portal/tests/unit/plugins/europeana/entity-management.spec.js
@@ -1,8 +1,7 @@
 import nock from 'nock';
 
 import entitymanage, { BASE_URL } from '@/plugins/europeana/entity-management';
-
-import axios from 'axios';
+const store = { state: { apis: { urls: { entityManagement: BASE_URL } } } };
 
 const proxyBody = { type: 'Concept',
   prefLabel: { en: 'Painting' },
@@ -53,7 +52,7 @@ describe('plugins/europeana/entity-management', () => {
         .query(query => query.profile === profile)
         .reply(200, entityResponses.items[0]);
 
-      const response = await entitymanage(axios).get(entityUri);
+      const response = await entitymanage({ store }).get(entityUri);
 
       expect(response.note.en).toEqual(['A medium for recording information in the form of writing or images']);
     });
@@ -67,7 +66,7 @@ describe('plugins/europeana/entity-management', () => {
         .query(query => query.profile === profile)
         .reply(200, entityResponses.items[0]);
 
-      await entitymanage(axios).get(entityUri, { profile });
+      await entitymanage({ store }).get(entityUri, { profile });
 
       expect(nock.isDone()).toBe(true);
     });
@@ -81,7 +80,7 @@ describe('plugins/europeana/entity-management', () => {
         .put(`/concept/${entityId}`)
         .reply(200, updatedEntity);
 
-      const response = await entitymanage(axios).update(entityUri, proxyBody);
+      const response = await entitymanage({ store }).update(entityUri, proxyBody);
 
       expect(response.id).toBe('http://data.europeana.eu/concept/124');
     });

--- a/packages/portal/tests/unit/plugins/europeana/recommendation.spec.js
+++ b/packages/portal/tests/unit/plugins/europeana/recommendation.spec.js
@@ -1,8 +1,7 @@
 import nock from 'nock';
 
 import recommendation, { BASE_URL } from '@/plugins/europeana/recommendation';
-
-import axios from 'axios';
+const store = { state: { apis: { urls: { recommendation: BASE_URL } } } };
 
 const recommendations = ['/123/def', '/123/ghi'];
 const oldRecommendedItem = ['/123/jkl'];
@@ -20,7 +19,7 @@ describe('plugins/europeana/recommendation', () => {
           .get('/record/123/abc')
           .reply(200, recommendations);
 
-        const response = await recommendation(axios).recommend('record', '/123/abc');
+        const response = await recommendation({ store }).recommend('record', '/123/abc');
 
         expect(nock.isDone()).toBe(true);
         expect(response).toEqual(recommendations);
@@ -33,7 +32,7 @@ describe('plugins/europeana/recommendation', () => {
           .get('/set/123')
           .reply(200, recommendations);
 
-        const response = await recommendation(axios).recommend('set', '/123');
+        const response = await recommendation({ store }).recommend('set', '/123');
 
         expect(nock.isDone()).toBe(true);
         expect(response).toEqual(recommendations);
@@ -48,7 +47,7 @@ describe('plugins/europeana/recommendation', () => {
           .post('/set/123')
           .reply(200, newRecommendedItem);
 
-        const response = await recommendation(axios).accept('set', '/123', oldRecommendedItem);
+        const response = await recommendation({ store }).accept('set', '/123', oldRecommendedItem);
 
         expect(nock.isDone()).toBe(true);
         expect(response).toEqual(newRecommendedItem);
@@ -63,7 +62,7 @@ describe('plugins/europeana/recommendation', () => {
           .post('/set/123')
           .reply(200, newRecommendedItem);
 
-        const response = await recommendation(axios).accept('set', '/123', oldRecommendedItem);
+        const response = await recommendation({ store }).accept('set', '/123', oldRecommendedItem);
 
         expect(nock.isDone()).toBe(true);
         expect(response).toEqual(newRecommendedItem);

--- a/packages/portal/tests/unit/plugins/europeana/search.spec.js
+++ b/packages/portal/tests/unit/plugins/europeana/search.spec.js
@@ -3,6 +3,7 @@ import search, {
   addContentTierFilter, rangeToQueryParam, rangeFromQueryParam
 } from '@/plugins/europeana/search';
 import { BASE_URL } from '@/plugins/europeana/record';
+const store = { state: { apis: { urls: { record: BASE_URL } } } };
 
 const apiEndpoint = '/search.json';
 
@@ -14,7 +15,7 @@ describe('plugins/europeana/search', () => {
     nock.cleanAll();
   });
 
-  describe('search({})()', () => {
+  describe('search()()', () => {
     describe('API request', () => {
       it('requests 24 results by default', async() => {
         baseRequest()
@@ -23,7 +24,7 @@ describe('plugins/europeana/search', () => {
           })
           .reply(200, defaultResponse);
 
-        await search({})(null, { query: 'anything' });
+        await search({ store })(null, { query: 'anything' });
 
         expect(nock.isDone()).toBe(true);
       });
@@ -35,7 +36,7 @@ describe('plugins/europeana/search', () => {
           })
           .reply(200, defaultResponse);
 
-        await search({})(null, { query: 'anything', rows: 9 });
+        await search({ store })(null, { query: 'anything', rows: 9 });
 
         expect(nock.isDone()).toBe(true);
       });
@@ -47,7 +48,7 @@ describe('plugins/europeana/search', () => {
           })
           .reply(200, defaultResponse);
 
-        await search({})(null, { page: 2, query: 'anything' });
+        await search({ store })(null, { page: 2, query: 'anything' });
 
         expect(nock.isDone()).toBe(true);
       });
@@ -59,7 +60,7 @@ describe('plugins/europeana/search', () => {
           })
           .reply(200, defaultResponse);
 
-        await search({})(null, { page: 42, query: 'anything' });
+        await search({ store })(null, { page: 42, query: 'anything' });
 
         expect(nock.isDone()).toBe(true);
       });
@@ -71,7 +72,7 @@ describe('plugins/europeana/search', () => {
           })
           .reply(200, defaultResponse);
 
-        await search({})(null, { query: 'anything', facet: 'LANGUAGE' });
+        await search({ store })(null, { query: 'anything', facet: 'LANGUAGE' });
 
         expect(nock.isDone()).toBe(true);
       });
@@ -83,7 +84,7 @@ describe('plugins/europeana/search', () => {
           })
           .reply(200, defaultResponse);
 
-        await search({})(null, { query: 'anything', facet: 'COUNTRY,REUSABILITY' });
+        await search({ store })(null, { query: 'anything', facet: 'COUNTRY,REUSABILITY' });
 
         expect(nock.isDone()).toBe(true);
       });
@@ -95,7 +96,7 @@ describe('plugins/europeana/search', () => {
           })
           .reply(200, defaultResponse);
 
-        await search({})(null, { query: '' });
+        await search({ store })(null, { query: '' });
 
         expect(nock.isDone()).toBe(true);
       });
@@ -107,7 +108,7 @@ describe('plugins/europeana/search', () => {
           })
           .reply(200, defaultResponse);
 
-        await search({})(null, { query: 'anything', reusability: 'open' });
+        await search({ store })(null, { query: 'anything', reusability: 'open' });
 
         expect(nock.isDone()).toBe(true);
       });
@@ -122,7 +123,7 @@ describe('plugins/europeana/search', () => {
             })
             .reply(200, defaultResponse);
 
-          await search()(null, { query: 'flor' }, { translateLang });
+          await search({ store })(null, { query: 'flor' }, { translateLang });
 
           expect(nock.isDone()).toBe(true);
         });
@@ -135,7 +136,7 @@ describe('plugins/europeana/search', () => {
             })
             .reply(200, defaultResponse);
 
-          await search()(null, { query: 'flor' });
+          await search({ store })(null, { query: 'flor' });
 
           expect(nock.isDone()).toBe(true);
         });
@@ -150,7 +151,7 @@ describe('plugins/europeana/search', () => {
             })
             .reply(200, defaultResponse);
 
-          await search()(null, { query: 'flor' }, { translateLang });
+          await search({ store })(null, { query: 'flor' }, { translateLang });
 
           expect(nock.isDone()).toBe(true);
         });
@@ -164,7 +165,7 @@ describe('plugins/europeana/search', () => {
             })
             .reply(200, defaultResponse);
 
-          await search({})(null, { query: 'dress (red OR blue)' });
+          await search({ store })(null, { query: 'dress (red OR blue)' });
 
           expect(nock.isDone()).toBe(true);
         });
@@ -176,7 +177,7 @@ describe('plugins/europeana/search', () => {
             })
             .reply(200, defaultResponse);
 
-          await search({})(null, { query: 'dress (red OR blue)' }, { escape: true });
+          await search({ store })(null, { query: 'dress (red OR blue)' }, { escape: true });
 
           expect(nock.isDone()).toBe(true);
         });
@@ -192,7 +193,7 @@ describe('plugins/europeana/search', () => {
             })
             .reply(200, defaultResponse);
 
-          await search({})(null, { query: 'test', boost: 'BOOST' });
+          await search({ store })(null, { query: 'test', boost: 'BOOST' });
 
           expect(nock.isDone()).toBe(true);
         });
@@ -212,7 +213,7 @@ describe('plugins/europeana/search', () => {
 
           let error;
           try {
-            await search({})(null, { query: 'NOT ' });
+            await search({ store })(null, { query: 'NOT ' });
           } catch (e) {
             error = e;
           }
@@ -224,7 +225,7 @@ describe('plugins/europeana/search', () => {
 
       describe('with `items`', () => {
         function searchResponse(options = {}) {
-          return search({})(null, { query: 'painting' }, options);
+          return search({ store })(null, { query: 'painting' }, options);
         }
 
         describe('.items', () => {
@@ -335,7 +336,7 @@ describe('plugins/europeana/search', () => {
 
           describe('when page is at the API limit', () => {
             function searchResponse() {
-              return search({})(null, { query: 'painting', page: 42 });
+              return search({ store })(null, { query: 'painting', page: 42 });
             }
 
             it('is `true`', async() => {

--- a/packages/portal/tests/unit/plugins/europeana/set.spec.js
+++ b/packages/portal/tests/unit/plugins/europeana/set.spec.js
@@ -2,6 +2,7 @@ import nock from 'nock';
 import sinon from 'sinon';
 
 import plugin, { BASE_URL } from '@/plugins/europeana/set';
+const store = { state: { apis: { urls: { set: BASE_URL } } } };
 
 const setId = '1234';
 const itemId = '/123/abc';
@@ -38,7 +39,7 @@ describe('@/plugins/europeana/set', () => {
         .query(true)
         .reply(200, setGetResponse);
 
-      const response = await plugin({ $config }).get(setId);
+      const response = await plugin({ $config, store }).get(setId);
       expect(response.items).toEqual(['http://data.europeana.eu/item/123/abc', 'http://data.europeana.eu/item/123/def']);
     });
 
@@ -48,7 +49,7 @@ describe('@/plugins/europeana/set', () => {
         .query(query => query.wskey === 'apikey')
         .reply(200, setGetResponse);
 
-      await plugin({ $config }).get(setId);
+      await plugin({ $config, store }).get(setId);
       expect(nock.isDone()).toBe(true);
     });
   });
@@ -65,7 +66,7 @@ describe('@/plugins/europeana/set', () => {
         .query(query => query.query === 'creator:auth-user-sub type:BookmarkFolder')
         .reply(200, searchResponse);
 
-      const response = await plugin({ $config }).getLikes('auth-user-sub');
+      const response = await plugin({ $config, store }).getLikes('auth-user-sub');
       expect(response).toBe('http://data.europeana.eu/set/163');
     });
   });
@@ -77,7 +78,7 @@ describe('@/plugins/europeana/set', () => {
         .query(true)
         .reply(200, likesResponse);
 
-      const response = await plugin({ $config }).createLikes();
+      const response = await plugin({ $config, store }).createLikes();
       expect(response.id).toBe('http://data.europeana.eu/set/1234');
     });
   });
@@ -88,7 +89,7 @@ describe('@/plugins/europeana/set', () => {
         .put(`/${setId}${itemId}`)
         .query(true)
         .reply(200, likesResponse);
-      const response =  await plugin({ $config }).modifyItems('add', setId, itemId);
+      const response =  await plugin({ $config, store }).modifyItems('add', setId, itemId);
       expect(response.id).toBe('http://data.europeana.eu/set/1234');
     });
   });
@@ -100,7 +101,7 @@ describe('@/plugins/europeana/set', () => {
         .query(true)
         .reply(204);
 
-      await plugin({ $config }).delete(setId);
+      await plugin({ $config, store }).delete(setId);
       expect(nock.isDone()).toBe(true);
     });
   });
@@ -113,7 +114,7 @@ describe('@/plugins/europeana/set', () => {
         .query(true)
         .reply(200);
 
-      await plugin({ $config }).update(setId, body);
+      await plugin({ $config, store }).update(setId, body);
       expect(nock.isDone()).toBe(true);
     });
 
@@ -125,7 +126,7 @@ describe('@/plugins/europeana/set', () => {
         .query(query => query.profile === params.profile)
         .reply(200);
 
-      await plugin({ $config }).update(setId, body, params);
+      await plugin({ $config, store }).update(setId, body, params);
       expect(nock.isDone()).toBe(true);
     });
   });
@@ -137,7 +138,7 @@ describe('@/plugins/europeana/set', () => {
         .query(true)
         .reply(200);
 
-      await plugin({ $config }).publish(setId);
+      await plugin({ $config, store }).publish(setId);
       expect(nock.isDone()).toBe(true);
     });
     describe('when request errors', () => {
@@ -152,7 +153,7 @@ describe('@/plugins/europeana/set', () => {
 
         let error;
         try {
-          await plugin({ $config }).publish(setId);
+          await plugin({ $config, store }).publish(setId);
         } catch (e) {
           error = e;
         }
@@ -170,7 +171,7 @@ describe('@/plugins/europeana/set', () => {
         .query(true)
         .reply(200);
 
-      await plugin({ $config }).unpublish(setId);
+      await plugin({ $config, store }).unpublish(setId);
       expect(nock.isDone()).toBe(true);
     });
     describe('when request errors', () => {
@@ -185,7 +186,7 @@ describe('@/plugins/europeana/set', () => {
 
         let error;
         try {
-          await plugin({ $config }).unpublish(setId);
+          await plugin({ $config, store }).unpublish(setId);
         } catch (e) {
           error = e;
         }
@@ -211,7 +212,7 @@ describe('@/plugins/europeana/set', () => {
         .query(true)
         .reply(200, 'response');
 
-      const response = await plugin({ $config }).search(searchParams);
+      const response = await plugin({ $config, store }).search(searchParams);
 
       expect(response.data).toEqual('response');
     });
@@ -225,7 +226,8 @@ describe('@/plugins/europeana/set', () => {
         };
         const context = {
           $config,
-          $apis: { record: { find: sinon.stub().resolves(recordSearchResponse) } }
+          $apis: { record: { find: sinon.stub().resolves(recordSearchResponse) } },
+          store
         };
         const setSearchResponse = {
           items: [

--- a/packages/portal/tests/unit/plugins/europeana/thumbnail.spec.js
+++ b/packages/portal/tests/unit/plugins/europeana/thumbnail.spec.js
@@ -1,22 +1,24 @@
-import thumbnail from '@/plugins/europeana/thumbnail';
+import thumbnail, { BASE_URL } from '@/plugins/europeana/thumbnail';
+const store = { state: { apis: { urls: { thumbnail: BASE_URL } } } };
 
 describe('plugins/europeana/thumbnail', () => {
   describe('default export', () => {
     describe('media()', () => {
       const uri = 'https://www.example.org/doc.pdf';
 
-      it('defaults to the v3 production thumbnail API', () => {
-        expect(thumbnail().media(uri).startsWith('https://api.europeana.eu/thumbnail/v3')).toBe(true);
+      it('defaults to the production thumbnail API', () => {
+        const context = { store: { state: { apis: { urls: {} } } } };
+        expect(thumbnail(context).media(uri).startsWith('https://api.europeana.eu/thumbnail/v3')).toBe(true);
       });
 
-      it('favours a thumbnail API in the context', () => {
-        const context = { $config: { europeana: { apis: { thumbnail: { url: 'https://thumbnail.example.org/thumbnail/v3' } } } } };
+      it('favours a thumbnail API in the store', () => {
+        const context = { store: { state: { apis: { urls: { thumbnail: 'https://thumbnail.example.org/thumbnail/v3' } } } } };
 
         expect(thumbnail(context).media(uri).startsWith('https://thumbnail.example.org/thumbnail/v3')).toBe(true);
       });
 
       describe('Thumbnail API v2', () => {
-        const context = { $config: { europeana: { apis: { thumbnail: { url: 'https://api.europeana.eu/thumbnail/v2' } } } } };
+        const context = { store: { state: { apis: { urls: { thumbnail: 'https://api.europeana.eu/thumbnail/v2' } } } } };
 
         it('is not supported', () => {
           expect(() => {
@@ -26,7 +28,7 @@ describe('plugins/europeana/thumbnail', () => {
       });
 
       describe('Thumbnail API v3', () => {
-        const context = { $config: { europeana: { apis: { thumbnail: { url: 'https://api.europeana.eu/thumbnail/v3' } } } } };
+        const context = { store, $config: { europeana: { apis: { thumbnail: { url: 'https://api.europeana.eu/thumbnail/v3' } } } } };
 
         describe('hash', () => {
           it('is used as-is when supplied', () => {
@@ -53,17 +55,9 @@ describe('plugins/europeana/thumbnail', () => {
     });
 
     describe('edmPreview()', () => {
-      describe('for Thumbnail API v2 edm:preview URL', () => {
-        describe('with v3 API URL in context', () => {
-          // const context = { $config: { europeana: { apis: { thumbnail: { url: 'https://api.europeana.eu/thumbnail/v3' } } } } };
-
-          test.todo('spec this');
-        });
-      });
-
       describe('for Thumbnail API v3 edm:preview URL', () => {
         describe('with v3 API URL in context', () => {
-          const context = { $config: { europeana: { apis: { thumbnail: { url: 'https://api.europeana.eu/thumbnail/v3' } } } } };
+          const context = { store, $config: { europeana: { apis: { thumbnail: { url: 'https://api.europeana.eu/thumbnail/v3' } } } } };
 
           it('overwrites API URL using context', () => {
             const url = 'https://example.org/thumbnail/v3/200/cffc370c6c63744ed934701a47b0349a';
@@ -84,7 +78,7 @@ describe('plugins/europeana/thumbnail', () => {
       });
 
       it('is `null` if edmPreview is absent', () => {
-        const edmPreview = thumbnail().edmPreview();
+        const edmPreview = thumbnail({ store }).edmPreview();
 
         expect(edmPreview).toBe(null);
       });

--- a/packages/portal/tests/unit/store/index.spec.js
+++ b/packages/portal/tests/unit/store/index.spec.js
@@ -17,6 +17,12 @@ describe('store/index.js', () => {
 
   describe('actions', () => {
     describe('nuxtServerInit', () => {
+      it('commits apis/init with the context', () => {
+        actions.nuxtServerInit(store, context);
+
+        expect(store.commit.calledWith('apis/init', context)).toBe(true);
+      });
+
       it('commits search/setView with the searchResultsView cookie', () => {
         actions.nuxtServerInit(store, context);
 

--- a/packages/portal/tests/unit/store/index.spec.js
+++ b/packages/portal/tests/unit/store/index.spec.js
@@ -17,12 +17,6 @@ describe('store/index.js', () => {
 
   describe('actions', () => {
     describe('nuxtServerInit', () => {
-      it('commits apis/init with the context', () => {
-        actions.nuxtServerInit(store, context);
-
-        expect(store.commit.calledWith('apis/init', context)).toBe(true);
-      });
-
       it('commits search/setView with the searchResultsView cookie', () => {
         actions.nuxtServerInit(store, context);
 


### PR DESCRIPTION
* extends apis store `init` mutation to set API base URLs from, in order of preference: custom request headers; environment variables; defaults
* modifies API plugin initialisation to treat the apis store as the authority for base URLs
* modifies components and pages to refer to the apis store for API URLs instead of the config
* fixes the lookup of the custom request headers for APIs with camel-cased IDs, e.g. entityManagement, iiifPresentation, by kebab-casing them for the header name