### PR TITLE
feat: redirect blog posts to stories

### DIFF
--- a/packages/portal/src/components/home/HomeLatestStories.vue
+++ b/packages/portal/src/components/home/HomeLatestStories.vue
@@ -18,7 +18,7 @@
         :title="card.name"
         :image-url="cardImage(card)"
         :image-optimisation-options="{ width: 960 }"
-        :url="cardLink(card)"
+        :url="contentfulEntryUrl(card)"
       />
     </b-card-group>
     <b-button
@@ -32,6 +32,7 @@
 
 <script>
   import ContentCard from '../content/ContentCard';
+  import { contentfulEntryUrl } from '@/utils/contentful/entry-url.js';
 
   export default {
     name: 'HomeLatestStories',
@@ -50,7 +51,8 @@
       const variables = {
         locale: this.$i18n.localeProperties.iso,
         preview: this.$route.query.mode === 'preview',
-        limit: 2
+        limit: 2,
+        redirectBlogsToStories: this.$features?.redirectBlogsToStories || false
       };
 
       const response = await this.$contentful.query('latestEditorialContent', variables);
@@ -58,22 +60,15 @@
 
       // Select three stories: at least one of each type, max two of each type;
       // sorted by date published, most recent first
-      this.cards = entries.blogPostingCollection.items
+      this.cards = (entries.blogPostingCollection?.items || [])
         .concat(entries.exhibitionPageCollection.items)
+        .concat((entries.storyCollection?.items || []))
         .sort((a, b) => new Date(b.datePublished) - new Date(a.datePublished))
         .slice(0, 3);
     },
 
     methods: {
-      cardLink(card) {
-        let link;
-        if (card['__typename'] === 'ExhibitionPage') {
-          link = { name: 'exhibitions-exhibition', params: { exhibition: card.identifier } };
-        } else if (card['__typename'] === 'BlogPosting') {
-          link = { name: 'blog-all', params: { pathMatch: card.identifier } };
-        }
-        return link;
-      },
+      contentfulEntryUrl,
 
       cardImage(card) {
         return card.primaryImageOfPage?.image?.url;

--- a/packages/portal/src/features/toggles.js
+++ b/packages/portal/src/features/toggles.js
@@ -3,6 +3,7 @@ export default [
   { name: 'acceptSetRecommendations' },
   { name: 'eventLogging' },
   { name: 'jiraServiceDeskFeedbackForm' },
+  { name: 'redirectBlogsToStories' },
   { name: 'rejectEntityRecommendations' },
   { name: 'storiesViewCounts' },
   { name: 'transcribathonCta' },

--- a/packages/portal/src/middleware/redirects.js
+++ b/packages/portal/src/middleware/redirects.js
@@ -1,16 +1,36 @@
-const redirects = {
-  'professionals': 'share-your-data'
-};
+export default ({ redirect, route, $features }) => {
+  const redirects = {
+    '/professionals': '/share-your-data'
+  };
+  if ($features?.redirectBlogsToStories) {
+    redirects['/blog'] = '/stories';
+    redirects['/blog/*'] = '/stories/*';
+  }
 
-export default ({ route, redirect }) => {
   for (const redirectFrom in redirects) {
+    let redirectTo = redirects[redirectFrom];
+
     const routePathParts = route.path.split('/');
-    const match = routePathParts[2] === redirectFrom;
-    const redirectTo = redirects[redirectFrom];
+    const locale = routePathParts[1];
+    const localelessPath = `/${routePathParts.slice(2).join('/')}`;
+
+    let match;
+    if (redirectFrom.endsWith('*')) {
+      const redirectFromPrefix = redirectFrom.slice(0, -1);
+      match = localelessPath.startsWith(redirectFromPrefix);
+      if (redirectTo.endsWith('*')) {
+        const redirectToPrefix = redirectTo.slice(0, -1);
+        const redirectToSuffix = localelessPath.slice(redirectFromPrefix.length);
+        redirectTo = `${redirectToPrefix}${redirectToSuffix}`;
+      }
+    } else {
+      match = localelessPath === redirectFrom;
+    }
 
     if (match) {
-      return redirect(`/${routePathParts[1]}/${redirectTo}`);
+      return redirect(`/${locale}${redirectTo}`);
     }
   }
+
   return null;
 };

--- a/packages/portal/src/modules/contentful/queries/entity-related-content.graphql
+++ b/packages/portal/src/modules/contentful/queries/entity-related-content.graphql
@@ -3,12 +3,13 @@ query EntityRelatedContent(
   $preview: Boolean = false,
   $limit: Int = 4,
   $entityUri: String!,
-  $query: String = ""
+  $query: String = "",
+  $redirectBlogsToStories: Boolean = false
 ) {
   blogPostingCollection(
     where: { relatedLink_contains_some: [$entityUri], name_contains: $query },
     preview: $preview, locale: $locale, order: datePublished_DESC, limit: $limit
-  ) {
+  ) @skip(if: $redirectBlogsToStories) {
     items {
       __typename
       name
@@ -27,6 +28,24 @@ query EntityRelatedContent(
     where: { relatedLink_contains_some: [$entityUri], name_contains: $query },
     preview: $preview, locale: $locale, order: datePublished_DESC, limit: $limit
   ) {
+    items {
+      __typename
+      name
+      identifier
+      primaryImageOfPage {
+        image {
+          url
+          contentType
+          description
+        }
+      }
+      datePublished
+    }
+  }
+  storyCollection(
+    where: { relatedLink_contains_some: [$entityUri], name_contains: $query },
+    preview: $preview, locale: $locale, order: datePublished_DESC, limit: $limit
+  ) @include(if: $redirectBlogsToStories) {
     items {
       __typename
       name

--- a/packages/portal/src/modules/contentful/queries/latest-editorial-content.graphql
+++ b/packages/portal/src/modules/contentful/queries/latest-editorial-content.graphql
@@ -2,12 +2,13 @@ query latestEditorialContent(
   $locale: String!,
   $preview: Boolean = false,
   $limit: Int = 1,
-  $query: String = ""
+  $query: String = "",
+  $redirectBlogsToStories: Boolean = false
 ) {
   blogPostingCollection(
     where: { name_contains: $query },
     preview: $preview, locale: $locale, order: datePublished_DESC, limit: $limit
-  ) {
+  ) @skip(if: $redirectBlogsToStories) {
     items {
       __typename
       name
@@ -26,6 +27,24 @@ query latestEditorialContent(
     where: { name_contains: $query },
     preview: $preview, locale: $locale, order: datePublished_DESC, limit: $limit
   ) {
+    items {
+      __typename
+      name
+      identifier
+      primaryImageOfPage {
+        image {
+          url
+          contentType
+          description
+        }
+      }
+      datePublished
+    }
+  }
+  storyCollection(
+    where: { name_contains: $query },
+    preview: $preview, locale: $locale, order: datePublished_DESC, limit: $limit
+  ) @include(if: $redirectBlogsToStories) {
     items {
       __typename
       name

--- a/packages/portal/src/modules/contentful/queries/related-content.graphql
+++ b/packages/portal/src/modules/contentful/queries/related-content.graphql
@@ -2,12 +2,13 @@ query EntityRelatedContent(
   $locale: String!,
   $preview: Boolean = false,
   $limit: Int = 4,
-  $query: String = ""
+  $query: String = "",
+  $redirectBlogsToStories: Boolean = false
 ) {
   blogPostingCollection(
     where: { name_contains: $query },
     preview: $preview, locale: $locale, order: datePublished_DESC, limit: $limit
-  ) {
+  ) @skip(if: $redirectBlogsToStories) {
     items {
       __typename
       name
@@ -26,6 +27,24 @@ query EntityRelatedContent(
     where: { name_contains: $query },
     preview: $preview, locale: $locale, order: datePublished_DESC, limit: $limit
   ) {
+    items {
+      __typename
+      name
+      identifier
+      primaryImageOfPage {
+        image {
+          url
+          contentType
+          description
+        }
+      }
+      datePublished
+    }
+  }
+  storyCollection(
+    where: { name_contains: $query },
+    preview: $preview, locale: $locale, order: datePublished_DESC, limit: $limit
+  ) @include(if: $redirectBlogsToStories) {
     items {
       __typename
       name

--- a/packages/portal/src/modules/contentful/queries/stories-by-sys-id.graphql
+++ b/packages/portal/src/modules/contentful/queries/stories-by-sys-id.graphql
@@ -17,6 +17,12 @@ query StoriesBySysId(
   ) {
     ...exhibitionPageCollectionFields
   }
+  storyCollection(
+    preview: $preview, locale: $locale, limit: $limit,
+    where: { AND: [ { sys: { id_in: $ids } }, { name_contains: $query } ] }
+  ) {
+    ...storyCollectionFields
+  }
 }
 
 fragment blogPostingCollectionFields on BlogPostingCollection {
@@ -34,6 +40,20 @@ fragment blogPostingCollectionFields on BlogPostingCollection {
 }
 
 fragment exhibitionPageCollectionFields on ExhibitionPageCollection {
+  items {
+    __typename
+    sys {
+      id
+    }
+    identifier
+    name
+    primaryImageOfPage {
+      ...imageWithAttributionFields
+    }
+  }
+}
+
+fragment storyCollectionFields on StoryCollection {
   items {
     __typename
     sys {

--- a/packages/portal/src/modules/contentful/queries/stories-minimal.graphql
+++ b/packages/portal/src/modules/contentful/queries/stories-minimal.graphql
@@ -1,12 +1,13 @@
 query storiesMinimal(
   $locale: String!,
   $preview: Boolean = false,
-  $query: String = ""
+  $query: String = "",
+  $redirectBlogsToStories: Boolean = false
 ) {
-	blogPostingCollection(
+	blogPostingCollection (
     preview: $preview, locale: $locale, order: datePublished_DESC, limit: 1500,
-    where: { name_contains: $query }
-  ) {
+    where: { name_contains: $query },
+  ) @skip(if: $redirectBlogsToStories) {
     items {
       date: datePublished
       sys {
@@ -30,6 +31,22 @@ query storiesMinimal(
       }
       cats: categoriesCollection(limit: 5) {
         items: items {
+          id: identifier
+        }
+      }
+    }
+  },
+  storyCollection (
+    preview: $preview, locale: $locale, order: datePublished_DESC, limit: 1500,
+    where: { name_contains: $query },
+  ) @include(if: $redirectBlogsToStories) {
+    items {
+      date: datePublished
+      sys {
+        id
+      }
+      cats: categoriesCollection(limit: 5) {
+        items {
           id: identifier
         }
       }

--- a/packages/portal/src/modules/contentful/queries/theme-related-content.graphql
+++ b/packages/portal/src/modules/contentful/queries/theme-related-content.graphql
@@ -3,12 +3,13 @@ query ThemeRelatedContent(
   $preview: Boolean = false,
   $limit: Int = 4,
   $theme: String!,
-  $query: String = ""
+  $query: String = "",
+  $redirectBlogsToStories: Boolean = false
 ) {
   blogPostingCollection(
     where: { genre_contains_some: [$theme], name_contains: $query },
     preview: $preview, locale: $locale, order: datePublished_DESC, limit: $limit
-  ) {
+  ) @skip(if: $redirectBlogsToStories) {
     items {
       __typename
       name
@@ -27,6 +28,24 @@ query ThemeRelatedContent(
     where: { genre_contains_some: [$theme], name_contains: $query },
     preview: $preview, locale: $locale, order: datePublished_DESC, limit: $limit
   ) {
+    items {
+      __typename
+      name
+      identifier
+      primaryImageOfPage {
+        image {
+          url
+          contentType
+          description
+        }
+      }
+      datePublished
+    }
+  }
+  storyCollection(
+    where: { genre_contains_some: [$theme], name_contains: $query },
+    preview: $preview, locale: $locale, order: datePublished_DESC, limit: $limit
+  ) @include(if: $redirectBlogsToStories) {
     items {
       __typename
       name

--- a/packages/portal/src/utils/contentful/entry-url.js
+++ b/packages/portal/src/utils/contentful/entry-url.js
@@ -1,0 +1,17 @@
+export const contentfulEntryUrl = (entry) => {
+  let urlPrefix;
+
+  switch (entry['__typename']) {
+    case 'BlogPosting':
+      urlPrefix = '/blog';
+      break;
+    case 'ExhibitionPage':
+      urlPrefix = '/exhibitions';
+      break;
+    case 'Story':
+      urlPrefix = '/stories';
+      break;
+  }
+
+  return `${urlPrefix}/${entry.identifier}`;
+};

--- a/packages/portal/tests/unit/components/home/HomeLatestStories.spec.js
+++ b/packages/portal/tests/unit/components/home/HomeLatestStories.spec.js
@@ -72,7 +72,8 @@ describe('components/home/HomeLatestStories', () => {
       expect(wrapper.vm.$contentful.query.calledWith('latestEditorialContent', {
         locale: 'en-GB',
         preview: false,
-        limit: 2
+        limit: 2,
+        redirectBlogsToStories: false
       })).toBe(true);
     });
 
@@ -89,30 +90,6 @@ describe('components/home/HomeLatestStories', () => {
   });
 
   describe('methods', () => {
-    describe('cardLink', () => {
-      it('constructs exhibition links', () => {
-        const wrapper = factory();
-
-        const link = wrapper.vm.cardLink({
-          __typename: 'ExhibitionPage',
-          identifier: 'exhibition'
-        });
-
-        expect(link.name).toBe('exhibitions-exhibition');
-      });
-
-      it('constructs blog post links', () => {
-        const wrapper = factory();
-
-        const link = wrapper.vm.cardLink({
-          __typename: 'BlogPosting',
-          identifier: 'blog'
-        });
-
-        expect(link.name).toBe('blog-all');
-      });
-    });
-
     describe('cardImage', () => {
       it('uses primaryImageOfPage URL', () => {
         const wrapper = factory();

--- a/packages/portal/tests/unit/components/related/RelatedEditorial.spec.js
+++ b/packages/portal/tests/unit/components/related/RelatedEditorial.spec.js
@@ -69,7 +69,8 @@ describe('components/related/RelatedEditorial', () => {
             query,
             locale: 'en-GB',
             preview: false,
-            limit: 4
+            limit: 4,
+            redirectBlogsToStories: false
           })).toBe(true);
         });
 
@@ -94,7 +95,8 @@ describe('components/related/RelatedEditorial', () => {
             theme: null,
             locale: 'en-GB',
             preview: false,
-            limit: 4
+            limit: 4,
+            redirectBlogsToStories: false
           })).toBe(true);
         });
 
@@ -124,7 +126,8 @@ describe('components/related/RelatedEditorial', () => {
             query,
             locale: 'en-GB',
             preview: false,
-            limit: 4
+            limit: 4,
+            redirectBlogsToStories: false
           })).toBe(true);
         });
 
@@ -149,7 +152,8 @@ describe('components/related/RelatedEditorial', () => {
             theme,
             locale: 'en-GB',
             preview: false,
-            limit: 4
+            limit: 4,
+            redirectBlogsToStories: false
           })).toBe(true);
         });
 
@@ -180,7 +184,8 @@ describe('components/related/RelatedEditorial', () => {
             theme: null,
             locale: 'en-GB',
             preview: false,
-            limit: 4
+            limit: 4,
+            redirectBlogsToStories: false
           })).toBe(true);
         });
 
@@ -201,32 +206,6 @@ describe('components/related/RelatedEditorial', () => {
 
           expect(wrapper.vm.$contentful.query.called).toBe(false);
         });
-      });
-    });
-  });
-
-  describe('methods', () => {
-    describe('entryUrl', () => {
-      it('prefixes BlogPosting entries with /blog', () => {
-        const wrapper = factory();
-
-        const entryUrl = wrapper.vm.entryUrl({
-          '__typename': 'BlogPosting',
-          identifier: 'interesting'
-        });
-
-        expect(entryUrl).toBe('/blog/interesting');
-      });
-
-      it('prefixes ExhibitionPage entries with /exhibitions', () => {
-        const wrapper = factory();
-
-        const entryUrl = wrapper.vm.entryUrl({
-          '__typename': 'ExhibitionPage',
-          identifier: 'educational'
-        });
-
-        expect(entryUrl).toBe('/exhibitions/educational');
       });
     });
   });

--- a/packages/portal/tests/unit/components/stories/StoriesInterface.spec.js
+++ b/packages/portal/tests/unit/components/stories/StoriesInterface.spec.js
@@ -181,7 +181,8 @@ describe('components/stories/StoriesInterface', () => {
 
       expect(wrapper.vm.$contentful.query.calledWith('storiesMinimal', {
         locale: 'en-GB',
-        preview: false
+        preview: false,
+        redirectBlogsToStories: false
       })).toBe(true);
     });
 
@@ -386,30 +387,6 @@ describe('components/stories/StoriesInterface', () => {
 
           expect(wrapper.vm.stories.length).toBe(2);
         });
-      });
-    });
-
-    describe('entryUrl', () => {
-      it('prefixes BlogPosting entries with /blog', () => {
-        const wrapper = factory();
-
-        const entryUrl = wrapper.vm.entryUrl({
-          '__typename': 'BlogPosting',
-          identifier: 'interesting'
-        });
-
-        expect(entryUrl).toBe('/blog/interesting');
-      });
-
-      it('prefixes ExhibitionPage entries with /exhibitions', () => {
-        const wrapper = factory();
-
-        const entryUrl = wrapper.vm.entryUrl({
-          '__typename': 'ExhibitionPage',
-          identifier: 'educational'
-        });
-
-        expect(entryUrl).toBe('/exhibitions/educational');
       });
     });
   });

--- a/packages/portal/tests/unit/middleware/redirects.spec.js
+++ b/packages/portal/tests/unit/middleware/redirects.spec.js
@@ -6,13 +6,31 @@ describe('middleware/redirects', () => {
   afterEach(sinon.resetHistory);
   const redirect = sinon.spy();
 
-  describe('when route path matches a redirect', () => {
+  it('redirects /professionals to /share-your-data', () => {
     const route = { path: '/fr/professionals' };
 
-    it('redirects to /share-your-data', () => {
-      middleware({ route, redirect });
+    middleware({ route, redirect });
 
-      expect(redirect.calledWith('/fr/share-your-data')).toBe(true);
+    expect(redirect.calledWith('/fr/share-your-data')).toBe(true);
+  });
+
+  describe('when redirectBlogsToStories feature is enabled', () => {
+    const $features = { redirectBlogsToStories: true };
+
+    it('redirects /blog to /stories', () => {
+      const route = { path: '/de/blog' };
+
+      middleware({ route, redirect, $features });
+
+      expect(redirect.calledWith('/de/stories')).toBe(true);
+    });
+
+    it('redirects /blog/* to /stories/*', () => {
+      const route = { path: '/nl/blog/nice' };
+
+      middleware({ route, redirect, $features });
+
+      expect(redirect.calledWith('/nl/stories/nice')).toBe(true);
     });
   });
 

--- a/packages/portal/tests/unit/utils/contentful/entry-url.spec.js
+++ b/packages/portal/tests/unit/utils/contentful/entry-url.spec.js
@@ -1,0 +1,32 @@
+import { contentfulEntryUrl } from '@/utils/contentful/entry-url.js';
+
+describe('@/utils/contentful/entity-url', () => {
+  describe('contentfulEntryUrl', () => {
+    it('prefixes BlogPosting entries with /blog', () => {
+      const url = contentfulEntryUrl({
+        '__typename': 'BlogPosting',
+        identifier: 'interesting'
+      });
+
+      expect(url).toBe('/blog/interesting');
+    });
+
+    it('prefixes ExhibitionPage entries with /exhibitions', () => {
+      const url = contentfulEntryUrl({
+        '__typename': 'ExhibitionPage',
+        identifier: 'educational'
+      });
+
+      expect(url).toBe('/exhibitions/educational');
+    });
+
+    it('prefixes Story entries with /stories', () => {
+      const url = contentfulEntryUrl({
+        '__typename': 'Story',
+        identifier: 'told'
+      });
+
+      expect(url).toBe('/stories/told');
+    });
+  });
+});


### PR DESCRIPTION
* add feature toggle `redirectBlogsToStories`, enabled with `ENABLE_REDIRECT_BLOGS_TO_STORIES=1`
* extend redirect middleware to redirect /blog to /stories and /blog/X to /stories/X, behind feature toggle
* add a utility helper function to get Contentful entry URLs, and make components use it, to DRY them up
* update Contentful GraphQL queries to conditionally retrieve either blogPosting or story entries, and have calling pages/components pass the state of the feature toggle to determine which is retrieved and displayed