### PR TITLE
fix: do not crop image with attribution sections

### DIFF
--- a/packages/portal/src/components/image/ImageWithAttribution.vue
+++ b/packages/portal/src/components/image/ImageWithAttribution.vue
@@ -87,14 +87,3 @@
     }
   };
 </script>
-
-<style lang="scss" scoped>
-figure {
-  overflow: hidden;
-
-  ::v-deep img {
-    width: 100%;
-    object-fit: cover;
-  }
-}
-</style>

--- a/packages/portal/src/components/story/StoryHero.vue
+++ b/packages/portal/src/components/story/StoryHero.vue
@@ -208,7 +208,9 @@
       width: 100%;
 
       img {
-        height: 100%
+        height: 100%;
+        object-fit: cover;
+        width: 100%;
       }
     }
   }


### PR DESCRIPTION
Only seems to cause issues on Safari, where the `object-fit` style causes the image to be cropped.

Caused by https://github.com/europeana/portal.js/pull/2047/commits/c3712a0579765aceb1c73f9b08e44712d0e0091b#diff-5afef1e4d9003ec3829eb5c49b3d10b26dc48b34ebb9f586327462c8900d6aa4