### PR TITLE
Fix: search dropdown options unreachable Safari/iOS

### DIFF
--- a/packages/portal/src/components/search/SearchQueryOptions.vue
+++ b/packages/portal/src/components/search/SearchQueryOptions.vue
@@ -200,10 +200,12 @@
     watch: {
       showSearchOptions(newVal) {
         if (newVal === true) {
-          this.$parent.$refs.searchdropdown.addEventListener('focusout', this.handleFocusOut);
+          window.addEventListener('click', this.handleClickOrFocusOutside);
+          window.addEventListener('focusin', this.handleClickOrFocusOutside);
           this.$parent.$refs.searchdropdown.addEventListener('keydown', this.handleKeyDown);
         } else {
-          this.$parent.$refs.searchdropdown.removeEventListener('focusout', this.handleFocusOut);
+          window.removeEventListener('click', this.handleClickOrFocusOutside);
+          window.removeEventListener('focusin', this.handleClickOrFocusOutside);
           this.$parent.$refs.searchdropdown.removeEventListener('keydown', this.handleKeyDown);
         }
       },
@@ -344,15 +346,15 @@
         }
       },
 
-      handleFocusOut(event) {
-        const relatedTargetOutsideSearchDropdown = this.checkIfRelatedTargetOutsideSearchDropdown(event);
-        if (relatedTargetOutsideSearchDropdown) {
+      handleClickOrFocusOutside(event) {
+        const targetOutsideSearchDropdown = this.checkIftargetOutsideSearchDropdown(event);
+        if (targetOutsideSearchDropdown) {
           this.$emit('hideOptions');
         }
       },
 
-      checkIfRelatedTargetOutsideSearchDropdown(event) {
-        return event.relatedTarget?.id !== 'show-search-button' && this.$parent.$refs.searchdropdown && !this.$parent.$refs.searchdropdown.contains(event.relatedTarget);
+      checkIftargetOutsideSearchDropdown(event) {
+        return event.target?.id !== 'show-search-button' && this.$parent.$refs.searchdropdown && !this.$parent.$refs.searchdropdown.contains(event.target);
       },
 
       navigateWithArrowKeys(event) {

--- a/packages/portal/tests/unit/components/search/SearchQueryOptions.spec.js
+++ b/packages/portal/tests/unit/components/search/SearchQueryOptions.spec.js
@@ -255,14 +255,14 @@ describe('components/search/SearchQueryOptions', () => {
       });
     });
 
-    describe('handleFocusOut', () => {
+    describe('handleClickOrFocusOutside', () => {
       const wrapper = parentFactory();
       const searchOptionsComponent = wrapper.find('[data-qa="search query options"]');
       describe('when user clicks outside the search form dropdown', () => {
         it('hides the search options', async() => {
-          const handleFocusOutEvent = new Event('click');
+          const handleClickEvent = new Event('click');
 
-          searchOptionsComponent.vm.handleFocusOut(handleFocusOutEvent);
+          searchOptionsComponent.vm.handleClickOrFocusOutside(handleClickEvent);
 
           expect(searchOptionsComponent.emitted('hideOptions').length).toBe(1);
         });
@@ -272,7 +272,7 @@ describe('components/search/SearchQueryOptions', () => {
         it('hides the search options', async() => {
           const tabOutsideEvent = new KeyboardEvent('keydown', { key: 'Tab' });
 
-          searchOptionsComponent.vm.handleFocusOut(tabOutsideEvent);
+          searchOptionsComponent.vm.handleClickOrFocusOutside(tabOutsideEvent);
 
           expect(searchOptionsComponent.emitted('hideOptions').length).toBe(2);
         });

--- a/packages/portal/tests/unit/components/search/SearchQueryOptions.spec.js
+++ b/packages/portal/tests/unit/components/search/SearchQueryOptions.spec.js
@@ -323,5 +323,19 @@ describe('components/search/SearchQueryOptions', () => {
         });
       });
     });
+
+    describe('checkIftargetOutsideSearchDropdown', () => {
+      const wrapper = parentFactory();
+      const searchOptionsComponent = wrapper.find('[data-qa="search query options"]');
+      describe('when user clicks the show search button', () => {
+        it('returns false', async() => {
+          const handleClickEvent = { target: { id: 'show-search-button' } };
+
+          const check = searchOptionsComponent.vm.checkIftargetOutsideSearchDropdown(handleClickEvent);
+
+          expect(check).toBe(false);
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
Issue: Listening to `focusout` event and checking for the `relatedTarget` is not working in all browsers. `relatedTarget` defines the secondary event target (the element receiving focus). But whether an element receives focus is browser specific. For example Safari and browsers on iOS do not set the focus state on buttons, leaving `relatedTarget` set to `null`.

Fix: Refactored to use `click` and `focusin` events and check the event’s `target`.