### PR TITLE
fix: pass fulltext query terms to IIIF viewer

### DIFF
--- a/packages/portal/src/components/item/ItemHero.vue
+++ b/packages/portal/src/components/item/ItemHero.vue
@@ -7,7 +7,7 @@
       <slot name="item-language-selector" />
       <IIIFViewer
         :uri="iiifPresentationManifest"
-        :search-query="$nuxt.context.from ? $nuxt.context.from.query.query : ''"
+        :search-query="searchQuery"
         :aria-label="$t('actions.viewDocument')"
         :item-id="identifier"
         :provider-url="providerUrl"
@@ -89,6 +89,7 @@
   import ShareButton from '../share/ShareButton';
   import WebResource from '@/plugins/europeana/edm/WebResource';
 
+  import advancedSearchMixin from '@/mixins/advancedSearch';
   import rightsStatementMixin from '@/mixins/rightsStatement';
 
   const TRANSCRIBATHON_URL_ROOT = /^https?:\/\/europeana\.transcribathon\.eu\//;
@@ -108,6 +109,7 @@
     },
 
     mixins: [
+      advancedSearchMixin,
       rightsStatementMixin
     ],
 
@@ -176,6 +178,24 @@
           return this.edmRights;
         }
         return '';
+      },
+      searchQuery() {
+        let query = [];
+
+        if (this.$nuxt.context.from) {
+          if (this.$nuxt.context.from.query.query) {
+            query.push(this.$nuxt.context.from.query.query);
+          }
+          if (this.$nuxt.context.from.query.qa) {
+            const advSearchRules = this.advancedSearchRulesFromRouteQuery(this.$nuxt.context.from.query.qa);
+            const fulltextTerms = advSearchRules
+              .filter((rule) => (rule.field === 'fulltext') && (rule.modifier === 'contains'))
+              .map((rule) => rule.term);
+            query = query.concat(fulltextTerms);
+          }
+        }
+
+        return query.join(' ');
       },
       selectedMedia: {
         get() {

--- a/packages/portal/src/components/item/ItemHero.vue
+++ b/packages/portal/src/components/item/ItemHero.vue
@@ -7,7 +7,7 @@
       <slot name="item-language-selector" />
       <IIIFViewer
         :uri="iiifPresentationManifest"
-        :search-query="searchQuery"
+        :search-query="fulltextSearchQuery"
         :aria-label="$t('actions.viewDocument')"
         :item-id="identifier"
         :provider-url="providerUrl"
@@ -179,19 +179,15 @@
         }
         return '';
       },
-      searchQuery() {
+      fulltextSearchQuery() {
         let query = [];
 
         if (this.$nuxt.context.from) {
-          if (this.$nuxt.context.from.query.query) {
-            query.push(this.$nuxt.context.from.query.query);
-          }
           if (this.$nuxt.context.from.query.qa) {
             const advSearchRules = this.advancedSearchRulesFromRouteQuery(this.$nuxt.context.from.query.qa);
-            const fulltextTerms = advSearchRules
+            query = advSearchRules
               .filter((rule) => (rule.field === 'fulltext') && (rule.modifier === 'contains'))
               .map((rule) => rule.term);
-            query = query.concat(fulltextTerms);
           }
         }
 

--- a/packages/portal/src/mixins/advancedSearch.js
+++ b/packages/portal/src/mixins/advancedSearch.js
@@ -123,8 +123,8 @@ export default {
       return { ...this.$route, query: newRouteQuery };
     },
 
-    advancedSearchRulesFromRouteQuery() {
-      return [].concat(this.advancedSearchRouteQuery || []).map((qa) => {
+    advancedSearchRulesFromRouteQuery(routeQuery) {
+      return [].concat(routeQuery || this.advancedSearchRouteQuery || []).map((qa) => {
         for (const modifier of this.advancedSearchModifiers) {
           for (const fieldType in modifier.patterns) {
             const pattern = modifier.patterns[fieldType];

--- a/packages/portal/tests/unit/components/item/ItemHero.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemHero.spec.js
@@ -180,26 +180,16 @@ describe('components/item/ItemHero', () => {
     });
   });
 
-  describe('searchQuery', () => {
-    it('includes query from Nuxt context from route', () => {
-      const query = 'hamburger';
-      const mocks = { $nuxt: { context: { from: { query: { query } } } } };
-      const wrapper = factory({ propsData: { identifier }, mocks });
-
-      const searchQuery = wrapper.vm.searchQuery;
-
-      expect(searchQuery).toBe(query);
-    });
-
+  describe('fulltextSearchQuery', () => {
     it('includes adv search fulltext contains terms from Nuxt context from route', () => {
       const query = 'hamburger';
       const qa = ['fulltext:(theater)', 'fulltext:(zeitung)', 'NOT fulltext:(direktor)', 'when:1901'];
       const mocks = { $nuxt: { context: { from: { query: { qa, query } } } } };
       const wrapper = factory({ propsData: { identifier }, mocks });
 
-      const searchQuery = wrapper.vm.searchQuery;
+      const fulltextSearchQuery = wrapper.vm.fulltextSearchQuery;
 
-      expect(searchQuery).toBe('hamburger theater zeitung');
+      expect(fulltextSearchQuery).toBe('theater zeitung');
     });
   });
 


### PR DESCRIPTION
In the search query passed to the IIIF viewer, include any terms from `fulltext contains` advanced search rules.