### PR TITLE
refactor: mv home page to component

### DIFF
--- a/packages/portal/nuxt.config.js
+++ b/packages/portal/nuxt.config.js
@@ -406,13 +406,6 @@ export default {
       'redirects'
     ],
     extendRoutes(routes) {
-      const nuxtHomeRouteIndex = routes.findIndex(route => route.name === 'home');
-      routes[nuxtHomeRouteIndex] = {
-        name: 'home',
-        path: '/',
-        component: 'src/pages/home/index.vue'
-      };
-
       const nuxtCollectionsPersonsOrPlacesRouteIndex = routes.findIndex(route => route.name === 'collections-persons-or-places');
       routes.splice(nuxtCollectionsPersonsOrPlacesRouteIndex, 1);
 

--- a/packages/portal/nuxt.config.js
+++ b/packages/portal/nuxt.config.js
@@ -75,6 +75,7 @@ export default {
           origin: [process.env.PORTAL_BASE_URL].concat(process.env.APP_FEEDBACK_CORS_ORIGIN?.split(',')).filter((origin) => !!origin)
         }
       },
+      homeSlug: process.env.APP_HOME_SLUG,
       internalLinkDomain: process.env.INTERNAL_LINK_DOMAIN,
       notificationBanner: process.env.APP_NOTIFICATION_BANNER,
       siteName: APP_SITE_NAME,

--- a/packages/portal/nuxt.config.js
+++ b/packages/portal/nuxt.config.js
@@ -75,7 +75,6 @@ export default {
           origin: [process.env.PORTAL_BASE_URL].concat(process.env.APP_FEEDBACK_CORS_ORIGIN?.split(',')).filter((origin) => !!origin)
         }
       },
-      homeSlug: process.env.APP_HOME_SLUG,
       internalLinkDomain: process.env.INTERNAL_LINK_DOMAIN,
       notificationBanner: process.env.APP_NOTIFICATION_BANNER,
       siteName: APP_SITE_NAME,

--- a/packages/portal/src/components/browse/BrowsePage.vue
+++ b/packages/portal/src/components/browse/BrowsePage.vue
@@ -10,7 +10,7 @@
       <ContentHeader
         :title="name"
         :description="headline"
-        :media-url="socialMediaImageUrl"
+        :media-url="imageUrl"
         button-variant="secondary"
         class="half-col"
       />
@@ -43,7 +43,7 @@
         type: Object,
         default: null
       },
-      socialMediaImageUrl: {
+      imageUrl: {
         type: String,
         default: null
       }

--- a/packages/portal/src/components/home/HomePage.vue
+++ b/packages/portal/src/components/home/HomePage.vue
@@ -66,17 +66,32 @@
 
     mixins: [pageMetaMixin],
 
+    props: {
+      sections: {
+        type: Array,
+        default: () => []
+      },
+
+      backgroundImages: {
+        type: Array,
+        default: () => []
+      },
+
+      socialMediaImage: {
+        type: Object,
+        default: null
+      }
+    },
+
     data() {
       return {
-        sections: [],
-        backgroundImage: null,
-        socialMediaImage: null
+        backgroundImage: this.selectRandomBackground(this.backgroundImages)
       };
     },
 
-    async fetch() {
-      await this.fetchContentfulEntry();
-    },
+    // async fetch() {
+    //   await this.fetchContentfulEntry();
+    // },
 
     computed: {
       pageMeta() {

--- a/packages/portal/tests/size/.size-limit.json
+++ b/packages/portal/tests/size/.size-limit.json
@@ -19,7 +19,7 @@
   {
     "name": "portal.js server",
     "running": false,
-    "limit": "975 KB",
+    "limit": "990 KB",
     "path": [
       ".nuxt/dist/server/*.js"
     ]


### PR DESCRIPTION
* mv the logic for home page retrieval and display from pages/home/index.vue to components/home/HomePage.vue
* make the catch-all pages/index.vue detect when there is no slug in the route and render HomePage
* DRY up the browse/static/landing page logic in pages/index.vue
* stop using a random image from the home page image set for the social media image as it should always have a specific one set
* rm redundant slug property from index page