### PR TITLE
refactor: use postgres connection pool

### DIFF
--- a/packages/portal/nuxt.config.js
+++ b/packages/portal/nuxt.config.js
@@ -486,7 +486,7 @@ export default {
   /*
   ** Enable modern builds
   */
-  modern: false,
+  modern: true,
 
   /*
   ** Render configuration

--- a/packages/portal/nuxt.config.js
+++ b/packages/portal/nuxt.config.js
@@ -42,7 +42,8 @@ const redisConfig = () => {
 const postgresConfig = () => {
   const postgresOptions = {
     enabled: featureIsEnabled('eventLogging'),
-    connectionString: process.env.POSTGRES_URL
+    connectionString: process.env.POSTGRES_URL,
+    max: Number(process.env.POSTGRES_MAX || 10)
   };
 
   if (process.env.POSTGRES_SSL_CA) {
@@ -485,7 +486,7 @@ export default {
   /*
   ** Enable modern builds
   */
-  modern: true,
+  modern: false,
 
   /*
   ** Render configuration

--- a/packages/portal/src/server-middleware/api/events/pg.js
+++ b/packages/portal/src/server-middleware/api/events/pg.js
@@ -21,6 +21,6 @@ export default {
   },
 
   query() {
-    return this.pool.query.apply(this.pool, arguments);
+    return this.pool.query(...arguments);
   }
 };

--- a/packages/portal/src/server-middleware/api/events/pg.js
+++ b/packages/portal/src/server-middleware/api/events/pg.js
@@ -1,0 +1,26 @@
+import { Pool } from 'pg';
+
+let pool;
+
+export default {
+  config: {},
+
+  get enabled() {
+    return this.config.enabled;
+  },
+
+  get pool() {
+    if (!pool) {
+      pool = new Pool(this.config);
+      pool.on('error', (err) => {
+        console.error('PostgreSQL pool error', err);
+        pool = null;
+      });
+    }
+    return pool;
+  },
+
+  query() {
+    return this.pool.query.apply(this.pool, arguments);
+  }
+};

--- a/packages/portal/src/server-middleware/api/events/trending.js
+++ b/packages/portal/src/server-middleware/api/events/trending.js
@@ -1,27 +1,17 @@
-import { Client } from 'pg';
+import pg from './pg.js';
 
 // TODO: use `next` for error handling
-// TODO: end pg conn when done?
-export default (options = {}) => {
-  let client;
+export default (config = {}) => {
+  pg.config = config;
 
   return async(req, res) => {
     try {
-      if (!options.enabled) {
+      if (!pg.enabled) {
         res.json({ items: [] });
         return;
       }
 
-      if (!client) {
-        client = new Client(options);
-        client.on('error', (err) => {
-          console.error('PostgreSQL client error', err);
-          client = null;
-        });
-        await client.connect();
-      }
-
-      const selectObjectResult = await client.query(`
+      const selectObjectResult = await pg.query(`
         SELECT o.uri, COUNT(a.id) AS num
         FROM events.actions a
         LEFT JOIN events.objects o ON a.object_id=o.id

--- a/packages/portal/src/server-middleware/api/utils.js
+++ b/packages/portal/src/server-middleware/api/utils.js
@@ -1,3 +1,7 @@
+import defu  from 'defu';
+
+import nuxtConfig from '../../../nuxt.config.js';
+
 export const errorHandler = (res, error) => {
   let status = error.status || 500;
   let message = error.message;
@@ -8,4 +12,13 @@ export const errorHandler = (res, error) => {
   }
 
   res.status(status).set('Content-Type', 'text/plain').send(message);
+};
+
+export const nuxtRuntimeConfig = (key) => {
+  const runtimeConfig = defu(nuxtConfig.privateRuntimeConfig, nuxtConfig.publicRuntimeConfig);
+  if (key) {
+    return runtimeConfig[key];
+  } else {
+    return runtimeConfig;
+  }
 };

--- a/packages/portal/tests/size/.size-limit.json
+++ b/packages/portal/tests/size/.size-limit.json
@@ -19,7 +19,7 @@
   {
     "name": "portal.js server",
     "running": false,
-    "limit": "845 KB",
+    "limit": "850 KB",
     "path": [
       ".nuxt/dist/server/*.js"
     ]

--- a/packages/portal/tests/unit/server-middleware/api/events/pg.spec.js
+++ b/packages/portal/tests/unit/server-middleware/api/events/pg.spec.js
@@ -1,0 +1,36 @@
+import pg from 'pg';
+import sinon from 'sinon';
+
+import pgEvents from '@/server-middleware/api/events/pg';
+
+const pgPoolOn = sinon.stub();
+const pgPoolQuery = sinon.stub();
+
+describe('@/server-middleware/api/events/pg', () => {
+  beforeAll(() => {
+    sinon.replace(pg.Pool.prototype, 'on', pgPoolOn);
+    sinon.replace(pg.Pool.prototype, 'query', pgPoolQuery);
+  });
+  afterEach(sinon.resetHistory);
+  afterAll(sinon.resetBehavior);
+
+  describe('pool', () => {
+    it('creates and returns a pg pool, with error handler', () => {
+      const pool = pgEvents.pool;
+
+      expect(pool instanceof pg.Pool).toBe(true);
+      expect(pgPoolOn.calledWith('error', sinon.match.func)).toBe(true);
+    });
+  });
+
+  describe('query', () => {
+    it('delegates with all args to pg pool', () => {
+      const sql = 'SELECT * FROM table WHERE type=$1';
+      const params = ['like'];
+
+      pgEvents.query(sql, params);
+
+      expect(pgPoolQuery.calledWith(sql, params)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
* Moves events server middleware code responsible for connecting to postgres into a single file
* Uses postgres connection pool, the max clients of which can be specified by env var `POSTGRES_MAX`, defaulting to 10
* Makes events server middlewares use this shared pg-connecting code