### PR TITLE
refactor: fix responsive images

### DIFF
--- a/packages/contentful/migrations/0128-add-size-image-profile.cjs
+++ b/packages/contentful/migrations/0128-add-size-image-profile.cjs
@@ -1,0 +1,25 @@
+module.exports = function(migration) {
+  const imageDisplayProfile = migration.editContentType('imageDisplayProfile');
+
+  imageDisplayProfile
+    .editField('sizes')
+    .name('Sizes')
+    .type('Array')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .defaultValue({
+      'en-GB': ['small', 'medium', 'large', 'xl', 'xxl', 'xxxl', 'wqhd', '4k', '4k+']
+    })
+    .disabled(false)
+    .omitted(false)
+    .items({
+      type: 'Symbol',
+
+      validations: [
+        {
+          in: ['small', 'medium', 'large', 'xl', 'xxl', 'xxxl', 'wqhd', '4k', '4k+']
+        }
+      ]
+    });
+};

--- a/packages/portal/src/components/DS4CH/DS4CHLandingHero.vue
+++ b/packages/portal/src/components/DS4CH/DS4CHLandingHero.vue
@@ -43,15 +43,16 @@
   import SmartLink from '@/components/generic/SmartLink';
   import parseMarkdownHtmlMixin from '@/mixins/parseMarkdownHtml';
 
-  const SRCSET_PRESETS = {
+  const CSS_VARS_PRESETS = {
     small: { w: 576, h: 896, fit: 'fill', q: 100, f: 'right' },
     medium: { w: 768, h: 1080, fit: 'fill', q: 100, f: 'right' },
     large: { w: 992, h: 1080, fit: 'fill', q: 100, f: 'right' },
     xl: { w: 1200, h: 1080, fit: 'fill', q: 100, f: 'right' },
-    xxl: { w: 1440, h: 1080, fit: 'fill', q: 100, f: 'right' },
-    xxxl: { w: 1920, h: 1080, fit: 'fill', q: 100, f: 'right' },
-    wqhd: { w: 2560, h: 1440, fit: 'fill', q: 100, f: 'right' },
-    '4k': { w: 3840, h: 2160, fit: 'fill', q: 100, f: 'right' }
+    xxl: { w: 1400, h: 1080, fit: 'fill', q: 100, f: 'right' },
+    xxxl: { w: 1880, h: 1080, fit: 'fill', q: 100, f: 'right' },
+    wqhd: { w: 2520, h: 1440, fit: 'fill', q: 100, f: 'right' },
+    '4k': { w: 3020, h: 1440, fit: 'fill', q: 100, f: 'right' },
+    '4k+': { w: 3840, h: 2160, fit: 'fill', q: 100, f: 'right' }
   };
 
   export default {
@@ -101,7 +102,7 @@
         imageCSSVars: this.heroImage?.image &&
           this.$contentful.assets.responsiveBackgroundImageCSSVars(
             this.heroImage.image,
-            SRCSET_PRESETS
+            CSS_VARS_PRESETS
           )
       };
     }

--- a/packages/portal/src/components/generic/StackedCardsSwiper.vue
+++ b/packages/portal/src/components/generic/StackedCardsSwiper.vue
@@ -76,9 +76,8 @@
     large: { w: 280, h: 400, fit: 'fill' },
     xl: { w: 300, h: 400, fit: 'fill' },
     xxl: { w: 320, h: 370, fit: 'fill' },
-    xxxl: { w: 355, h: 345, fit: 'fill' },
-    wqhd: { w: 405, h: 323, fit: 'fill' },
-    '4k': { w: 480, h: 470, fit: 'fill' }
+    '4k': { w: 355, h: 345, fit: 'fill' },
+    '4k+': { w: 480, h: 470, fit: 'fill' }
   };
 
   export default {
@@ -149,12 +148,12 @@
           }
         },
         imageSizes: [
-          '(max-width: 575px) 245px',
-          '(max-width: 767px) 260px',
-          '(max-width: 991px) 280px',
-          '(max-width: 1199px) 300px',
-          '(max-width: 1439px) 320px',
-          '(max-width: 3019px) 355px',
+          '(max-width: 575px) 245px', // bp-small
+          '(max-width: 767px) 260px', // bp-medium
+          '(max-width: 991px) 280px', // bp-large
+          '(max-width: 1199px) 300px', // bp-xl
+          '(max-width: 1399px) 320px', // bp-xxl
+          '(max-width: 3019px) 355px', // bp-4k
           '480px'
         ].join(',')
       };

--- a/packages/portal/src/components/home/HomeHero.vue
+++ b/packages/portal/src/components/home/HomeHero.vue
@@ -42,6 +42,18 @@
   import AttributionToggle from '@/components/generic/AttributionToggle';
   import EULogo from '@/components/image/ImageEULogo';
 
+  const CSS_VARS_PRESETS = {
+    small: { w: 576, h: 896, fit: 'fill' },
+    medium: { w: 768, h: 1080, fit: 'fill' },
+    large: { w: 992, h: 1080, fit: 'fill' },
+    xl: { w: 1200, h: 1080, fit: 'fill' },
+    xxl: { w: 1400, h: 1080, fit: 'fill' },
+    xxxl: { w: 1880, h: 1080, fit: 'fill' },
+    wqhd: { w: 2520, h: 1440, fit: 'fill' },
+    '4k': { w: 3020, h: 1440, fit: 'fill' },
+    '4k+': { w: 3840, h: 2160, fit: 'fill' }
+  };
+
   export default {
     name: 'HomeHero',
 
@@ -63,16 +75,7 @@
         return this.backgroundImage?.image &&
           this.$contentful.assets.responsiveBackgroundImageCSSVars(
             this.backgroundImage.image,
-            {
-              small: { w: 576, h: 896, fit: 'fill' },
-              medium: { w: 768, h: 1080, fit: 'fill' },
-              large: { w: 992, h: 1080, fit: 'fill' },
-              xl: { w: 1200, h: 1080, fit: 'fill' },
-              xxl: { w: 1400, h: 1080, fit: 'fill' },
-              xxxl: { w: 1880, h: 1080, fit: 'fill' },
-              wqhd: { w: 3020, h: 1440, fit: 'fill' },
-              '4k': { w: 3840, h: 2160, fit: 'fill' }
-            }
+            CSS_VARS_PRESETS
           );
       }
     },
@@ -142,6 +145,7 @@
       position: absolute;
       background-size: cover;
       background-repeat: no-repeat;
+      background-position: center;
       transition: transform 500ms ease-out;
 
       &::before {

--- a/packages/portal/src/components/landing/LandingCallToAction.vue
+++ b/packages/portal/src/components/landing/LandingCallToAction.vue
@@ -30,8 +30,9 @@
     xl: { w: 1200, h: 300, fit: 'fill' },
     xxl: { w: 1400, h: 300, fit: 'fill' },
     xxxl: { w: 1880, h: 300, fit: 'fill' },
-    wqhd: { w: 3020, h: 500, fit: 'fill' },
-    '4k': { w: 3840, h: 680, fit: 'fill' }
+    wqhd: { w: 2520, h: 350, fit: 'fill' },
+    '4k': { w: 3020, h: 350, fit: 'fill' },
+    '4k+': { w: 3840, h: 680, fit: 'fill' }
   };
 
   export default {

--- a/packages/portal/src/components/landing/LandingHero.vue
+++ b/packages/portal/src/components/landing/LandingHero.vue
@@ -42,14 +42,12 @@
   import parseMarkdownHtmlMixin from '@/mixins/parseMarkdownHtml';
 
   const SRCSET_PRESETS = {
-    small: { w: 500 },
     medium: { w: 500 },
     large: { w: 660 },
     xl: { w: 465 },
     xxl: { w: 555 },
-    xxxl: { w: 625 },
-    wqhd: { w: 625 },
-    '4k': { w: 938 }
+    '4k': { w: 625 },
+    '4k+': { w: 938 }
   };
 
   export default {

--- a/packages/portal/src/components/landing/LandingIllustrationGroup.vue
+++ b/packages/portal/src/components/landing/LandingIllustrationGroup.vue
@@ -71,9 +71,9 @@
   import { Grid, Keyboard, Lazy, Navigation, Pagination } from 'swiper';
 
   const SRCSET_PRESETS = {
-    small: { w: 98, h: 98 },
-    large: { w: 127, h: 127 },
-    '4k': { w: 340, h: 340 }
+    large: { w: 98, h: 98 },
+    '4k': { w: 127, h: 127 },
+    '4k+': { w: 340, h: 340 }
   };
 
   export default {
@@ -128,8 +128,8 @@
     data() {
       return {
         imageSizes: [
-          '(max-width: 991px) 98px',
-          '(max-width: 3019px) 127px',
+          '(max-width: 991px) 98px', // bp-large
+          '(max-width: 3019px) 127px', // bp-4k
           '340px'
         ].join(','),
 

--- a/packages/portal/src/components/landing/LandingImageCard.vue
+++ b/packages/portal/src/components/landing/LandingImageCard.vue
@@ -52,22 +52,21 @@
   import parseMarkdownHtmlMixin from '@/mixins/parseMarkdownHtml';
 
   const SRCSET_PRESETS = {
-    small: { w: 545, h: 270, fit: 'fill' },
-    medium: { w: 510, h: 306, fit: 'fill' },
-    large: { w: 510, h: 306, fit: 'fill' },
-    xl: { w: 570, h: 342, fit: 'fill' },
-    xxl: { w: 612, h: 367, fit: 'fill' },
-    xxxl: { w: 612, h: 367, fit: 'fill' },
-    wqhd: { w: 612, h: 367, fit: 'fill' },
-    '4k': { w: 918, h: 551, fit: 'fill' }
+    small: { w: 512, h: 342, fit: 'fill' },
+    medium: { w: 510, h: 340, fit: 'fill' },
+    large: { w: 690, h: 460, fit: 'fill' },
+    xl: { w: 465, h: 310, fit: 'fill' },
+    '4k': { w: 625, h: 417, fit: 'fill' },
+    '4k+': { w: 938, h: 625, fit: 'fill' }
   };
 
   const SIZES_PRESETS = [
-    '(max-width: 575px) 545px', // bp-small
-    '(max-width: 991px) 510px', // bp-large
-    '(max-width: 1199px) 570px', // bp-xl
-    '(max-width: 3019px) 612px', // bp-4k
-    '918px'
+    '(max-width: 575px) 512px', // bp-small
+    '(max-width: 767px) 510px', // bp-medium
+    '(max-width: 991px) 690px', // bp-large
+    '(max-width: 1199px) 465px', // bp-xl
+    '(max-width: 3019px) 625px', // bp-4k
+    '938px'
   ].join(',');
 
   const SRCSET_PRESETS_DS4CH = {
@@ -76,9 +75,8 @@
     large: { w: 690, h: 460, fit: 'fill' },
     xl: { w: 600, h: 400, fit: 'fill' },
     xxl: { w: 700, h: 467, fit: 'fill' },
-    xxxl: { w: 940, h: 627, fit: 'fill' },
-    wqhd: { w: 1500, h: 1000, fit: 'fill' },
-    '4k': { w: 1500, h: 1000, fit: 'fill' }
+    '4k': { w: 625, h: 417, fit: 'fill' },
+    '4k+': { w: 1500, h: 1000, fit: 'fill' }
   };
 
   const SIZES_PRESETS_DS4CH = [
@@ -87,9 +85,7 @@
     '(max-width: 991px) 690px', // bp-large
     '(max-width: 1199px) 600px', // bp-xl
     '(max-width: 1399px) 700px', // bp-xxl
-    '(max-width: 1879px) 940px', // bp-xxxl
-    '(max-width: 2519px) 1500px', // bp-wqhd
-    '(max-width: 3019px) 1500px', // bp-4k
+    '(max-width: 3019px) 625px', // bp-4k
     '1500px'
   ].join(',');
 
@@ -229,16 +225,8 @@
 
     ::v-deep figure {
       margin: 0;
-      height: 306px;
-      width: 100%;
-
-      @media (min-width: $bp-large) {
-        height: 367px;
-      }
-
-      @media (min-width: $bp-4k) {
-        height: 551px;
-      }
+      width: auto;
+      height: auto;
 
       img {
         width: auto;
@@ -319,10 +307,6 @@
         flex-basis: 1500px;
       }
 
-      ::v-deep figure {
-        width: auto;
-        height: auto;
-      }
     }
 
     .text-wrapper {

--- a/packages/portal/src/modules/contentful/templates/assets.js
+++ b/packages/portal/src/modules/contentful/templates/assets.js
@@ -7,7 +7,7 @@
 //   name: null,
 //   overlay: true,
 //   quality: 40,
-//   sizes: ['small', 'medium', 'large', 'xl', 'xxl', 'xxxl', '4k', 'wqhd']
+//   sizes: ['small', 'medium', 'large', 'xl', 'xxl', 'xxxl', 'wqhd', '4k', '4k+']
 // };
 const CONTENTFUL_IMAGES_ASSET_HOST = 'images.ctfassets.net';
 const CONTENTFUL_IMAGES_PARAMS_FL_PROGRESSIVE = 'progressive';

--- a/packages/portal/tests/unit/components/landing/LandingImageCard.spec.js
+++ b/packages/portal/tests/unit/components/landing/LandingImageCard.spec.js
@@ -5,22 +5,21 @@ import LandingImageCard from '@/components/landing/LandingImageCard.vue';
 const localVue = createLocalVue();
 
 const SRCSET_PRESETS = {
-  small: { w: 545, h: 270, fit: 'fill' },
-  medium: { w: 510, h: 306, fit: 'fill' },
-  large: { w: 510, h: 306, fit: 'fill' },
-  xl: { w: 570, h: 342, fit: 'fill' },
-  xxl: { w: 612, h: 367, fit: 'fill' },
-  xxxl: { w: 612, h: 367, fit: 'fill' },
-  wqhd: { w: 612, h: 367, fit: 'fill' },
-  '4k': { w: 918, h: 551, fit: 'fill' }
+  small: { w: 512, h: 342, fit: 'fill' },
+  medium: { w: 510, h: 340, fit: 'fill' },
+  large: { w: 690, h: 460, fit: 'fill' },
+  xl: { w: 465, h: 310, fit: 'fill' },
+  '4k': { w: 625, h: 417, fit: 'fill' },
+  '4k+': { w: 938, h: 625, fit: 'fill' }
 }.toString();
 
 const SIZES_PRESETS = [
-  '(max-width: 575px) 545px', // bp-small
-  '(max-width: 991px) 510px', // bp-large
-  '(max-width: 1199px) 570px', // bp-xl
-  '(max-width: 3019px) 612px', // bp-4k
-  '918px'
+  '(max-width: 575px) 512px', // bp-small
+  '(max-width: 767px) 510px', // bp-medium
+  '(max-width: 991px) 690px', // bp-large
+  '(max-width: 1199px) 465px', // bp-xl
+  '(max-width: 3019px) 625px', // bp-4k
+  '938px'
 ].join(',');
 
 const SRCSET_PRESETS_DS4CH = {
@@ -29,9 +28,8 @@ const SRCSET_PRESETS_DS4CH = {
   large: { w: 690, h: 460, fit: 'fill' },
   xl: { w: 600, h: 400, fit: 'fill' },
   xxl: { w: 700, h: 467, fit: 'fill' },
-  xxxl: { w: 940, h: 627, fit: 'fill' },
-  wqhd: { w: 1500, h: 1000, fit: 'fill' },
-  '4k': { w: 1500, h: 1000, fit: 'fill' }
+  '4k': { w: 625, h: 417, fit: 'fill' },
+  '4k+': { w: 1500, h: 1000, fit: 'fill' }
 }.toString();
 
 const SIZES_PRESETS_DS4CH = [
@@ -40,9 +38,7 @@ const SIZES_PRESETS_DS4CH = [
   '(max-width: 991px) 690px', // bp-large
   '(max-width: 1199px) 600px', // bp-xl
   '(max-width: 1399px) 700px', // bp-xxl
-  '(max-width: 1879px) 940px', // bp-xxxl
-  '(max-width: 2519px) 1500px', // bp-wqhd
-  '(max-width: 3019px) 1500px', // bp-4k
+  '(max-width: 3019px) 625px', // bp-4k
   '1500px'
 ].join(',');
 

--- a/packages/style/scss/responsive-background-image.scss
+++ b/packages/style/scss/responsive-background-image.scss
@@ -23,11 +23,15 @@
     background-image: var(--bg-img-xxxl, var(--bg-img-small));
   }
 
-  @media (min-width: ($bp-xxxl + 1px)) and (max-width: $bp-4k) {
+  @media (min-width: ($bp-xxxl + 1px)) and (max-width: $bp-wqhd) {
     background-image: var(--bg-img-wqhd, var(--bg-img-small));
   }
 
-  @media (min-width: ($bp-4k + 1px)) {
+  @media (min-width: ($bp-wqhd + 1px)) and (max-width: $bp-4k) {
     background-image: var(--bg-img-4k, var(--bg-img-small));
+  }
+
+  @media (min-width: ($bp-4k + 1px)) {
+    background-image: var(--bg-img-4k\+, var(--bg-img-small));
   }
 }


### PR DESCRIPTION
- Adds a CTF migration to add the 4k+ size to the image display profile
- Adds an additional size for the 4k and up breakpoint to all srcsets and background image CSS vars
- Fix the home hero background position to center the image
- Clean up LandingImageCard  ('pro' variant) image styles