### PR TITLE
chore: handle updated organisation entity URIs

### DIFF
--- a/packages/portal/src/cachers/collections/organisations.js
+++ b/packages/portal/src/cachers/collections/organisations.js
@@ -21,6 +21,7 @@ async function getRecordCounts() {
     rows: 0
   };
   const response = await axiosClient.get('/search.json', { params });
+
   return response.data?.facets?.[0]?.fields || [];
 }
 
@@ -63,10 +64,11 @@ const data = async(config = {}) => {
   return organisationData.map(
     organisation => {
       // Add recordCount
-      const organisationId = organisation.id;
-      const organisationWithCount = recordCounts.find(facet => facet.label === organisationId);
-      const recordCount = organisationWithCount?.count || 0;
-      organisation.recordCount = recordCount;
+      const organisationIds = [organisation.id].concat(organisation.sameAs || []).filter((uri) => isEntityUri(uri));
+      organisation.recordCount = recordCounts
+        .filter((facet) => organisationIds.includes(facet.label))
+        .map((facet) => facet.count)
+        .reduce((a, b) => a + b, 0);
 
       // Add countryPrefLabel with langmap prefLabel
       organisation.countryPrefLabel = organisationCountriesPrefLabels[organisation.country] || organisation.country;

--- a/packages/portal/src/plugins/europeana/entity.js
+++ b/packages/portal/src/plugins/europeana/entity.js
@@ -3,6 +3,14 @@ import md5 from 'md5';
 import EuropeanaApi from './apis/base.js';
 import { BASE_URL as EUROPEANA_DATA_URL } from './data.js';
 
+export const ENTITY_TYPES = [
+  { id: 'agent', qf: 'edm_agent', slug: 'person' },
+  { id: 'concept', qf: 'skos_concept', slug: 'topic' },
+  { id: 'organization', qf: 'foaf_organization', slug: 'organisation' },
+  { id: 'place', qf: 'edm_place', slug: 'place' },
+  { id: 'timespan', qf: 'edm_timespan', slug: 'time' }
+];
+
 export default class EuropeanaEntityApi extends EuropeanaApi {
   static ID = 'entity';
   static BASE_URL = 'https://api.europeana.eu/entity';
@@ -124,27 +132,24 @@ export function normalizeEntityId(id) {
 
 /**
  * Construct an entity-type-specific Record API query for an entity
- * @param {string} uri entity URI
+ * @param {string|string[]} uri entity URI(s)
  * @return {string} Record API query
  */
 export function getEntityQuery(uri) {
-  let entityQuery;
+  if (Array.isArray(uri)) {
+    return uri
+      .filter((u) => isEntityUri(u))
+      .map((u) => getEntityQuery(u))
+      .join(' OR ');
+  }
 
-  if (uri.includes('/concept/')) {
-    entityQuery = `skos_concept:"${uri}"`;
-  } else if (uri.includes('/agent/')) {
-    entityQuery = `edm_agent:"${uri}"`;
-  } else if (uri.includes('/timespan/')) {
-    entityQuery = `edm_timespan:"${uri}"`;
-  } else if (uri.includes('/organization/')) {
-    entityQuery = `foaf_organization:"${uri}"`;
-  } else if (uri.includes('/place/')) {
-    entityQuery = `edm_place:"${uri}"`;
+  const type = ENTITY_TYPES.find((type) => uri.includes(`/${type.id}/`));
+
+  if (type) {
+    return `${type.qf}:"${uri}"`;
   } else {
     throw new Error(`Unsupported entity URI "${uri}"`);
   }
-
-  return entityQuery;
 }
 
 /**
@@ -152,44 +157,29 @@ export function getEntityQuery(uri) {
  * optionally takes entity types as an array of values to check for.
  * Will return true/false
  * @param {string} uri A URI to check
- * @param {string[]} types the entity types to check, defaults to all.
  * @return {Boolean} true if the URI is a valid entity URI
  */
-export function isEntityUri(uri, types) {
-  types = types || ['concept', 'agent', 'place', 'timespan', 'organization'];
-  return RegExp(`^http://data\\.europeana\\.eu/(${types.join('|')})/\\d+$`).test(uri);
+export function isEntityUri(uri) {
+  const types = ENTITY_TYPES.map((type) => type.id);
+  return RegExp(`^${EUROPEANA_DATA_URL}/(${types.join('|')})/\\d+$`).test(uri);
 }
 
 /**
- * Retrieve the API name of the type using the human readable name
- * @param {string} type the type of the entity
+ * Retrieve the API name of the type using the human readable slug
+ * @param {string} slug the entity slug, e.g. "topic"
  * @return {string} retrieved API name of type
  */
-export function getEntityTypeApi(type) {
-  const names = {
-    place: 'place',
-    person: 'agent',
-    topic: 'concept',
-    time: 'timespan',
-    organisation: 'organization'
-  };
-  return type ? names[type] : null;
+export function getEntityTypeApi(slug) {
+  return ENTITY_TYPES.find((type) => type.slug === slug)?.id || null;
 }
 
 /**
  * Retrieve the human readable of the type using the API name
- * @param {string} type the type of the entity
+ * @param {string} id the id of the entity type, e.g. "concept"
  * @return {string} retrieved human readable name of type
  */
-export function getEntityTypeHumanReadable(type) {
-  const names = {
-    place: 'place',
-    agent: 'person',
-    concept: 'topic',
-    timespan: 'time',
-    organization: 'organisation'
-  };
-  return type ? names[type.toLowerCase()] : null;
+export function getEntityTypeHumanReadable(id) {
+  return ENTITY_TYPES.find((type) => type.id === id.toLowerCase())?.slug || null;
 }
 
 /**

--- a/packages/portal/tests/unit/cachers/collections/organisations.spec.js
+++ b/packages/portal/tests/unit/cachers/collections/organisations.spec.js
@@ -7,7 +7,7 @@ import nock from 'nock';
 const organisations = [
   { id: 'http://data.europeana.eu/organization/001', type: 'Organization', prefLabel: { en: 'Museum', es: 'Museo' }, country: 'ES' },
   { id: 'http://data.europeana.eu/organization/002', type: 'Organization', prefLabel: { en: 'Gallery' }, country: 'http://data.europeana.eu/place/001' },
-  { id: 'http://data.europeana.eu/organization/003', type: 'Organization', prefLabel: { en: 'Archive' }, sameAs: ['http://data.europeana.eu/organization/004'] }
+  { id: 'http://data.europeana.eu/organization/003', type: 'Organization', prefLabel: { en: 'Archive' }, sameAs: ['http://data.europeana.eu/organization/004', 'http://example.org/404'] }
 ];
 
 const fields = [

--- a/packages/portal/tests/unit/plugins/europeana/entity.spec.js
+++ b/packages/portal/tests/unit/plugins/europeana/entity.spec.js
@@ -478,8 +478,8 @@ describe('plugins/europeana/entity', () => {
     });
 
     describe('when multiple entity URIs supplied', () => {
-      const uris = ['http://data.europeana.eu/organization/12345', 'http://data.europeana.eu/organization/67890'];
-      it('queries on all, joined with OR', () => {
+      const uris = ['http://data.europeana.eu/organization/12345', 'http://data.europeana.eu/organization/67890', 'https://www.example.org/404'];
+      it('queries on all Europeana entities, joined with OR', () => {
         expect(getEntityQuery(uris)).toBe('foaf_organization:"http://data.europeana.eu/organization/12345" OR foaf_organization:"http://data.europeana.eu/organization/67890"');
       });
     });

--- a/packages/portal/tests/unit/plugins/europeana/entity.spec.js
+++ b/packages/portal/tests/unit/plugins/europeana/entity.spec.js
@@ -472,8 +472,15 @@ describe('plugins/europeana/entity', () => {
 
     describe('when entity is a place', () => {
       const uri = 'http://data.europeana.eu/place/12345';
-      it('queries on where', () => {
+      it('queries on edm_place', () => {
         expect(getEntityQuery(uri)).toBe(`edm_place:"${uri}"`);
+      });
+    });
+
+    describe('when multiple entity URIs supplied', () => {
+      const uris = ['http://data.europeana.eu/organization/12345', 'http://data.europeana.eu/organization/67890'];
+      it('queries on all, joined with OR', () => {
+        expect(getEntityQuery(uris)).toBe('foaf_organization:"http://data.europeana.eu/organization/12345" OR foaf_organization:"http://data.europeana.eu/organization/67890"');
       });
     });
 


### PR DESCRIPTION
The old entity URI is included in the sameAs property when retrieving the new entity data, so include the sameAs Europeana entity URI in:
1. Searches for items on the organisation entity collection page
2. Cached counts of items associated with the organisation entity, for the institutions page

Also DRY up the entity plugin by declaring entity types in a constant.