### PR TITLE
feat: DS4CH variant landing call to action

### DIFF
--- a/packages/portal/src/components/content/ContentPrimaryCallToAction.vue
+++ b/packages/portal/src/components/content/ContentPrimaryCallToAction.vue
@@ -1,5 +1,11 @@
 <template>
   <div class="primary-cta text-center">
+    <h2
+      v-if="title"
+      data-qa="primary cta title"
+    >
+      {{ title }}
+    </h2>
     <!-- eslint-disable vue/no-v-html -->
     <div
       class="primary-cta-rich-text text-left"
@@ -31,6 +37,10 @@
     mixins: [parseMarkdownHtmlMixin],
 
     props: {
+      title: {
+        type: String,
+        default: ''
+      },
       text: {
         type: String,
         default: ''

--- a/packages/portal/src/components/home/HomeHero.vue
+++ b/packages/portal/src/components/home/HomeHero.vue
@@ -68,9 +68,9 @@
               medium: { w: 768, h: 1080, fit: 'fill' },
               large: { w: 992, h: 1080, fit: 'fill' },
               xl: { w: 1200, h: 1080, fit: 'fill' },
-              xxl: { w: 1440, h: 1080, fit: 'fill' },
-              xxxl: { w: 1920, h: 1080, fit: 'fill' },
-              wqhd: { w: 2560, h: 1440, fit: 'fill' },
+              xxl: { w: 1400, h: 1080, fit: 'fill' },
+              xxxl: { w: 1880, h: 1080, fit: 'fill' },
+              wqhd: { w: 3020, h: 1440, fit: 'fill' },
               '4k': { w: 3840, h: 2160, fit: 'fill' }
             }
           );

--- a/packages/portal/src/components/landing/LandingCallToAction.vue
+++ b/packages/portal/src/components/landing/LandingCallToAction.vue
@@ -202,7 +202,7 @@
       }
 
       .primary-cta {
-        background-color: transparent;
+        background-color: transparent !important;
         padding: 0;
         max-width: $max-text-column-width !important;
 

--- a/packages/portal/src/components/landing/LandingCallToAction.vue
+++ b/packages/portal/src/components/landing/LandingCallToAction.vue
@@ -97,7 +97,7 @@
               xl: { w: 1200, h: 300, fit: 'fill' },
               xxl: { w: 1400, h: 300, fit: 'fill' },
               xxxl: { w: 1880, h: 300, fit: 'fill' },
-              wqhd: { w: 3020, h: 300, fit: 'fill' },
+              wqhd: { w: 3020, h: 500, fit: 'fill' },
               '4k': { w: 3840, h: 680, fit: 'fill' }
             }
           );

--- a/packages/portal/src/components/landing/LandingCallToAction.vue
+++ b/packages/portal/src/components/landing/LandingCallToAction.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-container>
+  <b-container :class="variant">
     <ContentPrimaryCallToAction
       :text="text"
       :link="link"
@@ -30,6 +30,14 @@
       link: {
         type: Object,
         default: () => {}
+      },
+      /**
+       * Variant to define layout and style
+       * @values pro, ds4ch
+       */
+      variant: {
+        type: String,
+        default: 'pro'
       }
     }
   };
@@ -54,6 +62,69 @@
       @media (min-width: $bp-large) {
         width: 100% !important;
         max-width: 960px;
+      }
+    }
+  }
+</style>
+
+<!-- Only DS4CH styles after this line! -->
+<style lang="scss">
+  @import '@europeana/style/scss/DS4CH/style';
+
+  .container.ds4ch {
+    padding-top: 6rem;
+    padding-bottom: 6rem;
+
+    @media (min-width: ($bp-large)) {
+      margin-left: 2rem;
+    }
+
+    @media (min-width: ($bp-extralarge)) {
+      margin-left: 4rem;
+    }
+
+    @media (min-width: ($bp-4k)) {
+      margin-left: 10rem;
+      padding-top: 16rem;
+      padding-bottom: 16rem;
+    }
+
+    .primary-cta {
+      background-color: transparent;
+      padding: 0;
+      max-width: $max-card-width !important;
+
+      @media (min-width: ($bp-large)) {
+        text-align: left !important;
+        margin-left: 0 !important;
+      }
+
+      @media (min-width: $bp-4k) {
+        max-width: 1250px !important;
+      }
+    }
+    .primary-cta-rich-text {
+      text-align: center !important;
+
+      @media (min-width: ($bp-medium)) {
+        margin-bottom: 2rem;
+      }
+
+      @media (min-width: ($bp-large)) {
+        text-align: left !important;
+      }
+
+      @media (min-width: $bp-4k) {
+        font-size: 2.667rem;
+        margin-bottom: 6rem;
+      }
+
+      h2 {
+        @extend %title-2;
+
+        @media (min-width: $bp-4k) {
+          margin-bottom: 4rem;
+        }
       }
     }
   }

--- a/packages/portal/src/components/landing/LandingCallToAction.vue
+++ b/packages/portal/src/components/landing/LandingCallToAction.vue
@@ -1,8 +1,15 @@
 <template>
   <div :class="variant">
+    <div
+      v-if="backgroundImage"
+      data-qa="landing cta background image"
+      class="background-image responsive-backround-image"
+      :class="{'twin-it': twinItBackground}"
+      :style="imageCSSVars"
+    />
     <b-container>
       <ContentPrimaryCallToAction
-        :title="title"
+        :title="displayTitle"
         :text="text"
         :link="link"
       />
@@ -42,12 +49,59 @@
         default: () => {}
       },
       /**
+       * Background image Object
+       */
+      backgroundImage: {
+        type: Object,
+        default: () => {}
+      },
+      /**
        * Variant to define layout and style
        * @values pro, ds4ch
        */
       variant: {
         type: String,
         default: 'pro'
+      }
+    },
+
+    computed: {
+      displayTitle() {
+        return this.variant === 'ds4ch' ? this.title : null;
+      },
+      twinItBackground() {
+        if (this.variant === 'ds4ch' && this.backgroundImage?.image?.title) {
+          return this.backgroundImage?.image?.title?.includes('Twin it');
+        } else {
+          return false;
+        }
+      },
+      imageCSSVars() {
+        if (this.twinItBackground) {
+          return this.$contentful.assets.responsiveBackgroundImageCSSVars(
+            this.backgroundImage.image,
+            {
+              xxl: { w: 1400, h: 300, fit: 'fill', f: 'left', q: 100 },
+              xxxl: { w: 1880, h: 300, fit: 'fill', f: 'left', q: 100 },
+              wqhd: { w: 3020, h: 500, fit: 'fill', f: 'left', q: 100 },
+              '4k': { w: 3840, h: 680, fit: 'fill', f: 'left', q: 100 }
+            }
+          );
+        } else {
+          return this.$contentful.assets.responsiveBackgroundImageCSSVars(
+            this.backgroundImage.image,
+            {
+              small: { w: 576, h: 350, fit: 'fill' },
+              medium: { w: 768, h: 310, fit: 'fill' },
+              large: { w: 992, h: 300, fit: 'fill' },
+              xl: { w: 1200, h: 300, fit: 'fill' },
+              xxl: { w: 1400, h: 300, fit: 'fill' },
+              xxxl: { w: 1880, h: 300, fit: 'fill' },
+              wqhd: { w: 3020, h: 300, fit: 'fill' },
+              '4k': { w: 3840, h: 680, fit: 'fill' }
+            }
+          );
+        }
       }
     }
   };
@@ -80,61 +134,90 @@
 <!-- Only DS4CH styles after this line! -->
 <style lang="scss">
   @import '@europeana/style/scss/DS4CH/style';
+  @import '@europeana/style/scss/responsive-background-image';
 
-  .ds4ch .container {
-    padding-top: 6rem;
-    padding-bottom: 6rem;
+  .ds4ch {
+    background-color: $black;
+    position: relative;
+    color: $white;
 
-    @media (min-width: ($bp-large)) {
-      margin-left: 2rem;
+    .background-image {
+      left: 0;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      position: absolute;
+      background-size: cover;
+      background-repeat: no-repeat;
+
+      &::after {
+        content: '';
+        left: 0;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        background-image: linear-gradient(0deg, rgba(25, 24, 23, 0.6), rgba(25, 24, 23, 0.6));
+        mix-blend-mode: multiply;
+        position: absolute;
+      }
+
+      &.twin-it {
+        background-position-y: center;
+
+        @media (max-width: $bp-extralarge) {
+          background-image: none;
+          background-color: $blue;
+        }
+
+        @media (min-width: ($bp-extralarge + 1px)) and (max-width: $bp-xxl) {
+          margin-left: -5rem;
+        }
+
+        @media (min-width: ($bp-xxl + 1px)) and (max-width: $bp-xxxl) {
+          margin-left: -1rem;
+        }
+
+        &::after {
+          content: none;
+        }
+      }
     }
 
-    @media (min-width: ($bp-extralarge)) {
-      margin-left: 4rem;
-    }
-
-    @media (min-width: ($bp-4k)) {
-      margin-left: 10rem;
-      padding-top: 16rem;
-      padding-bottom: 16rem;
-    }
-
-    h2 {
-      @extend %title-2;
+    .container {
+      padding-top: 3.625rem;
+      padding-bottom: 2rem;
+      position: relative;
 
       @media (min-width: $bp-4k) {
-        margin-bottom: 4rem;
-      }
-    }
-
-    .primary-cta {
-      background-color: transparent;
-      padding: 0;
-      max-width: $max-card-width !important;
-
-      @media (min-width: ($bp-large)) {
-        text-align: left !important;
-        margin-left: 0 !important;
+        padding-top: 7rem;
+        padding-bottom: 5rem;
       }
 
-      @media (min-width: $bp-4k) {
-        max-width: 1250px !important;
-      }
-    }
-    .primary-cta-rich-text {
-      text-align: center !important;
+      h2 {
+        @extend %title-2;
 
-      @media (min-width: ($bp-medium)) {
+        @media (min-width: $bp-4k) {
+          margin-bottom: 4rem;
+        }
+      }
+
+      .primary-cta {
+        background-color: transparent;
+        padding: 0;
+        max-width: $max-text-column-width !important;
+
+        @media (min-width: $bp-4k) {
+          max-width: 1450px !important;
+        }
+      }
+      .primary-cta-rich-text {
+        text-align: center !important;
         margin-bottom: 2rem;
-      }
 
-      @media (min-width: ($bp-large)) {
-        text-align: left !important;
-      }
-
-      @media (min-width: $bp-4k) {
-        font-size: 2.667rem;
-        margin-bottom: 6rem;
+        @media (min-width: $bp-4k) {
+          font-size: 2.5rem;
+          margin-bottom: 3.125rem;
+        }
       }
     }
   }

--- a/packages/portal/src/components/landing/LandingCallToAction.vue
+++ b/packages/portal/src/components/landing/LandingCallToAction.vue
@@ -1,10 +1,13 @@
 <template>
-  <b-container :class="variant">
-    <ContentPrimaryCallToAction
-      :text="text"
-      :link="link"
-    />
-  </b-container>
+  <div :class="variant">
+    <b-container>
+      <ContentPrimaryCallToAction
+        :title="title"
+        :text="text"
+        :link="link"
+      />
+    </b-container>
+  </div>
 </template>
 
 <script>
@@ -18,7 +21,14 @@
 
     props: {
       /**
-       * Text to display under title and above the info cards
+       * Title
+       */
+      title: {
+        type: String,
+        default: null
+      },
+      /**
+       * Text to display under title
        */
       text: {
         type: String,
@@ -71,7 +81,7 @@
 <style lang="scss">
   @import '@europeana/style/scss/DS4CH/style';
 
-  .container.ds4ch {
+  .ds4ch .container {
     padding-top: 6rem;
     padding-bottom: 6rem;
 
@@ -87,6 +97,14 @@
       margin-left: 10rem;
       padding-top: 16rem;
       padding-bottom: 16rem;
+    }
+
+    h2 {
+      @extend %title-2;
+
+      @media (min-width: $bp-4k) {
+        margin-bottom: 4rem;
+      }
     }
 
     .primary-cta {
@@ -117,14 +135,6 @@
       @media (min-width: $bp-4k) {
         font-size: 2.667rem;
         margin-bottom: 6rem;
-      }
-
-      h2 {
-        @extend %title-2;
-
-        @media (min-width: $bp-4k) {
-          margin-bottom: 4rem;
-        }
       }
     }
   }

--- a/packages/portal/src/components/landing/LandingPage.vue
+++ b/packages/portal/src/components/landing/LandingPage.vue
@@ -46,6 +46,7 @@
       />
       <LandingCallToAction
         v-if="contentType(section, 'PrimaryCallToAction')"
+        :title="variant === 'ds4ch' ? section.name : null"
         :text="section.text"
         :link="section.relatedLink"
         :variant="variant"

--- a/packages/portal/src/components/landing/LandingPage.vue
+++ b/packages/portal/src/components/landing/LandingPage.vue
@@ -46,9 +46,10 @@
       />
       <LandingCallToAction
         v-if="contentType(section, 'PrimaryCallToAction')"
-        :title="variant === 'ds4ch' ? section.name : null"
+        :title="section.name"
         :text="section.text"
         :link="section.relatedLink"
+        :background-image="section.image"
         :variant="variant"
       />
     </div>

--- a/packages/portal/src/components/landing/LandingPage.vue
+++ b/packages/portal/src/components/landing/LandingPage.vue
@@ -1,12 +1,14 @@
 <template>
   <div
     class="page white-page xxl-page"
+    :class="`${variant}-page`"
   >
     <LandingHero
       :headline="headline"
       :text="text"
       :cta="cta"
       :hero-image="primaryImageOfPage"
+      :variant="variant"
     />
     <div
       v-for="(section, index) in sections"
@@ -46,6 +48,7 @@
         v-if="contentType(section, 'PrimaryCallToAction')"
         :text="section.text"
         :link="section.relatedLink"
+        :variant="variant"
       />
     </div>
   </div>
@@ -87,6 +90,14 @@
       primaryImageOfPage: {
         type: Object,
         default: null
+      },
+      /**
+       * Variant to define layout and style
+       * @values pro, ds4ch
+       */
+      variant: {
+        type: String,
+        default: 'pro'
       }
     },
 

--- a/packages/portal/src/modules/contentful/queries/browse-landing-static-page.graphql
+++ b/packages/portal/src/modules/contentful/queries/browse-landing-static-page.graphql
@@ -1,9 +1,14 @@
 query BrowseLandingStaticPage(
-  $identifier: String!,
-  $locale: String!,
+  $identifier: String!
+  $locale: String!
   $preview: Boolean = false
 ) {
-  browsePageCollection(preview: $preview, locale: $locale, where: { identifier: $identifier }, limit: 1) {
+  browsePageCollection(
+    preview: $preview
+    locale: $locale
+    where: { identifier: $identifier }
+    limit: 1
+  ) {
     items {
       identifier
       name
@@ -17,7 +22,7 @@ query BrowseLandingStaticPage(
           __typename
           ... on CardGroup {
             headline
-          	text
+            text
             hasPartCollection(limit: 28) {
               items {
                 __typename
@@ -46,7 +51,7 @@ query BrowseLandingStaticPage(
               url
               text
             }
-        	}
+          }
           ... on AutomatedCardGroup {
             genre
             moreButton {
@@ -73,7 +78,12 @@ query BrowseLandingStaticPage(
       }
     }
   }
-  staticPageCollection(preview: $preview, locale: $locale, where: { identifier: $identifier }, limit: 1) {
+  staticPageCollection(
+    preview: $preview
+    locale: $locale
+    where: { identifier: $identifier }
+    limit: 1
+  ) {
     items {
       identifier
       name
@@ -92,13 +102,13 @@ query BrowseLandingStaticPage(
             embed
           }
           ... on ImageWithAttribution {
-            ... imageWithAttributionFields
+            ...imageWithAttributionFields
           }
           ... on ImageComparison {
             name
             hasPartCollection(limit: 2) {
               items {
-                ... imageWithAttributionFields
+                ...imageWithAttributionFields
               }
             }
           }
@@ -132,7 +142,12 @@ query BrowseLandingStaticPage(
       }
     }
   }
-  landingPageCollection(preview: $preview, locale: $locale, where: { identifier: $identifier }, limit: 1) {
+  landingPageCollection(
+    preview: $preview
+    locale: $locale
+    where: { identifier: $identifier }
+    limit: 1
+  ) {
     items {
       identifier
       name
@@ -155,7 +170,7 @@ query BrowseLandingStaticPage(
           __typename
           ... on CardGroup {
             headline
-          	text
+            text
             hasPartCollection(limit: 28) {
               items {
                 __typename
@@ -184,7 +199,7 @@ query BrowseLandingStaticPage(
               url
               text
             }
-        	}
+          }
           ... on InfoCardGroup {
             name
             text
@@ -264,6 +279,9 @@ query BrowseLandingStaticPage(
               url
               text
             }
+            image {
+              ...illustrationFields
+            }
           }
         }
       }
@@ -271,6 +289,7 @@ query BrowseLandingStaticPage(
   }
 }
 fragment imageFields on Asset {
+  title
   url
   contentType
   description

--- a/packages/portal/src/pages/microsite/DS4CH.eu.vue
+++ b/packages/portal/src/pages/microsite/DS4CH.eu.vue
@@ -4,28 +4,27 @@
       v-if="$fetchState.error"
       data-qa="error message container"
       :error="$fetchState.error"
-      :show-message="false"
+      :show-message="true"
     />
     <LandingPage
       v-else
-      :headline="page.headline"
+      :headline="page.headline || page.name"
       :text="page.text"
-      :cta="page.relatedLink"
       :sections="page.hasPartCollection?.items.filter((item) => !!item)"
       :primary-image-of-page="page.primaryImageOfPage"
+      variant="ds4ch"
     />
   </div>
 </template>
 
 <script>
-  import ErrorMessage from '@/components/error/ErrorMessage';
   import LandingPage from '@/components/landing/LandingPage';
 
   export default {
     name: 'DS4CHPage',
 
     components: {
-      ErrorMessage,
+      ErrorMessage: () => import('@/components/error/ErrorMessage'),
       LandingPage
     },
 

--- a/packages/portal/tests/unit/components/content/ContentPrimaryCallToAction.spec.js
+++ b/packages/portal/tests/unit/components/content/ContentPrimaryCallToAction.spec.js
@@ -5,12 +5,36 @@ import ContentPrimaryCallToAction from '@/components/content/ContentPrimaryCallT
 const localVue = createLocalVue();
 localVue.use(BootstrapVue);
 
-const factory = (propsData = { text: 'Call to action!', link: { text: 'I am the link', url: 'https://example.org/call-to-action' } }) => shallowMount(ContentPrimaryCallToAction, {
+const testPropsData = { title: 'Title', text: 'Call to action!', link: { text: 'I am the link', url: 'https://example.org/call-to-action' } };
+
+const factory = (propsData = testPropsData) => shallowMount(ContentPrimaryCallToAction, {
   localVue,
   propsData
 });
 
 describe('components/content/ContentPrimaryCallToAction', () => {
+  describe('when a title is available', () => {
+    it('shows a title', async() => {
+      const wrapper = factory();
+
+      const title = wrapper.find('[data-qa="primary cta title"');
+
+      expect(title.text()).toBe('Title');
+    });
+  });
+  describe('when there is no title', () => {
+    it('no title exists', async() => {
+      const propsDataWithoutTitle = { ...testPropsData };
+      delete propsDataWithoutTitle.title;
+
+      const wrapper = factory(propsDataWithoutTitle);
+
+      const title = wrapper.find('[data-qa="primary cta title"');
+
+      expect(title.exists()).toBe(false);
+    });
+  });
+
   it('shows text', async() => {
     const wrapper = factory();
 

--- a/packages/portal/tests/unit/components/landing/LandingCallToAction.spec.js
+++ b/packages/portal/tests/unit/components/landing/LandingCallToAction.spec.js
@@ -6,18 +6,74 @@ import LandingCallToAction from '@/components/landing/LandingCallToAction.vue';
 const localVue = createLocalVue();
 localVue.use(BootstrapVue);
 
-const factory = (propsData) => shallowMount(LandingCallToAction, {
+const testProps = { title: 'This is the title', text: 'this is the text', link: { text: 'link text', url: 'https://example.com/link' } };
+const testPropsWithBackground = { ...testProps,
+  backgroundImage: { image: { url: 'https://www.example.eu/img.jpg' } } };
+const testPropsDs4ch = {
+  ...testPropsWithBackground, variant: 'ds4ch'
+};
+const testPropsTwinItBackground = {
+  ...testPropsDs4ch,
+  backgroundImage: { image: { title: 'Twin it! background', url: 'https://www.example.eu/img.jpg' } }
+};
+const factory = (propsData = testProps) => shallowMount(LandingCallToAction, {
   localVue,
-  propsData
+  propsData,
+  mocks: {
+    $contentful: {
+      assets: {
+        responsiveBackgroundImageCSSVars: (img, sizes) => Object.keys(sizes)
+      }
+    }
+  }
 });
 
 describe('components/landing/LandingCallToAction', () => {
   it('passes the props to a primaryCallToAction component', () => {
-    const wrapper = factory({ text: 'this is the text', link: { text: 'link text', url: 'https://example.com/link' } });
+    const wrapper = factory();
 
     const ctaElement = wrapper.find('contentprimarycalltoaction-stub');
 
     expect(ctaElement.attributes('text')).toBe('this is the text');
     expect(ctaElement.attributes('link')).toBe('[object Object]');
+    expect(ctaElement.attributes('title')).toBeFalsy();
+  });
+
+  describe('when there is no background image', () => {
+    it('is not displayed', () => {
+      const wrapper = factory();
+
+      const background = wrapper.find('[data-qa="landing cta background image"]');
+
+      expect(background.exists()).toBe(false);
+    });
+  });
+  describe('when there is a background image', () => {
+    it('is displayed', () => {
+      const wrapper = factory(testPropsWithBackground);
+
+      const background = wrapper.find('[data-qa="landing cta background image"]');
+
+      expect(background.exists()).toBe(true);
+    });
+  });
+
+  describe('when the variant is ds4ch', () => {
+    it('passes a title prop', () => {
+      const wrapper = factory(testPropsDs4ch);
+
+      const ctaElement = wrapper.find('contentprimarycalltoaction-stub');
+
+      expect(ctaElement.attributes('title')).toBe('This is the title');
+    });
+    describe('and the background image needs specific Twin it images and styles', () => {
+      it('add the twin-it class to the background element', () => {
+        const wrapper = factory(testPropsTwinItBackground);
+
+        const backgroundTwinIt = wrapper.find('[data-qa="landing cta background image"].twin-it');
+
+        expect(backgroundTwinIt.exists()).toBe(true);
+      });
+    });
   });
 });

--- a/packages/style/scss/DS4CH/style.scss
+++ b/packages/style/scss/DS4CH/style.scss
@@ -1,19 +1,99 @@
 @import 'variables';
+@import '../icons';
 
-.btn {
+%title-2 {
+  font-family: $font-family-montserrat;
+  font-size: 1.375rem;
+  font-weight: 700;
+  line-height: 1.2;
+  margin-left: auto;
+  margin-right: auto;
 
-  &.btn-light-flat {
-    background-color: transparent;
-    color: $white;
+  @media(min-width: $bp-medium) {
+    font-size: $font-size-xl;
+  }
 
-    &:hover,
-    &:focus {
-      color: $yellow;
-      transition: $standard-transition;
-    }
+  @media(min-width: $bp-4k) {
+    font-size: 5.625rem;
   }
 }
 
-.bg-dark {
-  background-color: $black !important;
+.ds4ch-layout {
+  .btn {
+
+    &.btn-primary {
+      border: none;
+      border-radius: 0;
+      background-color: $yellow;
+      background-image: linear-gradient(to right, $black 50%, $yellow 50%);
+      background-size: 201% 100%; // Extra percent to prevent yellow line on hover effect
+      background-position: right;
+      color: $black;
+      display: inline-flex;
+      align-items: center;
+      font-family: $font-family-montserrat;
+      font-size: 1rem;
+      padding: 0.75rem 1rem;
+      transition: all 400ms ease-in-out;
+
+      @media (min-width: ($bp-4k)) {
+        font-size: 2.625rem;
+        padding: 2rem 2.625rem;
+      }
+
+      &::after {
+        @extend %icon-font;
+        content: '\e91b';
+
+        display: inline-flex;
+        align-items: center;
+        transform: rotate(-90deg);
+        font-size: 0.625rem;
+        margin-left: 0.625rem;
+
+        @media (min-width: ($bp-4k)) {
+          font-size: 1.75rem;
+          margin-left: 1.75rem;
+        }
+      }
+
+      &:hover,
+      &:focus,
+      &:active {
+        background-position: left;
+        color: $yellow;
+        box-shadow: none;
+      }
+    }
+
+    &.btn-light-flat {
+      background-color: transparent;
+      color: $white;
+
+      &:hover,
+      &:focus {
+        color: $yellow;
+        transition: $standard-transition;
+      }
+    }
+  }
+
+  .bg-dark {
+    background-color: $black !important;
+  }
+
+  .container {
+    padding-left: 2rem;
+    padding-right: 2rem;
+
+    @media (min-width: ($bp-extralarge)) {
+      padding-left: 4rem;
+      padding-right: 4rem;
+    }
+
+    @media (min-width: ($bp-4k)) {
+      padding-left: 10rem;
+      padding-right: 10rem;
+    }
+  }
 }

--- a/packages/style/scss/DS4CH/style.scss
+++ b/packages/style/scss/DS4CH/style.scss
@@ -14,7 +14,7 @@
   }
 
   @media(min-width: $bp-4k) {
-    font-size: 5.625rem;
+    font-size: 4.75rem;
   }
 }
 

--- a/packages/style/scss/responsive-background-image.scss
+++ b/packages/style/scss/responsive-background-image.scss
@@ -23,11 +23,11 @@
     background-image: var(--bg-img-xxxl, var(--bg-img-small));
   }
 
-  @media (min-width: ($bp-xxxl + 1px)) and (max-width: $bp-wqhd) {
+  @media (min-width: ($bp-xxxl + 1px)) and (max-width: $bp-4k) {
     background-image: var(--bg-img-wqhd, var(--bg-img-small));
   }
 
-  @media (min-width: ($bp-wqhd + 1px)) {
+  @media (min-width: ($bp-4k + 1px)) {
     background-image: var(--bg-img-4k, var(--bg-img-small));
   }
 }


### PR DESCRIPTION
- Adds the primary CTA title to be (conditionally) displayed as an h2
- Adds a responsive background image to the LandingCallToAction component with separate styling for the 'Twin it!'/3D background
- Fixes responsive background styles for wqhd and 4k  breakpoints (also for home hero)