### PR TITLE
fix: div on v-for instead of template

### DIFF
--- a/packages/portal/src/components/landing/LandingPage.vue
+++ b/packages/portal/src/components/landing/LandingPage.vue
@@ -18,20 +18,18 @@
       :cta="cta"
       :hero-image="primaryImageOfPage"
     />
-    <template
+    <div
       v-for="(section, index) in sections"
+      :key="index"
+      :id="sectionId(section)"
     >
       <LandingContentCardGroup
         v-if="contentfulEntryHasContentType(section, 'CardGroup')"
-        :id="sectionId(section)"
-        :key="index"
         :section="section"
         :variant="variant"
       />
       <LandingIllustrationGroup
         v-else-if="contentfulEntryHasContentType(section, 'IllustrationGroup')"
-        :id="sectionId(section)"
-        :key="index"
         :title="section.name"
         :text="section.text"
         :illustrations="section.hasPartCollection && section.hasPartCollection.items"
@@ -39,8 +37,6 @@
       />
       <LandingInfoCardGroup
         v-else-if="contentfulEntryHasContentType(section, 'InfoCardGroup')"
-        :id="sectionId(section)"
-        :key="index"
         :title="section.name"
         :text="section.text"
         :info-cards="section.hasPartCollection && section.hasPartCollection.items"
@@ -49,13 +45,11 @@
       />
       <div
         v-else-if="contentfulEntryHasContentType(section, 'ImageCard')"
-        :key="index"
         class="image-card-container-wrapper"
         :class="getClasses(section)"
       >
         <b-container class="image-card-container">
           <LandingImageCard
-            :id="sectionId(section)"
             :card="section"
             :variant="variant"
           />
@@ -63,16 +57,12 @@
       </div>
       <LandingImageCardGroup
         v-else-if="contentfulEntryHasContentType(section, 'ImageCardGroup')"
-        :id="sectionId(section)"
-        :key="index"
         :title="section.name"
         :text="section.text"
         :image-cards="section.hasPartCollection && section.hasPartCollection.items"
       />
       <LandingSubSection
         v-else-if="contentfulEntryHasContentType(section, 'LandingSubSection')"
-        :id="sectionId(section)"
-        :key="index"
         :title="section.name"
         :text="section.text"
         :sections="section.hasPartCollection && section.hasPartCollection.items"
@@ -80,8 +70,6 @@
       />
       <LandingEmbed
         v-else-if="contentfulEntryHasContentType(section, 'EmbedSection')"
-        :id="sectionId(section)"
-        :key="index"
         :title="section.name"
         :text="section.text"
         :background-image="section.image"
@@ -89,15 +77,13 @@
       />
       <LandingCallToAction
         v-else-if="contentfulEntryHasContentType(section, 'PrimaryCallToAction')"
-        :id="sectionId(section)"
-        :key="index"
         :title="section.name"
         :text="section.text"
         :link="section.relatedLink"
         :background-image="section.image"
         :variant="variant"
       />
-    </template>
+    </div>
   </div>
 </template>
 

--- a/packages/portal/src/components/landing/LandingPage.vue
+++ b/packages/portal/src/components/landing/LandingPage.vue
@@ -89,24 +89,35 @@
 
 <script>
   import kebabCase from 'lodash/kebabCase';
+
+  import DS4CHLandingHero from '../DS4CH/DS4CHLandingHero';
+  import LandingContentCardGroup from './LandingContentCardGroup';
+  import LandingCallToAction from './LandingCallToAction';
+  import LandingEmbed from './LandingEmbed';
   import LandingHero from './LandingHero';
-  import landingPageMixin from '@/mixins/landingPage.js';
+  import LandingImageCard from './LandingImageCard';
+  import LandingImageCardGroup from './LandingImageCardGroup';
+  import LandingInfoCardGroup from './LandingInfoCardGroup';
+  import LandingIllustrationGroup from './LandingIllustrationGroup';
+  import LandingSubSection from './LandingSubSection';
+
   import contentfulMixin from '@/mixins/contentful.js';
+  import landingPageMixin from '@/mixins/landingPage.js';
 
   export default {
     name: 'LandingPage',
 
     components: {
-      LandingContentCardGroup: () => import('./LandingContentCardGroup'),
-      LandingCallToAction: () => import('./LandingCallToAction'),
+      LandingContentCardGroup,
+      LandingCallToAction,
       LandingHero,
-      LandingIllustrationGroup: () => import('./LandingIllustrationGroup'),
-      LandingInfoCardGroup: () => import('./LandingInfoCardGroup'),
-      LandingImageCard: () => import('./LandingImageCard'),
-      LandingImageCardGroup: () => import('./LandingImageCardGroup'),
-      LandingSubSection: () => import('./LandingSubSection'),
-      LandingEmbed: () => import('./LandingEmbed'),
-      DS4CHLandingHero: () => import('../DS4CH/DS4CHLandingHero')
+      LandingIllustrationGroup,
+      LandingInfoCardGroup,
+      LandingImageCard,
+      LandingImageCardGroup,
+      LandingSubSection,
+      LandingEmbed,
+      DS4CHLandingHero
     },
 
     mixins: [

--- a/packages/portal/src/components/landing/LandingPage.vue
+++ b/packages/portal/src/components/landing/LandingPage.vue
@@ -20,8 +20,8 @@
     />
     <div
       v-for="(section, index) in sections"
-      :key="index"
       :id="sectionId(section)"
+      :key="index"
     >
       <LandingContentCardGroup
         v-if="contentfulEntryHasContentType(section, 'CardGroup')"

--- a/packages/portal/src/components/landing/LandingSubSection.vue
+++ b/packages/portal/src/components/landing/LandingSubSection.vue
@@ -51,6 +51,11 @@
 </template>
 
 <script>
+  import ContentCardSection from '../content/ContentCardSection';
+  import LandingAutomatedCardGroup from './LandingAutomatedCardGroup';
+  import LandingImageCard from './LandingImageCard';
+  import LandingInfoCardGroup from './LandingInfoCardGroup';
+
   import contentfulMixin from '@/mixins/contentful.js';
   import parseMarkdownHtmlMixin from '@/mixins/parseMarkdownHtml';
 
@@ -58,10 +63,10 @@
     name: 'LandingSubSection',
 
     components: {
-      ContentCardSection: () => import('../content/ContentCardSection'),
-      LandingAutomatedCardGroup: () => import('@/components/landing/LandingAutomatedCardGroup'),
-      LandingImageCard: () => import('@/components/landing/LandingImageCard'),
-      LandingInfoCardGroup: () => import('@/components/landing/LandingInfoCardGroup')
+      ContentCardSection,
+      LandingAutomatedCardGroup,
+      LandingImageCard,
+      LandingInfoCardGroup
     },
 
     mixins: [contentfulMixin, parseMarkdownHtmlMixin],

--- a/packages/portal/src/pages/index.vue
+++ b/packages/portal/src/pages/index.vue
@@ -111,6 +111,8 @@
       } else {
         this.$error(404, { scope: 'page' });
       }
+
+      this.page = Object.freeze(this.page);
     },
 
     computed: {


### PR DESCRIPTION
To prevent Nuxt re-fetching child components, causing janky layout shifts & messing with anchor links.

* Static import of all potential child components in LandingPage and LandingSubSection