### PR TITLE
refactor: use entity retrieve method to find entities

### DIFF
--- a/packages/portal/src/components/entity/EntityBadges.vue
+++ b/packages/portal/src/components/entity/EntityBadges.vue
@@ -27,10 +27,10 @@
 </template>
 
 <script>
+  import pick from 'lodash/pick.js';
+
   import collectionLinkGenMixin from '@/mixins/collectionLinkGen';
-
   import europeanaEntityLinks from '@/mixins/europeana/entities/entityLinks';
-
   import LinkBadge from '../generic/LinkBadge';
 
   export default {
@@ -84,13 +84,8 @@
 
     async fetch() {
       if (((this.entityUris?.length || 0) > 0) && ((this.relatedCollections?.length || 0) === 0)) {
-        const entities = await this.$apis.entity.find(this.entityUris, {
-          fl: 'skos_prefLabel.*,isShownBy,isShownBy.thumbnail,foaf_logo'
-        });
-
-        if (entities)  {
-          this.collections = entities;
-        }
+        const entities = await this.$apis.entity.find(this.entityUris);
+        this.collections = entities?.map((entity) => pick(entity, ['id', 'prefLabel', 'isShownBy', 'logo'])) || [];
         this.$emit('entitiesFromUrisFetched', this.collections);
       }
       this.$emit('fetched');

--- a/packages/portal/src/components/entity/EntityCardGroup.vue
+++ b/packages/portal/src/components/entity/EntityCardGroup.vue
@@ -29,6 +29,8 @@
 </template>
 
 <script>
+  import pick from 'lodash/pick.js';
+
   import collectionLinkGenMixin from '@/mixins/collectionLinkGen';
   import europeanaEntityLinks from '@/mixins/europeana/entities/entityLinks';
 
@@ -71,13 +73,8 @@
 
     async fetch() {
       if (this.entityUris?.length) {
-        const entities = await this.$apis.entity.find(this.entityUris, {
-          fl: 'skos_prefLabel.*,isShownBy,isShownBy.thumbnail,foaf_logo'
-        });
-
-        if (entities)  {
-          this.collections = entities;
-        }
+        const entities = await this.$apis.entity.find(this.entityUris);
+        this.collections = entities?.map((entity) => pick(entity, ['id', 'prefLabel', 'isShownBy', 'logo'])) || [];
       }
       this.$emit('fetched');
     }

--- a/packages/portal/src/pages/item/_.vue
+++ b/packages/portal/src/pages/item/_.vue
@@ -137,7 +137,8 @@
 
 <script>
   import ClientOnly from 'vue-client-only';
-  import isEmpty from 'lodash/isEmpty';
+  import isEmpty from 'lodash/isEmpty.js';
+  import pick from 'lodash/pick.js';
 
   import ItemDataProvider from '@/components/item/ItemDataProvider';
   import ItemHero from '@/components/item/ItemHero';
@@ -388,19 +389,14 @@
       },
 
       async fetchEntities() {
-        const params = {
-          fl: 'skos_prefLabel.*,isShownBy,isShownBy.thumbnail,foaf_logo'
-        };
         if (this.dataProviderEntityUri) {
           // Fetch related entities and the dataProvider entity.
           // If the entities can't be fetched, use existing data from the record for the dataProvider section
           try {
-            const entities = await this.$apis.entity.find([...this.relatedEntityUris, this.dataProviderEntityUri], params);
-
-            if (entities)  {
-              this.relatedCollections = entities.filter(entity => entity.id !== this.dataProviderEntityUri);
-              this.dataProviderEntity = entities.filter(entity => entity.id === this.dataProviderEntityUri)[0];
-            }
+            let entities = await this.$apis.entity.find([...this.relatedEntityUris, this.dataProviderEntityUri]);
+            entities = entities?.map((entity) => pick(entity, ['id', 'prefLabel', 'isShownBy', 'logo'])) || [];
+            this.relatedCollections = entities.filter((entity) => entity.id !== this.dataProviderEntityUri);
+            this.dataProviderEntity = entities.filter((entity) => entity.id === this.dataProviderEntityUri)[0] || null;
           } catch {
             // don't fall over
           } finally {
@@ -419,8 +415,8 @@
         } else if (this.relatedEntityUris.length > 0) {
           this.dataProviderEntity = null;
 
-          const entities  = await this.$apis.entity.find(this.relatedEntityUris, params);
-          this.relatedCollections = entities || [];
+          const entities = await this.$apis.entity.find(this.relatedEntityUris);
+          this.relatedCollections = entities?.map((entity) => pick(entity, ['id', 'prefLabel', 'isShownBy', 'logo'])) || [];
         } else {
           this.dataProviderEntity = null;
           this.relatedCollections = [];

--- a/packages/portal/src/plugins/europeana/entity.js
+++ b/packages/portal/src/plugins/europeana/entity.js
@@ -64,21 +64,28 @@ export default class EuropeanaEntityApi extends EuropeanaApi {
     if (entityUris?.length === 0) {
       return Promise.resolve([]);
     }
-    const q = entityUris.join('" OR "');
-    const searchParams = {
-      ...params,
-      query: `entity_uri:("${q}")`,
-      pageSize: entityUris.length
-    };
 
-    const response = await this.search(searchParams);
+    const entities = await this.retrieve(entityUris, params);
 
-    return (response.entities || [])
+    return (entities || [])
       // Preserve original order from arg
       .sort((a, b) => {
         const indexForA = entityUris.findIndex((uri) => a.id === uri);
         const indexForB = entityUris.findIndex((uri) => b.id === uri);
         return indexForA - indexForB;
+      });
+  }
+
+  retrieve(entityUris, params = {}) {
+    return this.axios.post('/retrieve', entityUris, {
+      params: {
+        ...this.axios.defaults.params,
+        ...params
+      }
+    })
+      .then((response) => response.data?.items)
+      .catch((error) => {
+        throw this.apiError(error);
       });
   }
 

--- a/packages/portal/tests/unit/pages/item/_.spec.js
+++ b/packages/portal/tests/unit/pages/item/_.spec.js
@@ -287,8 +287,7 @@ describe('pages/item/_.vue', () => {
             'http://data.europeana.eu/concept/1',
             'http://data.europeana.eu/timespan/1',
             'http://data.europeana.eu/place/1'
-          ],
-          { fl: 'skos_prefLabel.*,isShownBy,isShownBy.thumbnail,foaf_logo' }
+          ]
         )).toBe(true);
       });
 
@@ -485,8 +484,7 @@ describe('pages/item/_.vue', () => {
               'http://data.europeana.eu/concept/02',
               'http://data.europeana.eu/concept/03',
               'http://data.europeana.eu/organization/01'
-            ],
-            { fl: 'skos_prefLabel.*,isShownBy,isShownBy.thumbnail,foaf_logo' }
+            ]
           ];
           const successEntityResponse = [
             { id: 'http://data.europeana.eu/concept/47' },


### PR DESCRIPTION
As it's aware of old entity IDs.

It does not support field specification like the search method, so use lodash's pick to store only the needed fields.