### PR TITLE
feat: mixin to mark element parity

### DIFF
--- a/packages/portal/src/components/landing/LandingPage.vue
+++ b/packages/portal/src/components/landing/LandingPage.vue
@@ -82,6 +82,7 @@
   import LandingHero from '@/components/landing/LandingHero';
   import landingPageMixin from '@/mixins/landingPage.js';
   import contentfulMixin from '@/mixins/contentful.js';
+  import parityMixin from '@/mixins/parity.js';
 
   export default {
     name: 'LandingPage',
@@ -101,7 +102,8 @@
 
     mixins: [
       contentfulMixin,
-      landingPageMixin
+      landingPageMixin,
+      parityMixin
     ],
 
     props: {
@@ -141,6 +143,10 @@
       if (this.landingPageId === 'ds4ch') {
         this.variant = 'ds4ch';
       }
+    },
+
+    mounted() {
+      this.$nextTick(() => this.markParity('image-card'));
     }
   };
 </script>

--- a/packages/portal/src/mixins/parity.js
+++ b/packages/portal/src/mixins/parity.js
@@ -1,0 +1,12 @@
+export default {
+  methods: {
+    markParity(klass) {
+      const elements = document.getElementsByClassName(klass);
+
+      for (let i = 0; i < elements.length; i++) {
+        const parity = (((i + 1) % 2) === 1) ? 'odd' : 'even';
+        elements[i].dataset.parity = parity;
+      }
+    }
+  }
+};

--- a/packages/portal/tests/unit/mixins/parity.spec.js
+++ b/packages/portal/tests/unit/mixins/parity.spec.js
@@ -1,0 +1,35 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+
+import mixin from '@/mixins/parity';
+
+const component = {
+  template: `
+    <div>
+      <span id="target1" class="target" />
+      <span id="target2" class="target" />
+      <span id="target3" class="target" />
+    </div>
+  `,
+  mixins: [mixin]
+};
+
+const factory = () => shallowMount(component, {
+  attachTo: document.body,
+  localVue: createLocalVue()
+});
+
+describe('mixins/parity', () => {
+  describe('methods', () => {
+    describe('markParity', () => {
+      it('adds data-parity attributes to indicate odd/even', () => {
+        const wrapper = factory();
+
+        wrapper.vm.markParity('target');
+
+        expect(wrapper.find('#target1').attributes('data-parity')).toBe('odd');
+        expect(wrapper.find('#target2').attributes('data-parity')).toBe('even');
+        expect(wrapper.find('#target3').attributes('data-parity')).toBe('odd');
+      });
+    });
+  });
+});


### PR DESCRIPTION
* new parity mixin with `markParity` method which accepts an HTML class name as its param
* when called, gets all elements with the class name, detects if they are odd or even occurrences of the class name, and adds a data attribute to them, `data-parity` with either "odd" or "even"
* called when LandingPage is mounted, for the image-card class