### PR TITLE
refactor: paginate over entities via `next` in response

### DIFF
--- a/packages/portal/src/cachers/collections/index.js
+++ b/packages/portal/src/cachers/collections/index.js
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { createEuropeanaApiClient } from '../utils.js';
 import { getLabelledSlug } from '../../plugins/europeana/utils.js';
 
@@ -20,21 +21,18 @@ export const countEntities = async(params = {}, config = {}) => {
   return response.data?.partOf?.total;
 };
 
-const pageOfEntityResults = (page, params = {}) => {
-  return axiosClient.get('/search', {
-    params: {
-      ...axiosClient.defaults.config,
-      query: '*:*',
-      scope: 'europeana',
-      sort: 'id',
-      page,
-      pageSize,
-      ...params
-    }
-  })
-    .then(response => response.data.items || [])
-    .then(items => items.map(entityWithSlug));
-};
+const firstPageOfEntityResults = (params = {}) => axiosClient.get('/search', {
+  params: {
+    ...axiosClient.defaults.config,
+    query: '*:*',
+    scope: 'europeana',
+    sort: 'id',
+    pageSize,
+    ...params
+  }
+});
+
+const nextPageOfEntityResults = (url) => axios.get(url);
 
 const entityWithSlug = (entity) => ({
   ...entity,
@@ -43,14 +41,15 @@ const entityWithSlug = (entity) => ({
 
 const allEntityResults = async(params) => {
   let allResults = [];
-  let page = 0; // Yes, the Entity API pagination starts at page 0. ¯\_(ツ)_/¯
   let pageOfResults;
+  let next;
 
   // the API allows 100 entities per request. Loop until all entities are retrieved.
-  while (!Array.isArray(pageOfResults) || pageOfResults.length > 0) {
-    pageOfResults = await pageOfEntityResults(page, params);
+  while (!Array.isArray(pageOfResults) || next) {
+    const response = await (next ? nextPageOfEntityResults(next) : firstPageOfEntityResults(params));
+    pageOfResults = (response.data.items || []).map(entityWithSlug);
     allResults = allResults.concat(pageOfResults);
-    page = page + 1;
+    next = response.data.next;
   }
 
   return allResults;

--- a/packages/portal/tests/unit/cachers/collections/index.spec.js
+++ b/packages/portal/tests/unit/cachers/collections/index.spec.js
@@ -22,7 +22,8 @@ const apiResponse = {
         },
         isShownBy: 'http://www.example.eu'
       }
-    ]
+    ],
+    next: 'https://api.example.org/entity/search?wskey=entityApiKey&query=*:*&scope=europeana&sort=id&pageSize=100&type=timespan&page=2'
   },
   pageTwo: {
     items: [
@@ -34,8 +35,7 @@ const apiResponse = {
         isShownBy: 'http://www.example.eu'
       }
     ]
-  },
-  pageThree: {}
+  }
 };
 
 const dataToCache = [
@@ -89,19 +89,15 @@ describe('cachers/collections/index', () => {
     beforeEach(() => {
       nock(config.europeana.apis.entity.url)
         .get('/search')
-        .query(query => query.type === ENTITY_TYPE && query.scope === ENTITY_SCOPE && query.page === '0')
+        .query(query => query.type === ENTITY_TYPE && query.scope === ENTITY_SCOPE)
         .reply(200, apiResponse.pageOne);
       nock(config.europeana.apis.entity.url)
         .get('/search')
-        .query(query => query.type === ENTITY_TYPE && query.scope === ENTITY_SCOPE && query.page === '1')
-        .reply(200, apiResponse.pageTwo);
-      nock(config.europeana.apis.entity.url)
-        .get('/search')
         .query(query => query.type === ENTITY_TYPE && query.scope === ENTITY_SCOPE && query.page === '2')
-        .reply(200, apiResponse.pageThree);
+        .reply(200, apiResponse.pageTwo);
     });
 
-    it('paginates over data', async() => {
+    it('paginates over data via `next` in response', async() => {
       await cacher(params, config);
 
       expect(nock.isDone()).toBe(true);


### PR DESCRIPTION
Entity API search pagination is due to be changed from starting at 0 to starting at 1.

Refactor our entity caching code to not explicitly request the page and increment it, but instead don’t specify it in the first request, then rely on the `next` property in the subsequent responses, which contains the URL of the next page in the set.

Doing so means that it will work with both scenarios, first page being 0 or 1, without the need for e.g. a feature toggle to switch between the two.