### PR TITLE
fix: stop importing icon scss in components

### DIFF
--- a/packages/portal/src/components/entity/EntityTable.vue
+++ b/packages/portal/src/components/entity/EntityTable.vue
@@ -265,7 +265,7 @@
 
 <style lang="scss">
   @import '@europeana/style/scss/variables';
-  @import '@europeana/style/scss/icons';
+  @import '@europeana/style/scss/icon-font';
   @import '@europeana/style/scss/table';
 
   .entity-table {

--- a/packages/portal/src/components/generic/InfoCard.vue
+++ b/packages/portal/src/components/generic/InfoCard.vue
@@ -79,7 +79,7 @@
 
 <style lang="scss" scoped>
   @import '@europeana/style/scss/variables';
-  @import '@europeana/style/scss/icons';
+  @import '@europeana/style/scss/icon-font';
 
   .info-card {
     background: $white;

--- a/packages/portal/src/components/generic/NotificationBanner.vue
+++ b/packages/portal/src/components/generic/NotificationBanner.vue
@@ -76,7 +76,7 @@
 
 <style lang="scss" scoped>
   @import '@europeana/style/scss/variables';
-  @import '@europeana/style/scss/icons';
+  @import '@europeana/style/scss/icon-font';
 
   .container-fluid {
     background-color: $bodygrey;

--- a/packages/portal/src/components/item/ItemLanguageSelector.vue
+++ b/packages/portal/src/components/item/ItemLanguageSelector.vue
@@ -146,7 +146,7 @@
 <style lang="scss" scoped>
   @import '@europeana/style/scss/variables';
   @import '@europeana/style/scss/transitions';
-  @import '@europeana/style/scss/icons';
+  @import '@europeana/style/scss/icon-font';
 
   .icon-translate::before {
     font-size: 1.4375rem;

--- a/packages/portal/src/components/item/ItemSummaryInfo.vue
+++ b/packages/portal/src/components/item/ItemSummaryInfo.vue
@@ -141,7 +141,7 @@
 
 <style lang="scss" scoped>
   @import '@europeana/style/scss/variables';
-  @import '@europeana/style/scss/icons';
+  @import '@europeana/style/scss/icon-font';
 
   .description p:last-of-type {
     display: inline;

--- a/packages/portal/src/components/landing/LandingPageHeader.vue
+++ b/packages/portal/src/components/landing/LandingPageHeader.vue
@@ -90,7 +90,6 @@
 <style lang="scss" scoped>
   @import '@europeana/style/scss/variables';
   @import '@europeana/style/scss/mixins';
-  @import '@europeana/style/scss/icons';
 
   ::v-deep .b-sidebar-backdrop.bg-black {
     background-color: rgb(0 0 0);

--- a/packages/portal/src/components/metadata/MetadataField.vue
+++ b/packages/portal/src/components/metadata/MetadataField.vue
@@ -181,7 +181,6 @@
 
 <style lang="scss" scoped>
   @import '@europeana/style/scss/variables';
-  @import '@europeana/style/scss/icons';
 
   .metadata-row {
     border-bottom: 1px solid #e7e7e9;

--- a/packages/portal/src/components/metadata/MetadataOriginLabel.vue
+++ b/packages/portal/src/components/metadata/MetadataOriginLabel.vue
@@ -25,7 +25,7 @@
 
 <style lang="scss" scoped>
   @import '@europeana/style/scss/variables';
-  @import '@europeana/style/scss/icons';
+  @import '@europeana/style/scss/icon-font';
 
   .automated,
   .enrichment,

--- a/packages/portal/src/components/page/PageHeader.vue
+++ b/packages/portal/src/components/page/PageHeader.vue
@@ -153,7 +153,6 @@
 <style lang="scss" scoped>
   @import '@europeana/style/scss/variables';
   @import '@europeana/style/scss/mixins';
-  @import '@europeana/style/scss/icons';
 
   ::v-deep .b-sidebar-backdrop.bg-black {
     background-color: rgb(0 0 0);

--- a/packages/portal/src/components/page/PageNavigation.vue
+++ b/packages/portal/src/components/page/PageNavigation.vue
@@ -177,7 +177,7 @@
 
 <style lang="scss" scoped>
   @import '@europeana/style/scss/variables';
-  @import '@europeana/style/scss/icons';
+  @import '@europeana/style/scss/icon-font';
 
   .nav-item {
     margin-right: 1rem;

--- a/packages/portal/src/components/search/SearchFilters.vue
+++ b/packages/portal/src/components/search/SearchFilters.vue
@@ -479,7 +479,6 @@
 
 <style lang="scss" scoped>
   @import '@europeana/style/scss/variables';
-  @import '@europeana/style/scss/icons';
   @import '@europeana/style/scss/transitions';
 
   .filters-header {

--- a/packages/portal/src/components/search/SearchForm.vue
+++ b/packages/portal/src/components/search/SearchForm.vue
@@ -359,7 +359,6 @@
 
 <style lang="scss" scoped>
   @import '@europeana/style/scss/variables';
-  @import '@europeana/style/scss/icons';
   @import '@europeana/style/scss/transitions';
 
   .search-dropdown {

--- a/packages/portal/src/components/search/SearchQueryOptions.vue
+++ b/packages/portal/src/components/search/SearchQueryOptions.vue
@@ -381,7 +381,7 @@
 
 <style lang="scss" scoped>
   @import '@europeana/style/scss/variables';
-  @import '@europeana/style/scss/icons';
+  @import '@europeana/style/scss/icon-font';
 
   .list-group-item {
     border: 0;

--- a/packages/portal/src/components/search/SearchSidebarToggleButton.vue
+++ b/packages/portal/src/components/search/SearchSidebarToggleButton.vue
@@ -36,7 +36,6 @@
 <style lang="scss" scoped>
   @import '@europeana/style/scss/variables';
   @import '@europeana/style/scss/mixins';
-  @import '@europeana/style/scss/icons';
 
   .btn.icon-filter {
     &.filters-applied {

--- a/packages/portal/src/components/search/SearchViewToggles.vue
+++ b/packages/portal/src/components/search/SearchViewToggles.vue
@@ -65,7 +65,7 @@
 
 <style lang="scss" scoped>
   @import '@europeana/style/scss/variables';
-  @import '@europeana/style/scss/icons';
+  @import '@europeana/style/scss/icon-font';
 
   .form-group {
     margin: 0;

--- a/packages/portal/src/components/share/ShareSocialButton.vue
+++ b/packages/portal/src/components/share/ShareSocialButton.vue
@@ -78,8 +78,7 @@
 
 <style lang="scss" scoped>
   @import '@europeana/style/scss/variables';
-  @import '@europeana/style/scss/icons';
-
+  
   .btn {
     align-items: center;
     display: inline-flex;

--- a/packages/portal/src/pages/galleries/_.vue
+++ b/packages/portal/src/pages/galleries/_.vue
@@ -376,7 +376,7 @@
 
 <style lang="scss" scoped>
   @import '@europeana/style/scss/variables';
-  @import '@europeana/style/scss/icons';
+  @import '@europeana/style/scss/icon-font';
   @import '@europeana/style/scss/masonry';
 
   .usergallery-description {

--- a/packages/style/scss/icon-font.scss
+++ b/packages/style/scss/icon-font.scss
@@ -1,0 +1,16 @@
+%icon-font {
+  /* use !important to prevent issues with browser extensions that change fonts */
+  /* stylelint-disable-next-line */
+  font-family: 'icomoon';
+  speak: none;
+  font-style: normal;
+  font-weight: normal;
+  font-variant: normal;
+  text-transform: none;
+  vertical-align: middle;
+  line-height: 1;
+
+  /* Better Font Rendering =========== */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}

--- a/packages/style/scss/icons.scss
+++ b/packages/style/scss/icons.scss
@@ -1,19 +1,4 @@
-%icon-font {
-  /* use !important to prevent issues with browser extensions that change fonts */
-  /* stylelint-disable-next-line */
-  font-family: 'icomoon';
-  speak: none;
-  font-style: normal;
-  font-weight: normal;
-  font-variant: normal;
-  text-transform: none;
-  vertical-align: middle;
-  line-height: 1;
-
-  /* Better Font Rendering =========== */
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
+@import 'icon-font';
 
 [class^='icon-'],
 [class*=' icon-'] {


### PR DESCRIPTION
It greatly bloats inline scss as is duplicated for all scoped style sections.