### PR TITLE
configurable allowed feedback hosts

### DIFF
--- a/packages/portal/.env.example
+++ b/packages/portal/.env.example
@@ -178,6 +178,9 @@ OAUTH_CLIENT="YOUR_CLIENT"
 # JIRA_API_SERVICE_DESK_GALLERIES_CUSTOM_FIELD_SET_ID='customfield_10841'
 # JIRA_API_SERVICE_DESK_GALLERIES_CUSTOM_FIELD_SET_CREATOR_NICKNAME='customfield_10842'
 
+# Comma-separated list of hosts from which to accept feedback
+# FEEDBACK_ALLOWED_HOSTS=www.europeana.eu, pro.europeana.eu, test.europeana.eu, localhost:3000
+
 # Comma-separated list of two-letter language codes for which to enable search
 # translation.
 # APP_SEARCH_TRANSLATE_LOCALES=es,de

--- a/packages/portal/.env.example
+++ b/packages/portal/.env.example
@@ -178,8 +178,8 @@ OAUTH_CLIENT="YOUR_CLIENT"
 # JIRA_API_SERVICE_DESK_GALLERIES_CUSTOM_FIELD_SET_ID='customfield_10841'
 # JIRA_API_SERVICE_DESK_GALLERIES_CUSTOM_FIELD_SET_CREATOR_NICKNAME='customfield_10842'
 
-# Comma-separated list of hosts from which to accept feedback
-# FEEDBACK_ALLOWED_HOSTS=www.europeana.eu, pro.europeana.eu, test.europeana.eu, localhost:3000
+# Comma-separated list (no-spaces) of hosts from which to accept feedback
+# FEEDBACK_ALLOWED_HOSTS=www.europeana.eu,pro.europeana.eu,test.europeana.eu,localhost:3000
 
 # Comma-separated list of two-letter language codes for which to enable search
 # translation.

--- a/packages/portal/nuxt.config.js
+++ b/packages/portal/nuxt.config.js
@@ -179,6 +179,7 @@ export default {
           password: process.env.JIRA_API_SERVICE_DESK_FEEDBACK_PASSWORD || process.env.JIRA_API_PASSWORD,
           serviceDeskId: process.env.JIRA_API_SERVICE_DESK_FEEDBACK_ID,
           requestTypeId: process.env.JIRA_API_SERVICE_DESK_FEEDBACK_REQUEST_TYPE_ID,
+          allowedHosts: (process.env.FEEDBACK_ALLOWED_HOSTS || 'www.europeana.eu').split(','),
           customFields: {
             pageUrl: process.env.JIRA_API_SERVICE_DESK_FEEDBACK_CUSTOM_FIELD_PAGE_URL,
             browser: process.env.JIRA_API_SERVICE_DESK_FEEDBACK_CUSTOM_FIELD_BROWSER,

--- a/packages/portal/src/server-middleware/api/jira-service-desk/feedback.js
+++ b/packages/portal/src/server-middleware/api/jira-service-desk/feedback.js
@@ -40,7 +40,7 @@ const jiraData = (options, req) => {
 const validateFeedbackLength = feedback => wordLength(feedback) >= 5;
 
 const validateHost = (host, allowedHosts) => {
-  return allowedHosts.some(allowedHost => host === allowedHost)
+  return allowedHosts.some(allowedHost => host === allowedHost);
 };
 
 const validateFeedback = (requestBody, allowedHosts) => {

--- a/packages/portal/src/server-middleware/api/jira-service-desk/feedback.js
+++ b/packages/portal/src/server-middleware/api/jira-service-desk/feedback.js
@@ -47,8 +47,7 @@ const validateFeedback = (requestBody, allowedHosts) => {
   return new Promise((resolve, reject) => {
     if (!validateHost(new URL(requestBody.pageUrl).host, allowedHosts)) {
       reject(createHttpError(403, 'Forbidden pageUrl.'));
-    }
-    else if (validateFeedbackLength(requestBody.feedback)) {
+    } else if (validateFeedbackLength(requestBody.feedback)) {
       resolve();
     } else {
       reject(createHttpError(400, 'Invalid feedback.'));

--- a/packages/portal/src/server-middleware/api/jira-service-desk/feedback.js
+++ b/packages/portal/src/server-middleware/api/jira-service-desk/feedback.js
@@ -45,7 +45,10 @@ const validateHost = (host, allowedHosts) => {
 
 const validateFeedback = (requestBody, allowedHosts) => {
   return new Promise((resolve, reject) => {
-    if (validateFeedbackLength(requestBody.feedback) && validateHost(new URL(requestBody.pageUrl).host, allowedHosts)) {
+    if (!validateHost(new URL(requestBody.pageUrl).host, allowedHosts)) {
+      reject(createHttpError(403, 'Forbidden pageUrl.'));
+    }
+    else if (validateFeedbackLength(requestBody.feedback)) {
       resolve();
     } else {
       reject(createHttpError(400, 'Invalid feedback.'));

--- a/packages/portal/tests/unit/server-middleware/api/jira-service-desk/feedback.spec.js
+++ b/packages/portal/tests/unit/server-middleware/api/jira-service-desk/feedback.spec.js
@@ -114,8 +114,8 @@ describe('server-middleware/api/jira-service-desk/feedback', () => {
           const res = mockResponse();
 
           await middleware(req, res);
-          expect(res.status.calledWith(400)).toBe(true);
-          expect(res.send.calledWith('Invalid feedback.')).toBe(true);
+          expect(res.status.calledWith(403)).toBe(true);
+          expect(res.send.calledWith('Forbidden pageUrl.')).toBe(true);
         });
 
         it('truncates feedback to 50 characters in summary field, removing newlines', async() => {


### PR DESCRIPTION
Set in env file, for example:
`FEEDBACK_ALLOWED_HOSTS="localhost:3000,www.europeana.eu,pro.europeana.eu,test.eanadev.org"`