### PR TITLE
refactor: mv truncate filter to a mixin

### DIFF
--- a/packages/portal/src/components/content/ContentCard.vue
+++ b/packages/portal/src/components/content/ContentCard.vue
@@ -49,7 +49,7 @@
           v-if="displayTitle"
           :lang="displayTitle.code"
         >
-          {{ displayTitle.value | truncate(90, $t('formatting.ellipsis')) }}
+          {{ truncate(displayTitle.value, 90) }}
         </span>
       </SmartLink>
       <b-card-body
@@ -77,7 +77,7 @@
               :title="(variant === 'mosaic' && displayTitle) ? displayTitle.value : null"
             >
               <span>
-                {{ displayTitle.value | truncate(90, $t('formatting.ellipsis')) }}
+                {{ truncate(displayTitle.value, 90) }}
               </span>
             </SmartLink>
           </b-card-title>
@@ -122,6 +122,7 @@
   import ClientOnly from 'vue-client-only';
   import SmartLink from '../generic/SmartLink';
   import stripMarkdownMixin from '@/mixins/stripMarkdown';
+  import truncateMixin from '@/mixins/truncate';
   import { langMapValueForLocale } from  '@/plugins/europeana/utils';
 
   export default {
@@ -134,7 +135,8 @@
     },
 
     mixins: [
-      stripMarkdownMixin
+      stripMarkdownMixin,
+      truncateMixin
     ],
 
     props: {
@@ -414,11 +416,11 @@
       cardText(values) {
         const limited = (this.limitValuesWithinEachText > -1) ? values.slice(0, this.limitValuesWithinEachText) : [].concat(values);
         if (values.length > limited.length) {
-          limited.push(this.$t('formatting.ellipsis'));
+          limited.push('…');
         }
-        const joined = limited.join(this.$t('formatting.listSeperator') + ' ');
+        const joined = limited.join('; ');
         const stripped = this.stripMarkdown(joined);
-        return this.$options.filters.truncate(stripped, 255, this.$t('formatting.ellipsis'));
+        return this.truncate(stripped, 255);
       },
 
       redrawMasonry() {

--- a/packages/portal/src/components/entity/EntityHeader.vue
+++ b/packages/portal/src/components/entity/EntityHeader.vue
@@ -94,6 +94,7 @@
 
 <script>
   import ClientOnly from 'vue-client-only';
+  import truncateMixin from '@/mixins/truncate';
   import { getWikimediaThumbnailUrl } from '@/plugins/europeana/entity';
   import ShareButton from '@/components/share/ShareButton';
   import ShareSocialModal from '@/components/share/ShareSocialModal';
@@ -108,6 +109,10 @@
       EntityUpdateModal: () => import('@/components/entity/EntityUpdateModal'),
       EntityInformationModal: () => import('@/components/entity/EntityInformationModal')
     },
+
+    mixins: [
+      truncateMixin
+    ],
 
     props: {
       /**
@@ -190,7 +195,7 @@
 
     computed: {
       truncatedDescription() {
-        return this.$options.filters.truncate(this.fullDescription, this.limitCharacters, this.$t('formatting.ellipsis'));
+        return this.truncate(this.fullDescription, this.limitCharacters);
       },
       hasDescription() {
         return (this.description?.values?.length || 0) >= 1;

--- a/packages/portal/src/components/item/ItemSummaryInfo.vue
+++ b/packages/portal/src/components/item/ItemSummaryInfo.vue
@@ -76,6 +76,7 @@
 
 <script>
   import MetadataOriginLabel from '../metadata/MetadataOriginLabel';
+  import truncateMixin from '@/mixins/truncate';
 
   export default {
     name: 'ItemSummaryInfo',
@@ -83,6 +84,10 @@
     components: {
       MetadataOriginLabel
     },
+
+    mixins: [
+      truncateMixin
+    ],
 
     props: {
       description: {
@@ -107,7 +112,7 @@
       },
       truncatedDescription() {
         if (this.description?.values) {
-          return this.$options.filters.truncate(this.description.values[0], this.limitCharacters, this.$t('formatting.ellipsis'));
+          return this.truncate(this.description.values[0], this.limitCharacters);
         }
         return false;
       },

--- a/packages/portal/src/components/metadata/MetadataField.vue
+++ b/packages/portal/src/components/metadata/MetadataField.vue
@@ -128,7 +128,7 @@
         const display = { ...this.langMappedValues };
 
         if (this.limitDisplayValues && (display.values.length > this.limit)) {
-          display.values = display.values.slice(0, this.limit).concat(this.$t('formatting.ellipsis'));
+          display.values = display.values.slice(0, this.limit).concat('…');
         }
         return display;
       },

--- a/packages/portal/src/lang/en.js
+++ b/packages/portal/src/lang/en.js
@@ -788,10 +788,6 @@ export default {
     "ourMission": "Our mission",
     "ourMissionQuote": "Europeana empowers the cultural heritage sector in its digital transformation. We develop expertise, tools and policies to embrace digital change and encourage partnerships that foster innovation."
   },
-  "formatting": {
-    "ellipsis": "…",
-    "listSeperator": ";"
-  },
   "galleries": {
     "description": "Explore our galleries",
     "galleries": "Gallery | Galleries",

--- a/packages/portal/src/mixins/truncate.js
+++ b/packages/portal/src/mixins/truncate.js
@@ -1,0 +1,12 @@
+export const truncate = (text, length = 30) => {
+  if (!text) {
+    return null;
+  }
+  return text.length > length ? text.substring(0, length) + '…' : text;
+};
+
+export default {
+  methods: {
+    truncate
+  }
+};

--- a/packages/portal/src/plugins/europeana/search.js
+++ b/packages/portal/src/plugins/europeana/search.js
@@ -7,7 +7,7 @@ import pick from 'lodash/pick.js';
 import {
   escapeLuceneSpecials, isLangMap, reduceLangMapsForLocale
 } from './utils.js';
-import { truncate } from '../vue-filters.js';
+import { truncate } from '@/mixins/truncate.js';
 
 // Some facets do not support enquoting of their field values.
 export const unquotableFacets = [

--- a/packages/portal/src/plugins/europeana/search.js
+++ b/packages/portal/src/plugins/europeana/search.js
@@ -7,7 +7,7 @@ import pick from 'lodash/pick.js';
 import {
   escapeLuceneSpecials, isLangMap, reduceLangMapsForLocale
 } from './utils.js';
-import { truncate } from '@/mixins/truncate.js';
+import { truncate } from '../../mixins/truncate.js';
 
 // Some facets do not support enquoting of their field values.
 export const unquotableFacets = [

--- a/packages/portal/src/plugins/vue-filters.js
+++ b/packages/portal/src/plugins/vue-filters.js
@@ -15,14 +15,6 @@ Vue.filter('localise', val => {
   return val.toLocaleString('en');
 });
 
-export const truncate = (text, length, ellipsis = '…') => {
-  if (!text) {
-    return null;
-  }
-  return text.length > length ? text.substring(0, length) + ellipsis : text;
-};
-Vue.filter('truncate', truncate);
-
 export const wordLength = text => text?.trim()?.match(/\w+/g)?.length || 0;
 Vue.filter('wordLength', wordLength);
 

--- a/packages/portal/src/server-middleware/api/jira-service-desk/feedback.js
+++ b/packages/portal/src/server-middleware/api/jira-service-desk/feedback.js
@@ -2,7 +2,8 @@ import axios from 'axios';
 import createHttpError from 'http-errors';
 
 import { errorHandler } from '../utils.js';
-import { truncate, wordLength } from '../../../plugins/vue-filters';
+import { wordLength } from '@/plugins/vue-filters.js';
+import { truncate } from '@/mixins/truncate.js';
 
 const JIRA_SERVICE_DESK_API_PATH = '/rest/servicedeskapi/request';
 const JSON_CONTENT_TYPE = 'application/json';

--- a/packages/portal/src/server-middleware/api/jira-service-desk/feedback.js
+++ b/packages/portal/src/server-middleware/api/jira-service-desk/feedback.js
@@ -2,8 +2,8 @@ import axios from 'axios';
 import createHttpError from 'http-errors';
 
 import { errorHandler } from '../utils.js';
-import { wordLength } from '@/plugins/vue-filters.js';
-import { truncate } from '@/mixins/truncate.js';
+import { wordLength } from '../../../plugins/vue-filters.js';
+import { truncate } from '../../../mixins/truncate.js';
 
 const JIRA_SERVICE_DESK_API_PATH = '/rest/servicedeskapi/request';
 const JSON_CONTENT_TYPE = 'application/json';

--- a/packages/portal/src/server-middleware/api/jira-service-desk/galleries.js
+++ b/packages/portal/src/server-middleware/api/jira-service-desk/galleries.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 import { errorHandler } from '../utils.js';
-import { truncate } from '../../../plugins/vue-filters';
+import { truncate } from '@/mixins/truncate.js';
 
 const JIRA_SERVICE_DESK_API_PATH = '/rest/servicedeskapi/request';
 const JSON_CONTENT_TYPE = 'application/json';

--- a/packages/portal/src/server-middleware/api/jira-service-desk/galleries.js
+++ b/packages/portal/src/server-middleware/api/jira-service-desk/galleries.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 import { errorHandler } from '../utils.js';
-import { truncate } from '@/mixins/truncate.js';
+import { truncate } from '../../../mixins/truncate.js';
 
 const JIRA_SERVICE_DESK_API_PATH = '/rest/servicedeskapi/request';
 const JSON_CONTENT_TYPE = 'application/json';

--- a/packages/portal/tests/unit/components/metadata/MetadataField.spec.js
+++ b/packages/portal/tests/unit/components/metadata/MetadataField.spec.js
@@ -120,7 +120,7 @@ describe('components/metadata/MetadataField', () => {
 
         const fieldValues = wrapper.findAll('[data-qa="metadata field"] ul [data-qa="literal value"]');
         expect(fieldValues.at(0).text()).toBe(props.fieldData.def[0]);
-        expect(fieldValues.at(1).text()).toBe('formatting.ellipsis');
+        expect(fieldValues.at(1).text()).toBe('…');
       });
 
       describe('URIs', () => {

--- a/packages/portal/tests/unit/mixins/truncate.spec.js
+++ b/packages/portal/tests/unit/mixins/truncate.spec.js
@@ -1,0 +1,47 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+
+import mixin from '@/mixins/truncate';
+
+const component = {
+  template: `
+    <div></div>
+  `,
+  mixins: [mixin]
+};
+
+const factory = () => shallowMount(component, {
+  localVue: createLocalVue()
+});
+
+describe('mixins/truncate', () => {
+  describe('methods', () => {
+    describe('truncate', () => {
+      it('returns null if text is falsy', () => {
+        const wrapper = factory();
+        const text = undefined;
+
+        const truncated = wrapper.vm.truncate(text);
+
+        expect(truncated).toBeNull();
+      });
+
+      it('returns full text if not too long', () => {
+        const wrapper = factory();
+        const text = 'short';
+
+        const truncated = wrapper.vm.truncate(text);
+
+        expect(truncated).toBe('short');
+      });
+
+      it('truncates text if needed, and adds ellipsis', () => {
+        const wrapper = factory();
+        const text = 'short';
+
+        const truncated = wrapper.vm.truncate(text, 3);
+
+        expect(truncated).toBe('sho…');
+      });
+    });
+  });
+});


### PR DESCRIPTION
* in prep for Vue 3, which has no filters
* add unit tests, which filter didn't have
* drop the ellipsis and list separator formatting strings from the English lang file, as the other UI languages all just have the same symbol anyway