### PR TITLE
fix(workaround): retrieve each entity individually when finding

### DIFF
--- a/packages/portal/src/plugins/europeana/entity.js
+++ b/packages/portal/src/plugins/europeana/entity.js
@@ -60,20 +60,28 @@ export default class EuropeanaEntityApi extends EuropeanaApi {
    * @param {Object} params additional parameters sent to the API
    * @return {Array} entity data
    */
-  async find(entityUris, params = {}) {
+  async find(entityUris, params = {}) { // eslint-disable-line no-unused-vars
     if (entityUris?.length === 0) {
       return Promise.resolve([]);
     }
-    const q = entityUris.join('" OR "');
-    const searchParams = {
-      ...params,
-      query: `entity_uri:("${q}")`,
-      pageSize: entityUris.length
-    };
 
-    const response = await this.search(searchParams);
+    // const q = entityUris.join('" OR "');
+    // const searchParams = {
+    //   ...params,
+    //   query: `entity_uri:("${q}")`,
+    //   pageSize: entityUris.length
+    // };
+    //
+    // const response = await this.search(searchParams);
+    // const entities = response.entities || [];
 
-    return (response.entities || [])
+    const responses = await Promise.all(entityUris.map((uri) => {
+      const { type, id } = entityParamsFromUri(uri);
+      return this.get(type, id);
+    }));
+    const entities = responses.map((response) => response.entity);
+
+    return entities.filter(Boolean)
       // Preserve original order from arg
       .sort((a, b) => {
         const indexForA = entityUris.findIndex((uri) => a.id === uri);

--- a/packages/portal/src/plugins/europeana/entity.js
+++ b/packages/portal/src/plugins/europeana/entity.js
@@ -75,6 +75,9 @@ export default class EuropeanaEntityApi extends EuropeanaApi {
     // const response = await this.search(searchParams);
     // const entities = response.entities || [];
 
+    // NOTE: this is a temporary workaround to handle old entity organisation
+    //       IDs, because the Entity API will perform a redirect when the
+    //       individual entity is requested.
     const responses = await Promise.all(entityUris.map((uri) => {
       const { type, id } = entityParamsFromUri(uri);
       return this.get(type, id);

--- a/packages/portal/tests/unit/plugins/europeana/entity.spec.js
+++ b/packages/portal/tests/unit/plugins/europeana/entity.spec.js
@@ -142,30 +142,47 @@ describe('plugins/europeana/entity', () => {
 
     describe('find', () => {
       const uris = ['http://data.europeana.eu/agent/123', 'http://data.europeana.eu/concept/456'];
-      const uriQuery = 'entity_uri:("http://data.europeana.eu/agent/123" OR "http://data.europeana.eu/concept/456")';
-      const orderedEntitySearchResponse = {
-        items: [
-          { id: 'http://data.europeana.eu/agent/123' },
-          { id: 'http://data.europeana.eu/concept/456' }
-        ]
-      };
-      const unorderedEntitySearchResponse = {
-        items: [
-          { id: 'http://data.europeana.eu/concept/456' },
-          { id: 'http://data.europeana.eu/agent/123' }
-        ]
-      };
-      const searchEndpoint = '/search';
+      // const uriQuery = 'entity_uri:("http://data.europeana.eu/agent/123" OR "http://data.europeana.eu/concept/456")';
+      // const orderedEntitySearchResponse = {
+      //   items: [
+      //     { id: 'http://data.europeana.eu/agent/123' },
+      //     { id: 'http://data.europeana.eu/concept/456' }
+      //   ]
+      // };
+      // const unorderedEntitySearchResponse = {
+      //   items: [
+      //     { id: 'http://data.europeana.eu/concept/456' },
+      //     { id: 'http://data.europeana.eu/agent/123' }
+      //   ]
+      // };
+      // const searchEndpoint = '/search';
 
-      it('searches the API by entity URIs', async() => {
+      // it('searches the API by entity URIs', async() => {
+      //   nock(api.BASE_URL)
+      //     .get(searchEndpoint)
+      //     .query(query => query.query === uriQuery)
+      //     .reply(200, orderedEntitySearchResponse);
+      //
+      //   await (new api).find(uris);
+      //
+      //   expect(nock.isDone()).toBe(true);
+      // });
+
+      it('retrieves each entity individually (AS A WORKAROUND)', async() => {
         nock(api.BASE_URL)
-          .get(searchEndpoint)
-          .query(query => query.query === uriQuery)
-          .reply(200, orderedEntitySearchResponse);
+          .get('/agent/123.json')
+          .reply(200, { id: 'http://data.europeana.eu/agent/123' });
+        nock(api.BASE_URL)
+          .get('/concept/456.json')
+          .reply(200, { id: 'http://data.europeana.eu/concept/456' });
 
-        await (new api).find(uris);
+        const entities = await (new api).find(uris);
 
         expect(nock.isDone()).toBe(true);
+        expect(entities).toEqual([
+          { id: 'http://data.europeana.eu/agent/123' },
+          { id: 'http://data.europeana.eu/concept/456' }
+        ]);
       });
 
       it('resolves with a blank array if there are no URIs', async() => {
@@ -174,27 +191,27 @@ describe('plugins/europeana/entity', () => {
         expect(result).toEqual([]);
       });
 
-      it('preserves the order of the supplied URIs', async() => {
-        nock(api.BASE_URL)
-          .get(searchEndpoint)
-          .query(query => query.query === uriQuery)
-          .reply(200, unorderedEntitySearchResponse);
-
-        const entities = await (new api).find(uris);
-
-        expect(entities).toEqual(orderedEntitySearchResponse.items);
-      });
-
-      it('allows filtering by fl via params', async() => {
-        nock(api.BASE_URL)
-          .get(searchEndpoint)
-          .query(query => query.query === uriQuery && query.fl === 'skos_prefLabel.*,isShownBy,isShownBy.thumbnail,logo')
-          .reply(200, unorderedEntitySearchResponse);
-
-        const entities = await (new api).find(uris, { fl: 'skos_prefLabel.*,isShownBy,isShownBy.thumbnail,logo' });
-
-        expect(entities).toEqual(orderedEntitySearchResponse.items);
-      });
+      // it('preserves the order of the supplied URIs', async() => {
+      //   nock(api.BASE_URL)
+      //     .get(searchEndpoint)
+      //     .query(query => query.query === uriQuery)
+      //     .reply(200, unorderedEntitySearchResponse);
+      //
+      //   const entities = await (new api).find(uris);
+      //
+      //   expect(entities).toEqual(orderedEntitySearchResponse.items);
+      // });
+      //
+      // it('allows filtering by fl via params', async() => {
+      //   nock(api.BASE_URL)
+      //     .get(searchEndpoint)
+      //     .query(query => query.query === uriQuery && query.fl === 'skos_prefLabel.*,isShownBy,isShownBy.thumbnail,logo')
+      //     .reply(200, unorderedEntitySearchResponse);
+      //
+      //   const entities = await (new api).find(uris, { fl: 'skos_prefLabel.*,isShownBy,isShownBy.thumbnail,logo' });
+      //
+      //   expect(entities).toEqual(orderedEntitySearchResponse.items);
+      // });
     });
 
     describe('suggest', () => {


### PR DESCRIPTION
So that Entity API performs redirects when old organisation IDs are used.