### PR TITLE
fix: use retrieved entity ids as set keys

### DIFF
--- a/packages/portal/src/components/item/ItemPinModal.vue
+++ b/packages/portal/src/components/item/ItemPinModal.vue
@@ -128,10 +128,7 @@
          *     'entityUri2': { id: 'setId2', pinned: ['itemUri1', 'itemUri2'] },
          *   }
          */
-        sets: this.entityUris.reduce((memo, uri) => {
-          memo[uri] = this.setFactory();
-          return memo;
-        }, {})
+        sets: {}
       };
     },
 
@@ -184,6 +181,12 @@
         // Fetch the full entities first
         const entities = await this.$apis.entity.find(this.entityUris);
         this.entities = entities.map((entity) => pick(entity, 'id', 'prefLabel'));
+
+        // Initialise empty set objects
+        this.sets = this.entities.reduce((memo, entity) => {
+          memo[entity.id] = this.setFactory();
+          return memo;
+        }, {});
 
         const searchParams = {
           query: 'type:EntityBestItemsSet',

--- a/packages/portal/src/i18n/lang/en.js
+++ b/packages/portal/src/i18n/lang/en.js
@@ -1164,9 +1164,6 @@ export default {
       "saveItemToLikes": "Save this item to your Likes.",
       "update": "Update gallery"
     },
-    "entityBestBets": {
-      "title": "{entity} Page"
-    },
     "form": {
       "description": "Gallery description",
       "private": "Keep this gallery private",

--- a/packages/portal/src/mixins/europeana/entities/entityBestItemsSet.js
+++ b/packages/portal/src/mixins/europeana/entities/entityBestItemsSet.js
@@ -24,7 +24,7 @@ export default {
 
     entitySetTitle(entity) {
       return Object.entries(entity?.prefLabel || {}).reduce((memo, [lang, value]) => {
-        memo[lang] = this.$t('set.entityBestBets.title', { entity: Array.isArray(value) ? value[0] : value });
+        memo[lang] = Array.isArray(value) ? value[0] : value;
         return memo;
       }, {});
     },

--- a/packages/portal/tests/unit/mixins/europeana/entities/entityBestItemsSet.spec.js
+++ b/packages/portal/tests/unit/mixins/europeana/entities/entityBestItemsSet.spec.js
@@ -27,8 +27,8 @@ fixtures.entityPrefLabelArrays = {
   en: [fixtures.englishPrefLabel]
 };
 fixtures.setTitle = {
-  de: 'set.entityBestBets.title Deutsch',
-  en: 'set.entityBestBets.title English'
+  de: 'Deutsch',
+  en: 'English'
 };
 
 const factory = () => {


### PR DESCRIPTION
- uses the retrieved entity IDs for proper organisation entity handling
- Removes the `set.entityBestBets.title` string. That was used to create an entity best set title for each locale, but does not work as expected due to lazy loading of the i18n locales. That makes it impossible to access the string for each locale. Besides it does not really add any value to the title.