### PR TITLE
feat: sessions inactive until monitored event

### DIFF
--- a/packages/portal/src/mixins/logEvent.js
+++ b/packages/portal/src/mixins/logEvent.js
@@ -14,8 +14,6 @@ export default {
         return false;
       }
 
-      console.log('logEvent', actionType, itemIdentifier);
-
       let objectUri = itemIdentifier;
       if (!objectUri.startsWith(ITEM_URL_PREFIX)) {
         objectUri = `${ITEM_URL_PREFIX}${objectUri}`;

--- a/packages/portal/src/mixins/logEvent.js
+++ b/packages/portal/src/mixins/logEvent.js
@@ -4,15 +4,19 @@ import { ITEM_URL_PREFIX } from '@/plugins/europeana/data.js';
 
 export default {
   methods: {
-    logEvent(actionType, itemIdentifier) {
+    // TODO: if session is not active yet, push to a queue instead; watch for
+    //       changes to session active
+    async logEvent(actionType, itemIdentifier) {
       const loggingPermitted = this.$features.eventLogging &&
         process.client &&
         !isbot(navigator?.userAgent) &&
-        this.$session?.id;
+        this.$session?.isActive;
 
       if (!loggingPermitted) {
-        return;
+        return false;
       }
+
+      console.log('logEvent', actionType, itemIdentifier)
 
       let objectUri = itemIdentifier;
       if (!objectUri.startsWith(ITEM_URL_PREFIX)) {
@@ -25,12 +29,17 @@ export default {
         sessionId: this.$session.id
       };
 
-      return axios.create({
-        baseURL: this.$config.app.baseUrl
-      }).post(
-        '/_api/events',
-        postData
-      );
+      try {
+       await axios.create({
+          baseURL: this.$config.app.baseUrl
+        }).post(
+          '/_api/events',
+          postData
+        );
+        return true;
+      } catch(e) {
+        return false;
+      }
     }
   }
 };

--- a/packages/portal/src/mixins/logEvent.js
+++ b/packages/portal/src/mixins/logEvent.js
@@ -4,10 +4,8 @@ import { ITEM_URL_PREFIX } from '@/plugins/europeana/data.js';
 
 export default {
   methods: {
-    // TODO: if session is not active yet, push to a queue instead; watch for
-    //       changes to session active
     async logEvent(actionType, itemIdentifier) {
-      const loggingPermitted = this.$features.eventLogging &&
+      const loggingPermitted = this.$features?.eventLogging &&
         process.client &&
         !isbot(navigator?.userAgent) &&
         this.$session?.isActive;
@@ -16,7 +14,7 @@ export default {
         return false;
       }
 
-      console.log('logEvent', actionType, itemIdentifier)
+      console.log('logEvent', actionType, itemIdentifier);
 
       let objectUri = itemIdentifier;
       if (!objectUri.startsWith(ITEM_URL_PREFIX)) {
@@ -30,14 +28,14 @@ export default {
       };
 
       try {
-       await axios.create({
+        await axios.create({
           baseURL: this.$config.app.baseUrl
         }).post(
           '/_api/events',
           postData
         );
         return true;
-      } catch(e) {
+      } catch (e) {
         return false;
       }
     }

--- a/packages/portal/src/pages/item/_.vue
+++ b/packages/portal/src/pages/item/_.vue
@@ -213,7 +213,8 @@
         timespans: [],
         title: null,
         type: null,
-        useProxy: true
+        useProxy: true,
+        viewLogged: false
       };
     },
 
@@ -333,6 +334,12 @@
       },
       'relatedEntityUris'() {
         this.fetchEntities();
+      },
+      async '$session.isActive'(sessionActive) {
+        console.log('$session.isActive changed to', sessionActive);
+        if (!this.viewLogged) {
+          this.viewLogged = await this.logEvent('view', this.identifier);
+        }
       }
     },
 
@@ -340,7 +347,6 @@
       this.fetchEntities();
       this.fetchAnnotations();
       if (!this.$fetchState.error) {
-        this.logEvent('view', this.identifier);
         if (!this.$fetchState.pending) {
           this.trackCustomDimensions();
         }

--- a/packages/portal/src/pages/item/_.vue
+++ b/packages/portal/src/pages/item/_.vue
@@ -335,22 +335,27 @@
       'relatedEntityUris'() {
         this.fetchEntities();
       },
-      async '$session.isActive'(sessionActive) {
-        if (!this.$fetchState.error && !this.viewLogged && sessionActive) {
-          this.viewLogged = await this.logEvent('view', this.identifier);
-        }
+      '$session.isActive'() {
+        this.logEventIfNeeded();
       }
     },
 
     mounted() {
       this.fetchEntities();
       this.fetchAnnotations();
+      this.logEventIfNeeded();
       if (!this.$fetchState.error && !this.$fetchState.pending) {
         this.trackCustomDimensions();
       }
     },
 
     methods: {
+      async logEventIfNeeded() {
+        if (!this.$fetchState.error && !this.viewLogged && this.$session.isActive) {
+          this.viewLogged = await this.logEvent('view', this.identifier);
+        }
+      },
+
       trackCustomDimensions() {
         if (!this.$waitForMatomo) {
           return;

--- a/packages/portal/src/pages/item/_.vue
+++ b/packages/portal/src/pages/item/_.vue
@@ -336,8 +336,7 @@
         this.fetchEntities();
       },
       async '$session.isActive'(sessionActive) {
-        console.log('$session.isActive changed to', sessionActive);
-        if (!this.viewLogged) {
+        if (!this.$fetchState.error && !this.viewLogged && sessionActive) {
           this.viewLogged = await this.logEvent('view', this.identifier);
         }
       }
@@ -346,10 +345,8 @@
     mounted() {
       this.fetchEntities();
       this.fetchAnnotations();
-      if (!this.$fetchState.error) {
-        if (!this.$fetchState.pending) {
-          this.trackCustomDimensions();
-        }
+      if (!this.$fetchState.error && !this.$fetchState.pending) {
+        this.trackCustomDimensions();
       }
     },
 

--- a/packages/portal/tests/unit/mixins/logEvent.spec.js
+++ b/packages/portal/tests/unit/mixins/logEvent.spec.js
@@ -96,9 +96,10 @@ describe('mixins/logEvent', () => {
             it('does not post to event logging API', async() => {
               const wrapper = factory({ mocks: { $features } });
 
-              await wrapper.vm.logEvent('like', 'http://data.europeana.eu/item/123/abc');
+              const logged = await wrapper.vm.logEvent('like', 'http://data.europeana.eu/item/123/abc');
 
               expect(nock.isDone()).toBe(false);
+              expect(logged).toBe(false);
             });
           });
 
@@ -106,9 +107,10 @@ describe('mixins/logEvent', () => {
             it('does not post to event logging API', async() => {
               const wrapper = factory({ mocks: { $features, $session: {} } });
 
-              await wrapper.vm.logEvent('like', 'http://data.europeana.eu/item/123/abc');
+              const logged = await wrapper.vm.logEvent('like', 'http://data.europeana.eu/item/123/abc');
 
               expect(nock.isDone()).toBe(false);
+              expect(logged).toBe(false);
             });
           });
 
@@ -116,9 +118,10 @@ describe('mixins/logEvent', () => {
             it('posts to event logging API', async() => {
               const wrapper = factory({ mocks: { $features, $session: { isActive: true } } });
 
-              await wrapper.vm.logEvent('like', 'http://data.europeana.eu/item/123/abc');
+              const logged = await wrapper.vm.logEvent('like', 'http://data.europeana.eu/item/123/abc');
 
               expect(nock.isDone()).toBe(true);
+              expect(logged).toBe(true);
             });
           });
         });

--- a/packages/portal/tests/unit/mixins/logEvent.spec.js
+++ b/packages/portal/tests/unit/mixins/logEvent.spec.js
@@ -102,7 +102,7 @@ describe('mixins/logEvent', () => {
             });
           });
 
-          describe('when there is no session ID', () => {
+          describe('when there is no active session', () => {
             it('does not post to event logging API', async() => {
               const wrapper = factory({ mocks: { $features, $session: {} } });
 
@@ -112,9 +112,9 @@ describe('mixins/logEvent', () => {
             });
           });
 
-          describe('when there is a session ID', () => {
+          describe('when there is an active session', () => {
             it('posts to event logging API', async() => {
-              const wrapper = factory({ mocks: { $features, $session: { id: 'uuid' } } });
+              const wrapper = factory({ mocks: { $features, $session: { isActive: true } } });
 
               await wrapper.vm.logEvent('like', 'http://data.europeana.eu/item/123/abc');
 

--- a/packages/vue-session/src/manager.js
+++ b/packages/vue-session/src/manager.js
@@ -23,7 +23,6 @@ export default class Manager {
     this.#storage = new Storage(options.storage);
 
     this.loadStoredSession();
-    // this.touch();
     this.startMonitoring();
   }
 

--- a/packages/vue-session/src/manager.js
+++ b/packages/vue-session/src/manager.js
@@ -1,6 +1,7 @@
 import Monitor from './monitor.js';
 import Session from './session.js';
 import Storage from './storage.js';
+import Vue from 'vue';
 
 /**
  * Manages session(s) for the user
@@ -22,7 +23,7 @@ export default class Manager {
     this.#storage = new Storage(options.storage);
 
     this.loadStoredSession();
-    this.touch();
+    // this.touch();
     this.startMonitoring();
   }
 
@@ -34,7 +35,7 @@ export default class Manager {
   }
 
   set session(session) {
-    this.#session = session;
+    this.#session = Vue.observable(session);
   }
 
   loadStoredSession() {

--- a/packages/vue-session/src/monitor.js
+++ b/packages/vue-session/src/monitor.js
@@ -10,7 +10,7 @@ export default class Monitor {
   /**
    * @typedef {Object} MonitorOptions
    * @property {string[]} events Document events to listen to for activity.
-   *   Default to `['keypress', 'mousedown', 'mousemove', 'scroll', 'touchstart']`.
+   *   Defaults to `['keypress', 'mousedown', 'mousemove', 'scroll', 'touchstart']`.
    * @property {number} interval Number of seconds to pause event listeners
    *   after activity is detected before resuming them. Defaults to 60 seconds.
    */

--- a/packages/vue-session/src/session.js
+++ b/packages/vue-session/src/session.js
@@ -25,7 +25,6 @@ export default class Session {
     this.id = data?.id || uuid();
     this.timestamp = data?.timestamp || Date.now();
     this.timeout = options.timeout || this.constructor.DEFAULTS.timeout;
-    console.log('new session', this.id);
   }
 
   get hasExpired() {
@@ -37,7 +36,6 @@ export default class Session {
   }
 
   touch() {
-    console.log('touching session', this.id);
     this.#active = true;
     this.timestamp = Date.now();
   }

--- a/packages/vue-session/src/session.js
+++ b/packages/vue-session/src/session.js
@@ -25,7 +25,7 @@ export default class Session {
     this.id = data?.id || uuid();
     this.timestamp = data?.timestamp || Date.now();
     this.timeout = options.timeout || this.constructor.DEFAULTS.timeout;
-    console.log('new session', this.id)
+    console.log('new session', this.id);
   }
 
   get hasExpired() {
@@ -37,7 +37,7 @@ export default class Session {
   }
 
   touch() {
-    console.log('touching session', this.id)
+    console.log('touching session', this.id);
     this.#active = true;
     this.timestamp = Date.now();
   }

--- a/packages/vue-session/src/session.js
+++ b/packages/vue-session/src/session.js
@@ -8,6 +8,8 @@ export default class Session {
     timeout: 30 // in minutes
   };
 
+  #active = false;
+
   /**
    * @typedef {Object} SessionOptions
    * @property {number} timeout Number of minutes of inactivity after which a
@@ -23,13 +25,20 @@ export default class Session {
     this.id = data?.id || uuid();
     this.timestamp = data?.timestamp || Date.now();
     this.timeout = options.timeout || this.constructor.DEFAULTS.timeout;
+    console.log('new session', this.id)
   }
 
   get hasExpired() {
     return Date.now() - this.timestamp > (this.timeout * 60 * 1000);
   }
 
+  get isActive() {
+    return !this.hasExpired && this.#active;
+  }
+
   touch() {
+    console.log('touching session', this.id)
+    this.#active = true;
     this.timestamp = Date.now();
   }
 }

--- a/packages/vue-session/tests/manager.spec.js
+++ b/packages/vue-session/tests/manager.spec.js
@@ -15,19 +15,19 @@ describe('Manager', () => {
       expect(manager.session.id).toBe('uuid');
     });
 
-    it('touches session to update timestamp', () => {
+    it('does not touch session to update timestamp', () => {
       const timestamp = Date.now() - 1000;
       localStorage.setItem('session', `{"id":"uuid","timestamp":${timestamp}}`);
 
       const manager = new Manager();
 
-      expect(manager.session.timestamp).toBeGreaterThan(timestamp);
+      expect(manager.session.timestamp).toBe(timestamp);
     });
 
     it('starts monitoring, touching session on activity', () => {
       const manager = new Manager({ monitor: { events: ['wheel'] } });
       sinon.spy(manager.session, 'touch');
-      sinon.resetHistory();
+      // sinon.resetHistory();
 
       document.dispatchEvent(new WheelEvent('wheel'));
 

--- a/packages/vue-session/tests/session.spec.js
+++ b/packages/vue-session/tests/session.spec.js
@@ -66,6 +66,35 @@ describe('Session', () => {
     });
   });
 
+  describe('isActive', () => {
+    it('starts `false`', () => {
+      const session = new Session();
+
+      expect(session.isActive).toBe(false);
+    });
+
+    describe('when session touched', () => {
+      it('becomes `true`', () => {
+        const timeout = 10;
+        const timestamp = Date.now() - ((timeout + 1) * 60 * 1000);
+        const session = new Session({}, { timeout });
+
+        session.touch();
+        session.timestamp = timestamp;
+
+        expect(session.isActive).toBe(false);
+      });
+
+      it('is `false` again if session expired', () => {
+        const session = new Session();
+
+        session.touch();
+
+        expect(session.isActive).toBe(true);
+      });
+    });
+  });
+
   describe('touch', () => {
     it('updates the timestamp', () => {
       const timestamp = Date.now() - (60 * 1000);


### PR DESCRIPTION
* vue-session package:
  * Add a getter `isActive` to Session class instances, indicating whether the session is active
  * When Manager class instance instantiates a session, it is by default not marked as active
  * Sessions are only marked as active when Monitor class instance observes one of the monitored events and calls the callback, touching the session
  * Sessions are not considered active if they have expired
  * Sessions accessed via the manager are reactive in Vue, so may be used in watchers and computed properties
* logEvent mixin:
  * only log event if session is active
  * return true/false indicating if event was logged
* item page:
  * do not (attempt to) log view event until session is active