### PR TITLE
fix: prevent duplicate event log requests

### DIFF
--- a/docker/compose/postgres/model/06-clean-up-duplicate-events-actions.psql
+++ b/docker/compose/postgres/model/06-clean-up-duplicate-events-actions.psql
@@ -1,0 +1,30 @@
+SET search_path TO EVENTS;
+
+-- remove the event actions, leaving one of each
+DELETE
+FROM actions
+WHERE id in
+    (SELECT id
+     FROM actions a
+     INNER JOIN
+       (SELECT object_id,
+               action_type_id,
+               session_id,
+               count(a.id) num,
+               min(a.id) first_action_id
+        FROM actions a
+        INNER JOIN objects o ON a.object_id=o.id
+        INNER JOIN action_types AT ON a.action_type_id=at.id
+        INNER JOIN sessions s ON a.session_id=s.id
+        GROUP BY action_type_id,
+                 session_id,
+                 object_id) an ON a.object_id=an.object_id
+     AND a.action_type_id=an.action_type_id
+     AND a.session_id=an.session_id
+     AND a.id <> an.first_action_id
+     WHERE num > 1 );
+
+-- add a uniqueness constraint on the three foreign keys to prevent recurrence
+ALTER TABLE actions
+ADD CONSTRAINT unq_object_id_action_type_id_session_id
+UNIQUE(object_id, action_type_id, session_id);

--- a/docker/compose/postgres/model/06-clean-up-duplicate-events-actions.psql
+++ b/docker/compose/postgres/model/06-clean-up-duplicate-events-actions.psql
@@ -13,12 +13,10 @@ WHERE id in
                count(a.id) num,
                min(a.id) first_action_id
         FROM actions a
-        INNER JOIN objects o ON a.object_id=o.id
-        INNER JOIN action_types AT ON a.action_type_id=at.id
-        INNER JOIN sessions s ON a.session_id=s.id
-        GROUP BY action_type_id,
-                 session_id,
-                 object_id) an ON a.object_id=an.object_id
+        GROUP BY object_id,
+                 action_type_id,
+                 session_id
+                 ) an ON a.object_id=an.object_id
      AND a.action_type_id=an.action_type_id
      AND a.session_id=an.session_id
      AND a.id <> an.first_action_id

--- a/packages/portal/src/mixins/logEvent.js
+++ b/packages/portal/src/mixins/logEvent.js
@@ -4,6 +4,7 @@ import isbot from 'isbot';
 export default {
   data() {
     return {
+      eventBeingLogged: false,
       eventLogged: false,
       eventToLog: null
     };
@@ -15,6 +16,7 @@ export default {
         this.$features?.eventLogging &&
         this.eventToLog &&
         !this.eventLogged &&
+        !this.eventBeingLogged &&
         !this.$fetchState?.error &&
         process.client &&
         !isbot(navigator?.userAgent) &&
@@ -40,6 +42,8 @@ export default {
         return;
       }
 
+      this.eventBeingLogged = true;
+
       const postData = {
         ...this.eventToLog,
         sessionId: this.$session?.id
@@ -55,6 +59,8 @@ export default {
         this.eventLogged = true;
       } catch (e) {
         this.eventLogged = false;
+      } finally {
+        this.eventBeingLogged = false;
       }
     }
   }


### PR DESCRIPTION
Before the initial request is complete, the `eventMayBeLogged` watcher will also trigger and send another identical request, i.e. before `eventLogged` has been set to `true`. Prevent this via an additional progress-monitoring boolean, `eventBeingLogged`.

SQL migration to clean up, and prevent recurrence, to be run **after** code deployment.