### PR TITLE
feat: institutions page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,7 @@ jobs:
       -
         name: Check image size
         env:
-          DOCKER_IMAGE_SIZE_LIMIT: '358M'
+          DOCKER_IMAGE_SIZE_LIMIT: '359M'
         run: |
           docker_image_size=$(docker image inspect --format '{{.Size}}' ${{ needs.metadata.outputs.docker-full-tag }})
           if [ ${docker_image_size} -gt $(numfmt --from=si ${DOCKER_IMAGE_SIZE_LIMIT}) ]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -12727,6 +12727,11 @@
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-2.0.1.tgz",
       "integrity": "sha512-I2TiqT5iWBEyB8GRfTDP0hiLZ0YeDJZ+upDxjBfOC2lebO5LezQMv7QvIUTzdb64jQyAKLf1AHADtGN+jw6v8Q=="
     },
+    "node_modules/diacritics": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/diacritics/-/diacritics-1.3.0.tgz",
+      "integrity": "sha512-wlwEkqcsaxvPJML+rDh/2iS824jbREk6DUMUKkEaSlxdYHeS43cClJtsWglvw2RfeXGm6ohKDqsXteJ5sP5enA=="
+    },
     "node_modules/didyoumean2": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/didyoumean2/-/didyoumean2-5.0.0.tgz",
@@ -16777,6 +16782,17 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
       "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
+    "node_modules/i18n-iso-countries": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/i18n-iso-countries/-/i18n-iso-countries-7.10.1.tgz",
+      "integrity": "sha512-9DXmAMkfGcGNE+E/2fE85UUjjkPeT0LHMA8d+kcxXiO+s50W28lxiICel8f8qWZmCNic1cuhN1+nw7ZazMQJFA==",
+      "dependencies": {
+        "diacritics": "1.3.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/i18next": {
       "version": "19.9.2",
@@ -36163,6 +36179,7 @@
         "elastic-apm-node": "^3.24.0",
         "express": "^4.17.1",
         "http-errors": "^2.0.0",
+        "i18n-iso-countries": "^7.10.1",
         "isbot": "^3.7.0",
         "lodash": "^4.17.21",
         "marked": "^4.0.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16784,9 +16784,9 @@
       "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
     },
     "node_modules/i18n-iso-countries": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/i18n-iso-countries/-/i18n-iso-countries-7.10.1.tgz",
-      "integrity": "sha512-9DXmAMkfGcGNE+E/2fE85UUjjkPeT0LHMA8d+kcxXiO+s50W28lxiICel8f8qWZmCNic1cuhN1+nw7ZazMQJFA==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/i18n-iso-countries/-/i18n-iso-countries-7.11.0.tgz",
+      "integrity": "sha512-MP2+aAJwvBTuruaMEj+mPEhu4D9rn03GkkbuP8/xkvNzhVwNe2cAg1ivkL5Oj+vwqEwvIcf5C7Q+5Y/UZNLBHw==",
       "dependencies": {
         "diacritics": "1.3.0"
       },
@@ -36179,7 +36179,7 @@
         "elastic-apm-node": "^3.24.0",
         "express": "^4.17.1",
         "http-errors": "^2.0.0",
-        "i18n-iso-countries": "^7.10.1",
+        "i18n-iso-countries": "^7.11.0",
         "isbot": "^3.7.0",
         "lodash": "^4.17.21",
         "marked": "^4.0.10",

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -37,7 +37,7 @@
     "elastic-apm-node": "^3.24.0",
     "express": "^4.17.1",
     "http-errors": "^2.0.0",
-    "i18n-iso-countries": "^7.10.1",
+    "i18n-iso-countries": "^7.11.0",
     "isbot": "^3.7.0",
     "lodash": "^4.17.21",
     "marked": "^4.0.10",

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -37,6 +37,7 @@
     "elastic-apm-node": "^3.24.0",
     "express": "^4.17.1",
     "http-errors": "^2.0.0",
+    "i18n-iso-countries": "^7.10.1",
     "isbot": "^3.7.0",
     "lodash": "^4.17.21",
     "marked": "^4.0.10",

--- a/packages/portal/src/cachers/collections/organisations.js
+++ b/packages/portal/src/cachers/collections/organisations.js
@@ -2,7 +2,7 @@ import baseData from './index.js';
 import { createEuropeanaApiClient } from '../utils.js';
 import { isEntityUri } from '../../plugins/europeana/entity.js';
 import uniq from 'lodash/uniq.js';
-// TODO: remove and uninstall when deprecated afte API released with place references for countries
+// TODO: remove and uninstall when deprecated after API released with place references for countries
 import countryCodes from 'i18n-iso-countries';
 import localeCodes from '../../plugins/i18n/codes.js';
 

--- a/packages/portal/src/cachers/collections/organisations.js
+++ b/packages/portal/src/cachers/collections/organisations.js
@@ -47,7 +47,7 @@ const data = async(config = {}) => {
       const entityId = country.split('/').pop();
       organisationCountriesPrefLabels[country] = await getCountryPrefLabel(`/place/${entityId}.json`);
     } else if (country) {
-      // Production Entity API returns country code. This as in between solution. No support for Maltese (mt)
+      // Production Entity API returns country code. This as in between solution.
       // TODO: remove when deprecated after API released with place references for countries
       const countryPrefLabelForLocale = {};
       for (const locale of localeCodes) {

--- a/packages/portal/src/cachers/collections/organisations.js
+++ b/packages/portal/src/cachers/collections/organisations.js
@@ -6,7 +6,8 @@ import uniq from 'lodash/uniq.js';
 import countryCodes from 'i18n-iso-countries';
 import localeCodes from '../../plugins/i18n/codes.js';
 
-const PICK = ['slug', 'recordCount', 'prefLabel', 'country', 'countryPrefLabel'];
+const PICK = ['slug', 'recordCount', 'prefLabel', 'countryPrefLabel'];
+const LOCALISE = 'countryPrefLabel';
 
 let axiosClient;
 let axiosClientEntity;
@@ -47,7 +48,7 @@ const data = async(config = {}) => {
       organisationCountriesPrefLabels[country] = await getCountryPrefLabel(`/place/${entityId}.json`);
     } else if (country) {
       // Production Entity API returns country code. This as in between solution. No support for Maltese (mt)
-      // TODO: remove when deprecated afte API released with place references for countries
+      // TODO: remove when deprecated after API released with place references for countries
       const countryPrefLabelForLocale = {};
       for (const locale of localeCodes) {
         const countryNameFromCode = countryCodes.getName(country, locale, { select: 'official' });
@@ -76,5 +77,6 @@ const data = async(config = {}) => {
 
 export {
   data,
+  LOCALISE,
   PICK
 };

--- a/packages/portal/src/cachers/collections/organisations.js
+++ b/packages/portal/src/cachers/collections/organisations.js
@@ -1,9 +1,15 @@
 import baseData from './index.js';
 import { createEuropeanaApiClient } from '../utils.js';
+import { isEntityUri } from '../../plugins/europeana/entity.js';
+import uniq from 'lodash/uniq.js';
+// TODO: remove and uninstall when deprecated afte API released with place references for countries
+import countryCodes from 'i18n-iso-countries';
+import localeCodes from '../../plugins/i18n/codes.js';
 
-const PICK = ['slug', 'recordCount', 'prefLabel'];
+const PICK = ['slug', 'recordCount', 'prefLabel', 'country', 'countryPrefLabel'];
 
 let axiosClient;
+let axiosClientEntity;
 
 async function getRecordCounts() {
   const params = {
@@ -17,19 +23,53 @@ async function getRecordCounts() {
   return response.data?.facets?.[0]?.fields || [];
 }
 
+async function getCountryPrefLabel(entityUrl) {
+  const response = await axiosClientEntity.get(entityUrl);
+  return response.data.prefLabel;
+}
+
 const data = async(config = {}) => {
   const organisationData = await baseData({ type: 'organization' }, config);
 
   axiosClient = createEuropeanaApiClient(config.europeana?.apis?.record);
+  axiosClientEntity = createEuropeanaApiClient(config.europeana?.apis?.entity);
 
   const recordCounts = await getRecordCounts();
 
+  // Get array with all unique countries to only have to request prefLabels once
+  const organisationCountries = uniq(organisationData.map(organisation => organisation.country));
+
+  const organisationCountriesPrefLabels = {};
+  for (const country of organisationCountries) {
+    // Acceptance Entity API returns entity URI for country
+    if (isEntityUri(country)) {
+      const entityId = country.split('/').pop();
+      organisationCountriesPrefLabels[country] = await getCountryPrefLabel(`/place/${entityId}.json`);
+    } else if (country) {
+      // Production Entity API returns country code. This as in between solution. No support for Maltese (mt)
+      // TODO: remove when deprecated afte API released with place references for countries
+      const countryPrefLabelForLocale = {};
+      for (const locale of localeCodes) {
+        const countryNameFromCode = countryCodes.getName(country, locale, { select: 'official' });
+        if (countryNameFromCode) {
+          countryPrefLabelForLocale[locale] = countryNameFromCode;
+        }
+      }
+      organisationCountriesPrefLabels[country] = countryPrefLabelForLocale;
+    }
+  }
+
   return organisationData.map(
     organisation => {
+      // Add recordCount
       const organisationId = organisation.id;
       const organisationWithCount = recordCounts.find(facet => facet.label === organisationId);
       const recordCount = organisationWithCount?.count || 0;
       organisation.recordCount = recordCount;
+
+      // Add countryPrefLabel with langmap prefLabel
+      organisation.countryPrefLabel = organisationCountriesPrefLabels[organisation.country] || organisation.country;
+
       return organisation;
     });
 };

--- a/packages/portal/src/components/entity/EntityTable.vue
+++ b/packages/portal/src/components/entity/EntityTable.vue
@@ -133,8 +133,6 @@
     data() {
       return {
         collections: null,
-        sortBy: this.$route?.query?.sort?.split(' ')[0] || 'prefLabel',
-        sortDesc: this.$route?.query?.sort?.split(' ')[1] === 'desc',
         filter: this.$route?.query?.filter || null,
         fields: [
           {
@@ -161,7 +159,6 @@
           }
         ],
         typeSingular: this.type.slice(0, -1),
-        currentPage: Number(this.$route?.query?.page) || 1,
         totalResults: this.collections?.length || 0,
         perPage: 40
       };
@@ -188,6 +185,15 @@
       },
       cacheKey() {
         return `${this.$i18n.locale}/collections/${this.type}`;
+      },
+      currentPage() {
+        return Number(this.$route?.query?.page) || 1;
+      },
+      sortBy() {
+        return this.$route?.query?.sort?.split(' ')[0] || 'prefLabel';
+      },
+      sortDesc() {
+        return this.$route?.query?.sort?.split(' ')[1] === 'desc';
       }
     },
 
@@ -195,13 +201,6 @@
       '$route.query.filter'() {
         this.filter = this.$route.query.filter;
         this.updateRouteQuery({ page: 1 });
-      },
-      '$route.query.page'() {
-        this.currentPage = Number(this.$route?.query?.page) || 1;
-      },
-      '$route.query.sort'() {
-        this.sortBy = this.$route.query.sort.split(' ')[0];
-        this.sortDesc = this.$route.query.sort.split(' ')[1] === 'desc';
       },
       'collections.length'() {
         this.totalResults  = this.collections.length;

--- a/packages/portal/src/components/entity/EntityTable.vue
+++ b/packages/portal/src/components/entity/EntityTable.vue
@@ -11,6 +11,7 @@
       </b-col>
     </b-row>
     <b-form
+      class="search-form position-relative mb-4"
       inline
       @submit.stop.prevent="() => {}"
     >
@@ -210,4 +211,8 @@
   @import '@europeana/style/scss/variables';
   @import '@europeana/style/scss/icons';
   @import '@europeana/style/scss/table';
+
+  .search-form {
+    border: 1px solid $bodygrey;
+  }
 </style>

--- a/packages/portal/src/components/entity/EntityTable.vue
+++ b/packages/portal/src/components/entity/EntityTable.vue
@@ -213,7 +213,6 @@
         const nativeNameLangMapValue = langMapValueForLocale(nativeName, this.$i18n.locale);
         const englishName = this.organizationEntityNonNativeEnglishName({ ...org, type: 'Organization' });
         const englishNameLangMapValue = englishName && langMapValueForLocale(englishName, this.$i18n.locale);
-        // const countryPrefLabelLangMap = langMapValueForLocale(org.countryPrefLabel, this.$i18n.locale);
 
         return {
           ...org,

--- a/packages/portal/src/components/entity/EntityTable.vue
+++ b/packages/portal/src/components/entity/EntityTable.vue
@@ -116,6 +116,13 @@
             label: this.$t('pages.collections.table.name')
           },
           this.type === 'organisations' && {
+            key: 'countryPrefLabel',
+            sortable: true,
+            sortDirection: 'desc',
+            label: this.$t('pages.collections.organisations.table.country'),
+            class: 'text-center'
+          },
+          this.type === 'organisations' && {
             key: 'recordCount',
             sortable: true,
             sortDirection: 'desc',
@@ -174,13 +181,15 @@
         const nativeNameLangMapValue = langMapValueForLocale(nativeName, this.$i18n.locale);
         const englishName = this.organizationEntityNonNativeEnglishName({ ...org, type: 'Organization' });
         const englishNameLangMapValue = englishName && langMapValueForLocale(englishName, this.$i18n.locale);
+        const countryPrefLabelLangMap = langMapValueForLocale(org.countryPrefLabel, this.$i18n.locale);
 
         return {
           ...org,
           prefLabel: nativeNameLangMapValue.values[0],
           prefLabelLang: nativeNameLangMapValue.code,
           altLabel: englishNameLangMapValue?.values[0],
-          altLabelLang: englishNameLangMapValue?.code
+          altLabelLang: englishNameLangMapValue?.code,
+          countryPrefLabel: countryPrefLabelLangMap.values[0]
         };
       },
       entityRoute(slug) {

--- a/packages/portal/src/components/entity/EntityTable.vue
+++ b/packages/portal/src/components/entity/EntityTable.vue
@@ -82,7 +82,11 @@
           :class="{'show': row.detailsShowing}"
           variant="light-flat"
           @click="row.toggleDetails"
-        />
+        >
+          <span class="visually-hidden">
+            {{ $t('pages.collections.organisations.table.showMoreData', { organisation:row.item.prefLabel }) }}
+          </span>
+        </b-button>
       </template>
       <template
         v-if="type === 'organisations'"

--- a/packages/portal/src/components/entity/EntityTable.vue
+++ b/packages/portal/src/components/entity/EntityTable.vue
@@ -84,7 +84,7 @@
           @click="row.toggleDetails"
         >
           <span class="visually-hidden">
-            {{ $t('pages.collections.organisations.table.showMoreData', { organisation:row.item.prefLabel }) }}
+            {{ $t('pages.collections.table.showMoreData', { entity: row.item.prefLabel }) }}
           </span>
         </b-button>
       </template>
@@ -144,7 +144,7 @@
           this.type === 'organisations' && {
             key: 'countryPrefLabel',
             sortable: true,
-            label: this.$t('pages.collections.organisations.table.country'),
+            label: this.$t('pages.collections.table.country'),
             class: 'text-center d-none d-md-table-cell'
           },
           this.type === 'organisations' && {

--- a/packages/portal/src/components/entity/EntityTable.vue
+++ b/packages/portal/src/components/entity/EntityTable.vue
@@ -200,7 +200,8 @@
           return this.sort[0] || 'prefLabel';
         },
         set(value) {
-          this.sort = { sortBy: value, sortDesc: this.sortDesc };
+          // Switching to another column always resets ordering to ascending
+          this.sort = { sortBy: value, sortDesc: false };
         }
       },
       sortDesc: {

--- a/packages/portal/src/components/entity/EntityTable.vue
+++ b/packages/portal/src/components/entity/EntityTable.vue
@@ -10,13 +10,27 @@
         />
       </b-col>
     </b-row>
+    <b-form
+      inline
+      @submit.stop.prevent="() => {}"
+    >
+      <b-form-input
+        v-model="filter"
+        role="searchbox"
+        :placeholder="$t('pages.collections.table.searchPlaceholder')"
+        :aria-label="$t('search.title')"
+      />
+    </b-form>
     <b-table
       :fields="fields"
       :items="collections"
       :sort-by.sync="sortBy"
       :busy="$fetchState.pending"
+      :filter="filter"
+      :per-page="20"
       striped
       class="borderless"
+      @filtered="onFiltered"
     >
       <template #table-busy>
         <div class="text-center my-2">
@@ -84,6 +98,7 @@
       return {
         collections: null,
         sortBy: 'prefLabel',
+        filter: this.$route?.query?.query || null,
         fields: [
           {
             key: 'prefLabel',
@@ -126,6 +141,13 @@
           `${this.$i18n.locale}/collections/${this.type}`;
       }
     },
+
+    watch: {
+      '$route.query.query'() {
+        this.filter = this.$route?.query?.query || null;
+      }
+    },
+
     methods: {
       organisationData(org) {
         const nativeName = this.organizationEntityNativeName({ ...org, type: 'Organization' });
@@ -143,6 +165,9 @@
       },
       entityRoute(slug) {
         return `/collections/${this.typeSingular}/${slug}`;
+      },
+      onFiltered() {
+        this.$router.push({ ...this.$route, query: { query: this.filter } });
       }
     }
   };

--- a/packages/portal/src/components/entity/EntityTable.vue
+++ b/packages/portal/src/components/entity/EntityTable.vue
@@ -187,10 +187,7 @@
         return `/_api/cache/${this.cacheKey}`;
       },
       cacheKey() {
-        // For organisations, get unlocalised labels, for both English and native.
-        return this.type === 'organisations' ?
-          'collections/organisations' :
-          `${this.$i18n.locale}/collections/${this.type}`;
+        return `${this.$i18n.locale}/collections/${this.type}`;
       }
     },
 
@@ -217,15 +214,14 @@
         const nativeNameLangMapValue = langMapValueForLocale(nativeName, this.$i18n.locale);
         const englishName = this.organizationEntityNonNativeEnglishName({ ...org, type: 'Organization' });
         const englishNameLangMapValue = englishName && langMapValueForLocale(englishName, this.$i18n.locale);
-        const countryPrefLabelLangMap = langMapValueForLocale(org.countryPrefLabel, this.$i18n.locale);
+        // const countryPrefLabelLangMap = langMapValueForLocale(org.countryPrefLabel, this.$i18n.locale);
 
         return {
           ...org,
           prefLabel: nativeNameLangMapValue.values[0],
           prefLabelLang: nativeNameLangMapValue.code,
           altLabel: englishNameLangMapValue?.values[0],
-          altLabelLang: englishNameLangMapValue?.code,
-          countryPrefLabel: countryPrefLabelLangMap.values[0]
+          altLabelLang: englishNameLangMapValue?.code
         };
       },
       entityRoute(slug) {

--- a/packages/portal/src/components/entity/EntityTable.vue
+++ b/packages/portal/src/components/entity/EntityTable.vue
@@ -131,7 +131,7 @@
         collections: null,
         sortBy: this.$route?.query?.sort?.split(' ')[0] || 'prefLabel',
         sortDesc: this.$route?.query?.sort?.split(' ')[1] === 'desc',
-        filter: this.$route?.query?.query || null,
+        filter: this.$route?.query?.filter || null,
         fields: [
           {
             key: 'prefLabel',
@@ -191,8 +191,8 @@
     },
 
     watch: {
-      '$route.query.query'() {
-        this.filter = this.$route.query.query;
+      '$route.query.filter'() {
+        this.filter = this.$route.query.filter;
         this.updateRouteQuery({ page: 1 });
       },
       '$route.query.page'() {
@@ -229,7 +229,7 @@
       },
       onFiltered(filteredItems) {
         this.totalResults = filteredItems.length;
-        this.updateRouteQuery({ query: this.filter });
+        this.updateRouteQuery({ filter: this.filter });
       },
       onSortchanged(ctx) {
         this.updateRouteQuery({ sort: `${ctx.sortBy} ${ctx.sortDesc ? 'desc' : 'asc'}` });

--- a/packages/portal/src/components/entity/EntityTable.vue
+++ b/packages/portal/src/components/entity/EntityTable.vue
@@ -27,6 +27,7 @@
       :fields="fields"
       :items="collections"
       :sort-by.sync="sortBy"
+      :sort-desc.sync="sortDesc"
       :busy="$fetchState.pending"
       :filter="filter"
       :current-page="currentPage"
@@ -34,6 +35,7 @@
       striped
       class="borderless"
       @filtered="onFiltered"
+      @sort-changed="onSortchanged"
     >
       <template #table-busy>
         <div class="text-center my-2">
@@ -108,7 +110,8 @@
     data() {
       return {
         collections: null,
-        sortBy: 'prefLabel',
+        sortBy: this.$route?.query?.sort?.split(' ')[0] || 'prefLabel',
+        sortDesc: this.$route?.query?.sort?.split(' ')[1] === 'desc',
         filter: this.$route?.query?.query || null,
         fields: [
           {
@@ -119,14 +122,12 @@
           this.type === 'organisations' && {
             key: 'countryPrefLabel',
             sortable: true,
-            sortDirection: 'desc',
             label: this.$t('pages.collections.organisations.table.country'),
             class: 'text-center'
           },
           this.type === 'organisations' && {
             key: 'recordCount',
             sortable: true,
-            sortDirection: 'desc',
             label: this.$t('pages.collections.table.items'),
             class: 'text-right'
           }
@@ -171,6 +172,10 @@
       '$route.query.page'() {
         this.currentPage = Number(this.$route?.query?.page) || 1;
       },
+      '$route.query.sort'() {
+        this.sortBy = this.$route.query.sort.split(' ')[0];
+        this.sortDesc = this.$route.query.sort.split(' ')[1] === 'desc';
+      },
       'collections.length'() {
         this.totalResults  = this.collections.length;
       }
@@ -199,6 +204,9 @@
       onFiltered(filteredItems) {
         this.totalResults = filteredItems.length;
         this.updateRouteQuery({ query: this.filter });
+      },
+      onSortchanged(ctx) {
+        this.updateRouteQuery({ sort: `${ctx.sortBy} ${ctx.sortDesc ? 'desc' : 'asc'}` });
       },
       updateRouteQuery(newQuery) {
         this.$router.push({ ...this.$route, query: { ...this.$route.query, ...newQuery } });

--- a/packages/portal/src/components/entity/EntityTable.vue
+++ b/packages/portal/src/components/entity/EntityTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="entity-table">
     <b-row
       v-if="$fetchState.error"
       class="flex-md-row py-4"
@@ -11,7 +11,7 @@
       </b-col>
     </b-row>
     <b-form
-      class="search-form position-relative mb-4"
+      class="search-form position-relative"
       inline
       @submit.stop.prevent="() => {}"
     >
@@ -246,26 +246,33 @@
   @import '@europeana/style/scss/icons';
   @import '@europeana/style/scss/table';
 
-  .search-form {
-    border: 1px solid $bodygrey;
-  }
+  .entity-table {
 
-  td.table-name-cell {
-    overflow-wrap: anywhere;
-  }
+    .search-form {
+      margin-bottom: 1rem;
 
-  th.table-toggle-cell {
-    display: none;
-  }
-
-  .button-toggle {
-    background-color: transparent;
-    &::before {
-      font-size: 0.5rem;
+      @media (min-width: $bp-medium) {
+        margin-bottom: 2rem;
+      }
     }
 
-    &.show::before {
-      transform: rotateX(180deg);
+    td.table-name-cell {
+      overflow-wrap: anywhere;
+    }
+
+    th.table-toggle-cell {
+      display: none;
+    }
+
+    .button-toggle {
+      background-color: transparent;
+      &::before {
+        font-size: 0.5rem;
+      }
+
+      &.show::before {
+        transform: rotateX(180deg);
+      }
     }
   }
 </style>

--- a/packages/portal/src/components/entity/EntityTable.vue
+++ b/packages/portal/src/components/entity/EntityTable.vue
@@ -20,6 +20,7 @@
         role="searchbox"
         :placeholder="$t('pages.collections.table.searchPlaceholder')"
         :aria-label="$t('search.title')"
+        data-qa="entity table filter"
       />
     </b-form>
     <b-table
@@ -52,6 +53,7 @@
             <span
               v-if="data.item.altLabel"
               :lang="data.item.altLabelLang"
+              class="subtitle"
             >
               {{ data.item.altLabel }}
             </span>
@@ -70,6 +72,23 @@
         <span>
           {{ data.item.recordCount | localise }}
         </span>
+      </template>
+      <template
+        v-if="type === 'organisations'"
+        #cell(showDetails)="row"
+      >
+        <b-button
+          class="button-toggle button-icon-only icon-chevron"
+          :class="{'show': row.detailsShowing}"
+          variant="light-flat"
+          @click="row.toggleDetails"
+        />
+      </template>
+      <template
+        v-if="type === 'organisations'"
+        #row-details="row"
+      >
+        <span>{{ row.item.countryPrefLabel }}</span>
       </template>
     </b-table>
     <PaginationNavInput
@@ -117,19 +136,24 @@
           {
             key: 'prefLabel',
             sortable: true,
-            label: this.$t('pages.collections.table.name')
+            label: this.$t('pages.collections.table.name'),
+            class: 'table-name-cell'
           },
           this.type === 'organisations' && {
             key: 'countryPrefLabel',
             sortable: true,
             label: this.$t('pages.collections.organisations.table.country'),
-            class: 'text-center'
+            class: 'text-center d-none d-md-table-cell'
           },
           this.type === 'organisations' && {
             key: 'recordCount',
             sortable: true,
             label: this.$t('pages.collections.table.items'),
             class: 'text-right'
+          },
+          this.type === 'organisations' && {
+            key: 'showDetails',
+            class: 'table-toggle-cell d-md-none'
           }
         ],
         typeSingular: this.type.slice(0, -1),
@@ -144,8 +168,10 @@
         let collections = response.data[this.cacheKey];
         if (this.type === 'organisations') {
           collections = collections.map(this.organisationData);
+          this.collections = collections; // Do not freeze as _showDetails prop needs to be reactive for toggling the details display on small screens
+        } else {
+          this.collections = collections.map(Object.freeze);
         }
-        this.collections = collections.map(Object.freeze);
       } catch (e) {
         // TODO: set fetch state error from message
         console.error({ statusCode: 500, message: e.toString() });
@@ -222,5 +248,24 @@
 
   .search-form {
     border: 1px solid $bodygrey;
+  }
+
+  td.table-name-cell {
+    overflow-wrap: anywhere;
+  }
+
+  th.table-toggle-cell {
+    display: none;
+  }
+
+  .button-toggle {
+    background-color: transparent;
+    &::before {
+      font-size: 0.5rem;
+    }
+
+    &.show::before {
+      transform: rotateX(180deg);
+    }
   }
 </style>

--- a/packages/portal/src/components/generic/PaginationNavInput.vue
+++ b/packages/portal/src/components/generic/PaginationNavInput.vue
@@ -20,7 +20,6 @@
           :disabled="prevDisabled"
           :aria-hidden="prevDisabled"
           class="page-link"
-          :tabindex="prevDisabled && '-1'"
         >
           <span class="icon-arrow-down mr-1" />
           {{ $t('actions.previous') }}
@@ -51,7 +50,6 @@
           :disabled="nextDisabled"
           :aria-hidden="nextDisabled"
           class="page-link"
-          :tabindex="nextDisabled && '-1'"
         >
           {{ $t('actions.next') }}
           <span class="icon-arrow-down ml-1" />

--- a/packages/portal/src/components/generic/SmartLink.vue
+++ b/packages/portal/src/components/generic/SmartLink.vue
@@ -3,6 +3,7 @@
     v-if="useRouterLink"
     :to="path"
     :class="linkClass"
+    :disabled="disabled"
     @click.capture.native="logSearchLink && setLoggableInteraction()"
   >
     <slot />
@@ -12,6 +13,7 @@
     :href="path"
     :target="isExternalLink ? '_blank' : '_self'"
     :class="[{ 'is-external-link' : isExternalLink && !hideExternalIcon }, linkClass]"
+    :disabled="disabled"
   >
     <slot /><!-- This comment removes white space which gets underlined
  --><span
@@ -36,13 +38,15 @@
         type: [String, Object],
         default: ''
       },
-
       linkClass: {
         type: String,
         default: ''
       },
-
       hideExternalIcon: {
+        type: Boolean,
+        default: false
+      },
+      disabled: {
         type: Boolean,
         default: false
       }

--- a/packages/portal/src/components/search/SearchQueryOptions.vue
+++ b/packages/portal/src/components/search/SearchQueryOptions.vue
@@ -216,6 +216,9 @@
         if (newVal) {
           this.trackSuggestionClick(newVal);
         }
+      },
+      onSearchablePage() {
+        return this.$store.state.search.active;
       }
     },
 
@@ -284,10 +287,9 @@
       },
 
       linkGen(queryTerm, path) {
-        const query = {
-          ...this.$route.query,
-          query: queryTerm || ''
-        };
+        const query = this.onSearchablePage ? { ...this.$route.query } : {};
+        query.query = queryTerm || '';
+
         return {
           path: path || this.localePath({
             name: 'search'

--- a/packages/portal/src/components/stories/StoriesTagsDropdown.vue
+++ b/packages/portal/src/components/stories/StoriesTagsDropdown.vue
@@ -13,6 +13,7 @@
     >
       <b-form
         class="search-form"
+        :class="{ 'show': showDropdown}"
         inline
         @submit.stop.prevent="() => {}"
       >
@@ -154,7 +155,9 @@
   z-index: 20;
   box-shadow: $boxshadow;
   padding: 0.5rem 0 0 0.5rem;
-  border-top: 1px solid $middlegrey;
+  border: 1px solid $bodygrey;
+  border-bottom-left-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
 
   @media (min-width: $bp-4k) {
     font-size: 1.5rem;
@@ -175,8 +178,9 @@
   }
 }
 
-.form-inline {
-  box-shadow: $boxshadow-light;
-  border-radius: 0;
+.search-form.show {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+
 }
 </style>

--- a/packages/portal/src/components/stories/StoriesTagsDropdown.vue
+++ b/packages/portal/src/components/stories/StoriesTagsDropdown.vue
@@ -13,7 +13,7 @@
     >
       <b-form
         class="search-form"
-        :class="{ 'show': showDropdown}"
+        :class="{ 'show': showDropdown }"
         inline
         @submit.stop.prevent="() => {}"
       >

--- a/packages/portal/src/lang/en.js
+++ b/packages/portal/src/lang/en.js
@@ -985,11 +985,6 @@ export default {
     "collections": {
       "organisations": {
         "description": "Explore the institutions which share digital cultural heritage items on Europeana.eu.",
-        "table": {
-          "country": "Country",
-          "name": "Name",
-          "showMoreData": "Show more data for {organisation}"
-        },
         "title": "Institutions"
       },
       "persons": {
@@ -999,9 +994,11 @@ export default {
         "title": "Places"
       },
       "table": {
+        "country": "Country",
         "items": "Items",
         "name": "Name",
-        "searchPlaceholder": "Search within table"
+        "searchPlaceholder": "Search within table",
+        "showMoreData": "Show more data for {entity}"
       },
       "times": {
         "title": "Centuries"

--- a/packages/portal/src/lang/en.js
+++ b/packages/portal/src/lang/en.js
@@ -997,7 +997,8 @@ export default {
       },
       "table": {
         "items": "Items",
-        "name": "Name"
+        "name": "Name",
+        "searchPlaceholder": "Search within table"
       },
       "times": {
         "title": "Centuries"

--- a/packages/portal/src/lang/en.js
+++ b/packages/portal/src/lang/en.js
@@ -987,7 +987,8 @@ export default {
         "description": "Explore the institutions which share digital cultural heritage items on Europeana.eu.",
         "table": {
           "country": "Country",
-          "name": "Name"
+          "name": "Name",
+          "showMoreData": "Show more data for {organisation}"
         },
         "title": "Institutions"
       },

--- a/packages/portal/src/lang/en.js
+++ b/packages/portal/src/lang/en.js
@@ -986,6 +986,7 @@ export default {
       "organisations": {
         "description": "Explore the institutions which share digital cultural heritage items on Europeana.eu.",
         "table": {
+          "country": "Country",
           "name": "Name"
         },
         "title": "Institutions"

--- a/packages/portal/src/lang/en.js
+++ b/packages/portal/src/lang/en.js
@@ -984,10 +984,11 @@ export default {
   "pages": {
     "collections": {
       "organisations": {
+        "description": "Explore the institutions which share digital cultural heritage items on Europeana.eu.",
         "table": {
           "name": "Name"
         },
-        "title": "Organisations"
+        "title": "Institutions"
       },
       "persons": {
         "title": "Persons"

--- a/packages/portal/src/pages/collections/_type/_.vue
+++ b/packages/portal/src/pages/collections/_type/_.vue
@@ -294,6 +294,7 @@
           const langMapValue = langMapValueForLocale(this.entity.acronym, this.$i18n.locale);
           labelledMoreInfo.push({ label: this.$t('organisation.nameAcronym'), value: langMapValue.values[0], lang: langMapValue.code });
         }
+        // TODO: Update to use API country field?
         if (this.entity?.hasAddress?.countryName)  {
           labelledMoreInfo.push({ label: this.$t('organisation.country'), value: this.entity.hasAddress.countryName });
         }

--- a/packages/portal/src/pages/collections/_type/index.vue
+++ b/packages/portal/src/pages/collections/_type/index.vue
@@ -8,10 +8,11 @@
     <b-container
       v-else
     >
+      <!-- Replace media URL when available or a default placeholder is implemented -->
       <ContentHeader
         :title="pageMeta.title"
         :description="pageMeta.description"
-        :media-url="pageMeta.image"
+        :media-url="'/'"
         button-variant="secondary"
         class="half-col"
       />
@@ -56,8 +57,7 @@
       pageMeta() {
         return {
           title: this.$t(`pages.collections.${this.$route.params.type}.title`),
-          description: this.description,
-          image: require('@europeana/style/img/logo.svg')
+          description: this.description
         };
       }
     },

--- a/packages/portal/src/pages/collections/_type/index.vue
+++ b/packages/portal/src/pages/collections/_type/index.vue
@@ -19,7 +19,7 @@
         <EntityTable
           :type="$route.params.type"
           data-qa="collections table"
-          class="mt-4"
+          class="mt-3 mt-md-4"
         />
       </client-only>
     </b-container>

--- a/packages/portal/src/pages/collections/_type/index.vue
+++ b/packages/portal/src/pages/collections/_type/index.vue
@@ -10,11 +10,16 @@
     >
       <ContentHeader
         :title="pageMeta.title"
+        :description="pageMeta.description"
+        :media-url="pageMeta.image"
+        button-variant="secondary"
+        class="half-col"
       />
       <client-only>
         <EntityTable
           :type="$route.params.type"
           data-qa="collections table"
+          class="mt-4"
         />
       </client-only>
     </b-container>
@@ -45,9 +50,14 @@
     },
 
     computed: {
+      description() {
+        return this.$route.params.type === 'organisations' ? this.$t('pages.collections.organisations.description') : null;
+      },
       pageMeta() {
         return {
-          title: this.$t(`pages.collections.${this.$route.params.type}.title`)
+          title: this.$t(`pages.collections.${this.$route.params.type}.title`),
+          description: this.description,
+          image: require('@europeana/style/img/logo.svg')
         };
       }
     },

--- a/packages/portal/tests/size/.size-limit.json
+++ b/packages/portal/tests/size/.size-limit.json
@@ -19,7 +19,7 @@
   {
     "name": "portal.js server",
     "running": false,
-    "limit": "990 KB",
+    "limit": "995 KB",
     "path": [
       ".nuxt/dist/server/*.js"
     ]

--- a/packages/portal/tests/unit/cachers/collections/organisations.spec.js
+++ b/packages/portal/tests/unit/cachers/collections/organisations.spec.js
@@ -1,11 +1,13 @@
 import * as cacher from '@/cachers/collections/organisations.js';
 import * as baseCacher from '@/cachers/collections/index.js';
+import countryCodes from 'i18n-iso-countries';
 import sinon from 'sinon';
 import nock from 'nock';
 
 const organisations = [
-  { id: 'http://data.europeana.eu/organization/001', type: 'Organization', prefLabel: { en: 'Museum', es: 'Museo' } },
-  { id: 'http://data.europeana.eu/organization/002', type: 'Organization', prefLabel: { en: 'Gallery' } }
+  { id: 'http://data.europeana.eu/organization/001', type: 'Organization', prefLabel: { en: 'Museum', es: 'Museo' }, country: 'ES' },
+  { id: 'http://data.europeana.eu/organization/002', type: 'Organization', prefLabel: { en: 'Gallery' }, country: 'http://data.europeana.eu/place/001' },
+  { id: 'http://data.europeana.eu/organization/002', type: 'Organization', prefLabel: { en: 'Archive' } }
 ];
 
 const fields = [
@@ -14,16 +16,24 @@ const fields = [
   { label: 'http://data.europeana.eu/organization/003', count: 150 }
 ];
 
-const apiResponse = {
+const apiFacetResponse = {
   facets: [{
     name: 'foaf_organization',
     fields
   }]
 };
 
+const apiPlaceResponse = {
+  prefLabel: { en: 'France' }
+};
+
 const config = {
   europeana: {
     apis: {
+      entity: {
+        url: 'https://api.example.org/entity',
+        key: 'entityApiKey'
+      },
       record: {
         url: 'https://api.example.org/record',
         key: 'recordApiKey'
@@ -42,14 +52,27 @@ const mockFacetRequest = () => {
         query['f.foaf_organization.facet.limit'] === '10000' &&
         query.rows === '0'
     ))
-    .reply(200, apiResponse);
+    .reply(200, apiFacetResponse);
+};
+
+const mockPlaceRequest = () => {
+  nock(config.europeana.apis.entity.url)
+    .get('/place/001.json')
+    .query(query => query.wskey === config.europeana.apis.entity.key)
+    .reply(200, apiPlaceResponse);
+};
+
+const mockApiRequests = () => {
+  mockFacetRequest();
+  mockPlaceRequest();
 };
 
 describe('@/cachers/collections/organisations', () => {
   sinon.stub(baseCacher, 'default').resolves(organisations);
+  sinon.stub(countryCodes, 'getName').withArgs('ES', 'en', { select: 'official' }).returns('Spain');
 
   it('fetches data with type: organization', async() => {
-    mockFacetRequest();
+    mockApiRequests();
     await cacher.data(config);
 
     expect(baseCacher.default.calledWith({ type: 'organization' }, config)).toBe(true);
@@ -57,7 +80,7 @@ describe('@/cachers/collections/organisations', () => {
   });
 
   it('picks slug, recordCount and prefLabel', () => {
-    expect(cacher.PICK).toEqual(['slug', 'recordCount', 'prefLabel']);
+    expect(cacher.PICK).toEqual(['slug', 'recordCount', 'prefLabel', 'country', 'countryPrefLabel']);
   });
 
   it('localises nothing', () => {
@@ -66,12 +89,39 @@ describe('@/cachers/collections/organisations', () => {
 
   describe('when there is no fields on the facets response', () => {
     it('recordCount falls back to 0', async() => {
-      apiResponse.facets[0].fields = null;
-      mockFacetRequest();
+      apiFacetResponse.facets[0].fields = null;
+      mockApiRequests();
       const organisationData = await cacher.data(config);
 
       expect(organisationData[0].recordCount).toBe(0);
-      apiResponse.fields = fields;
+      apiFacetResponse.fields = fields;
+    });
+  });
+
+  describe('when the country on the organisation entity is an entity reference', () => {
+    it('fetches the place entity prefLabel', async() => {
+      mockApiRequests();
+      const organisationData = await cacher.data(config);
+
+      expect(organisationData[1].countryPrefLabel).toEqual(apiPlaceResponse.prefLabel);
+    });
+  });
+
+  describe('when the country on the organisation entity is a language code', () => {
+    it('fetches the place entity prefLabel', async() => {
+      mockApiRequests();
+      const organisationData = await cacher.data(config);
+
+      expect(organisationData[0].countryPrefLabel).toEqual({ en: 'Spain' });
+    });
+  });
+
+  describe('when there is no country on the organisation entity', () => {
+    it('does not include a countryPrefLabel', async() => {
+      mockApiRequests();
+      const organisationData = await cacher.data(config);
+
+      expect(organisationData[2].countryPrefLabel).toEqual(undefined);
     });
   });
 });

--- a/packages/portal/tests/unit/cachers/collections/organisations.spec.js
+++ b/packages/portal/tests/unit/cachers/collections/organisations.spec.js
@@ -80,11 +80,11 @@ describe('@/cachers/collections/organisations', () => {
   });
 
   it('picks slug, recordCount and prefLabel', () => {
-    expect(cacher.PICK).toEqual(['slug', 'recordCount', 'prefLabel', 'country', 'countryPrefLabel']);
+    expect(cacher.PICK).toEqual(['slug', 'recordCount', 'prefLabel', 'countryPrefLabel']);
   });
 
-  it('localises nothing', () => {
-    expect(cacher.LOCALISE).toBeUndefined();
+  it('localises countryPrefLabel', () => {
+    expect(cacher.LOCALISE).toEqual('countryPrefLabel');
   });
 
   describe('when there is no fields on the facets response', () => {

--- a/packages/portal/tests/unit/components/entity/EntityTable.spec.js
+++ b/packages/portal/tests/unit/components/entity/EntityTable.spec.js
@@ -187,15 +187,13 @@ describe('components/entity/EntityTable', () => {
 
   describe('when the table is sorted', () => {
     it('updates the route query', async() => {
-      const newSortField = 'recordCount';
-      const newSortDirection = 'desc';
       const wrapper = factory();
       sinon.spy(wrapper.vm, 'updateRouteQuery');
 
-      wrapper.vm.onSortchanged({ sortBy: newSortField, sortDesc: true });
-      await wrapper.vm.$nextTick();
+      const recordCountTh = wrapper.find('[aria-colindex="3"]');
+      await recordCountTh.trigger('click');
 
-      expect(wrapper.vm.updateRouteQuery.calledWith({ sort: `${newSortField} ${newSortDirection}` })).toBe(true);
+      expect(wrapper.vm.updateRouteQuery.calledWith({ sort: 'recordCount asc' })).toBe(true);
     });
   });
 });

--- a/packages/portal/tests/unit/components/entity/EntityTable.spec.js
+++ b/packages/portal/tests/unit/components/entity/EntityTable.spec.js
@@ -27,10 +27,10 @@ const factory = (propsData = { type: 'organisations' }, fetchState = { error: fa
   stubs: ['SmartLink']
 });
 
-const middlewarePath = '/_api/cache/collections/organisations';
+const middlewarePath = '/_api/cache/en/collections/organisations';
 const collections = [
-  { slug: '001-museum', prefLabel: { de: 'museum', en: 'museum' }, countryPrefLabel: { de: 'Deutschland' } },
-  { slug: '002-library', prefLabel: { nl: 'bibliotheek', en: 'library' }, countryPrefLabel: { nl: 'Nederland' }  }
+  { slug: '001-museum', prefLabel: { de: 'museum', en: 'museum' }, countryPrefLabel: 'Deutschland' },
+  { slug: '002-library', prefLabel: { nl: 'bibliotheek', en: 'library' }, countryPrefLabel: 'Nederland' }
 ];
 
 const organisations = [
@@ -55,7 +55,7 @@ const organisations = [
 describe('components/entity/EntityTable', () => {
   describe('fetch()', () => {
     beforeEach(() => {
-      $axiosGetStub.withArgs(middlewarePath).resolves({ data: { 'collections/organisations': collections } });
+      $axiosGetStub.withArgs(middlewarePath).resolves({ data: { 'en/collections/organisations': collections } });
     });
 
     afterEach(() => {

--- a/packages/portal/tests/unit/components/entity/EntityTable.spec.js
+++ b/packages/portal/tests/unit/components/entity/EntityTable.spec.js
@@ -20,7 +20,7 @@ const factory = (propsData = { type: 'organisations' }, fetchState = { error: fa
     },
     $t: (val) => val,
     $i18n: { locale: 'en' },
-    $route: { query: { page: 1, query: null } },
+    $route: { query: { page: 1, query: null, sort: null } },
     $router: { push: () => {} }
   }
 });
@@ -122,7 +122,7 @@ describe('components/entity/EntityTable', () => {
     });
   });
 
-  describe('when the route query page updates', () => {
+  describe('when the route page query updates', () => {
     it('updates the current table page', async() => {
       const wrapper = factory();
 
@@ -143,17 +143,57 @@ describe('components/entity/EntityTable', () => {
     });
   });
 
+  describe('when the route sort query updates', () => {
+    it('updates the current table sort order and field', async() => {
+      const wrapper = factory();
+      const sortField = 'countryPrefLabel';
+      const sortDirection = 'desc';
+
+      wrapper.vm.$route.query.sort = `${sortField} ${sortDirection}`;
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.sortBy).toEqual(sortField);
+      expect(wrapper.vm.sortDesc).toEqual(true);
+    });
+    describe('when falsy value', () => {
+      it('falls back to sorting on the name in asc order', async() => {
+        const wrapper = factory();
+
+        wrapper.vm.$route.query.sort = null;
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.vm.sortBy).toEqual('prefLabel');
+        expect(wrapper.vm.sortDesc).toEqual(false);
+      });
+    });
+  });
+
   describe('when the table is filtered', () => {
     it('updates total results and updates the route query', async() => {
+      const newQuery = 'museum';
       const wrapper = factory();
       sinon.spy(wrapper.vm, 'updateRouteQuery');
 
-      wrapper.vm.filter = 'museum';
+      wrapper.vm.filter = newQuery;
       wrapper.vm.onFiltered([organisations[0]]);
       await wrapper.vm.$nextTick();
 
       expect(wrapper.vm.totalResults).toEqual(1);
-      expect(wrapper.vm.updateRouteQuery.calledWith({ query: 'museum' })).toBe(true);
+      expect(wrapper.vm.updateRouteQuery.calledWith({ query: newQuery })).toBe(true);
+    });
+  });
+
+  describe('when the table is sorted', () => {
+    it('updates the route query', async() => {
+      const newSortField = 'recordCount';
+      const newSortDirection = 'desc';
+      const wrapper = factory();
+      sinon.spy(wrapper.vm, 'updateRouteQuery');
+
+      wrapper.vm.onSortchanged({ sortBy: newSortField, sortDesc: true });
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.updateRouteQuery.calledWith({ sort: `${newSortField} ${newSortDirection}` })).toBe(true);
     });
   });
 });

--- a/packages/portal/tests/unit/components/entity/EntityTable.spec.js
+++ b/packages/portal/tests/unit/components/entity/EntityTable.spec.js
@@ -1,5 +1,5 @@
 import { createLocalVue } from '@vue/test-utils';
-import { shallowMountNuxt } from '../../utils';
+import { mountNuxt } from '../../utils';
 import sinon from 'sinon';
 import BootstrapVue from 'bootstrap-vue';
 
@@ -10,7 +10,7 @@ localVue.use(BootstrapVue);
 
 const $axiosGetStub = sinon.stub();
 
-const factory = (propsData = { type: 'organisations' }, fetchState = { error: false, pending: false }) => shallowMountNuxt(EntityTable, {
+const factory = (propsData = { type: 'organisations' }, fetchState = { error: false, pending: false }) => mountNuxt(EntityTable, {
   localVue,
   propsData,
   mocks: {
@@ -21,14 +21,16 @@ const factory = (propsData = { type: 'organisations' }, fetchState = { error: fa
     $t: (val) => val,
     $i18n: { locale: 'en' },
     $route: { query: { page: 1, query: null, sort: null } },
-    $router: { push: () => {} }
-  }
+    $router: { push: () => {} },
+    localePath: () => '/'
+  },
+  stubs: ['SmartLink']
 });
 
 const middlewarePath = '/_api/cache/collections/organisations';
 const collections = [
-  { slug: '001-museum', prefLabel: { de: 'museum', en: 'museum' } },
-  { slug: '002-library', prefLabel: { nl: 'bibliotheek', en: 'library' } }
+  { slug: '001-museum', prefLabel: { de: 'museum', en: 'museum' }, countryPrefLabel: { de: 'Deutschland' } },
+  { slug: '002-library', prefLabel: { nl: 'bibliotheek', en: 'library' }, countryPrefLabel: { nl: 'Nederland' }  }
 ];
 
 const organisations = [
@@ -37,14 +39,16 @@ const organisations = [
     prefLabel: 'museum',
     prefLabelLang: 'de',
     altLabel: 'museum',
-    altLabelLang: null
+    altLabelLang: null,
+    countryPrefLabel: 'Deutschland'
   },
   {
     slug: '002-library',
     prefLabel: 'bibliotheek',
     prefLabelLang: 'nl',
     altLabel: 'library',
-    altLabelLang: null
+    altLabelLang: null,
+    countryPrefLabel: 'Nederland'
   }
 ];
 
@@ -169,16 +173,14 @@ describe('components/entity/EntityTable', () => {
   });
 
   describe('when the table is filtered', () => {
-    it('updates total results and updates the route query', async() => {
+    it('updates the route query', async() => {
       const newQuery = 'museum';
       const wrapper = factory();
       sinon.spy(wrapper.vm, 'updateRouteQuery');
 
-      wrapper.vm.filter = newQuery;
-      wrapper.vm.onFiltered([organisations[0]]);
+      wrapper.find('[data-qa="entity table filter"]').setValue(newQuery);
       await wrapper.vm.$nextTick();
 
-      expect(wrapper.vm.totalResults).toEqual(1);
       expect(wrapper.vm.updateRouteQuery.calledWith({ query: newQuery })).toBe(true);
     });
   });

--- a/packages/portal/tests/unit/components/entity/EntityTable.spec.js
+++ b/packages/portal/tests/unit/components/entity/EntityTable.spec.js
@@ -20,7 +20,7 @@ const factory = (propsData = { type: 'organisations' }, fetchState = { error: fa
     },
     $t: (val) => val,
     $i18n: { locale: 'en' },
-    $route: { query: { page: 1, query: null, sort: null } },
+    $route: { query: { page: 1, filter: null, sort: null } },
     $router: { push: () => {} },
     localePath: () => '/'
   },
@@ -110,7 +110,7 @@ describe('components/entity/EntityTable', () => {
     it('filters the table on the query', async() => {
       const wrapper = factory();
 
-      wrapper.vm.$route.query.query = newQuery;
+      wrapper.vm.$route.query.filter = newQuery;
       await wrapper.vm.$nextTick();
 
       expect(wrapper.vm.filter).toEqual(newQuery);
@@ -119,7 +119,7 @@ describe('components/entity/EntityTable', () => {
       const wrapper = factory();
       sinon.spy(wrapper.vm, 'updateRouteQuery');
 
-      wrapper.vm.$route.query.query = newQuery;
+      wrapper.vm.$route.query.filter = newQuery;
       await wrapper.vm.$nextTick();
 
       expect(wrapper.vm.updateRouteQuery.calledWith({ page: 1 })).toBe(true);
@@ -181,7 +181,7 @@ describe('components/entity/EntityTable', () => {
       wrapper.find('[data-qa="entity table filter"]').setValue(newQuery);
       await wrapper.vm.$nextTick();
 
-      expect(wrapper.vm.updateRouteQuery.calledWith({ query: newQuery })).toBe(true);
+      expect(wrapper.vm.updateRouteQuery.calledWith({ filter: newQuery })).toBe(true);
     });
   });
 

--- a/packages/style/scss/form.scss
+++ b/packages/style/scss/form.scss
@@ -223,6 +223,7 @@ h3.facet-label,
   padding-left: 2.5em;
   height: auto;
   border-radius: 0.5em;
+  border: 1px solid $bodygrey;
   width: 100%;
 
   @media (min-width: $bp-4k) {

--- a/packages/style/scss/table.scss
+++ b/packages/style/scss/table.scss
@@ -18,6 +18,7 @@ table,
 
     div {
       display: inline-block;
+      white-space: nowrap; // prevents the sort toggle from wrapping under the label
     }
   }
 
@@ -46,14 +47,14 @@ table,
       display: block;
     }
 
-    strong + span {
+    strong + .subtitle {
       font-size: $font-size-extrasmall;
       line-height: 1.25rem;
       color: $mediumgrey;
       text-transform: uppercase;
     }
 
-    a:hover strong + span {
+    a:hover strong + .subtitle {
       color: inherit;
     }
   }

--- a/packages/style/scss/table.scss
+++ b/packages/style/scss/table.scss
@@ -70,6 +70,12 @@ table,
       font-size: 1rem;
       margin-left: 0.5rem;
       display: inline-block;
+      transition: $standard-transition;
+    }
+
+    &[aria-sort='ascending'] div::after,
+    &[aria-sort='descending'] div::after {
+      color: $innovationblue;
     }
 
     &[aria-sort='descending'] div::after {
@@ -77,7 +83,7 @@ table,
     }
 
     &:hover div::after {
-      color: $innovationblue;
+      color: $black;
     }
   }
 


### PR DESCRIPTION
- Updates the organisations cacher to retrieve the country from entity API and manipulate the value to a prefLabel: 
  - Production entity API returns a country code: uses `i18n-iso-countries` to get prefLabels. (no Maltese (mt) support)
  - Acceptance entity API returns entity URI. Does a prefLabel look up for each country
  - Localises the country prefLabel
- Adds search/filter feature to the EntityTable
- Adds pagination to the EntityTable
- Adds the country column for organisations type table
- Adds a row details slot for organisations type table to toggle display of (more) data on smaller screens
- Saves and applies the filter, sort and page queries in the URL
- Updates the search form styles (reused on Stories page)
- Prevents URL query parameters from Stories and collections type pages to persist to Search pages
- Adds a description (when available) and share button to the collections type page