### PR TITLE
feat: locales for feature notifications

### DIFF
--- a/packages/portal/.env.example
+++ b/packages/portal/.env.example
@@ -183,6 +183,10 @@ OAUTH_CLIENT="YOUR_CLIENT"
 # Optional expiration date for the feature notification, after which it will no
 # longer be shown.
 # APP_FEATURE_NOTIFICATION_EXPIRATION=2022-02-22
+#
+# Optional comma-separated list of UI locales for which the feature notification
+# will be shown, and not for any others
+# APP_FEATURE_NOTIFICATION_LOCALES=en,nl
 
 # Username of the official Europeana account for published set-driven galleries.
 # APP_GALLERIES_EUROPEANA_ACCOUNT=europeana

--- a/packages/portal/nuxt.config.js
+++ b/packages/portal/nuxt.config.js
@@ -13,7 +13,8 @@ import versions from './pkg-versions.js';
 import { locales as i18nLocales } from '@europeana/i18n';
 import i18nDateTime from './src/i18n/datetime.js';
 import { exclude as i18nRoutesExclude } from './src/i18n/routes.js';
-import features, { featureIsEnabled, featureNotificationExpiration } from './src/features/index.js';
+import features, { featureIsEnabled } from './src/features/index.js';
+import { featureNotificationExpiration } from './src/features/notifications.js';
 
 import {
   nuxtRuntimeConfig as europeanaApisRuntimeConfig
@@ -70,8 +71,11 @@ export default {
       galleries: {
         europeanaAccount: process.env.APP_GALLERIES_EUROPEANA_ACCOUNT || 'europeana'
       },
-      featureNotification: process.env.APP_FEATURE_NOTIFICATION,
-      featureNotificationExpiration: featureNotificationExpiration(process.env.APP_FEATURE_NOTIFICATION_EXPIRATION),
+      featureNotification: {
+        expiration: featureNotificationExpiration(process.env.APP_FEATURE_NOTIFICATION_EXPIRATION),
+        locales: process.env.APP_FEATURE_NOTIFICATION_LOCALES?.split(','),
+        name: process.env.APP_FEATURE_NOTIFICATION
+      },
       feedback: {
         cors: {
           origin: [process.env.PORTAL_BASE_URL].concat(process.env.APP_FEEDBACK_CORS_ORIGIN?.split(',')).filter((origin) => !!origin)

--- a/packages/portal/src/components/generic/NewFeatureNotification.vue
+++ b/packages/portal/src/components/generic/NewFeatureNotification.vue
@@ -1,6 +1,7 @@
 <template>
   <b-toast
-    id="new-feature-toast"
+    v-if="enabled"
+    :id="toastId"
     auto-hide-delay="60000"
     is-status
     no-close-button
@@ -10,7 +11,7 @@
     append-toast
     toaster="b-toaster-bottom-left-dynamic"
   >
-    <slot />
+    <p>{{ $t(`newFeatureNotification.text.${name}`) }}</p>
     <div class="d-flex justify-content-between align-items-start">
       <b-button
         class="mr-2"
@@ -38,32 +39,53 @@
     name: 'NewFeatureNotification',
 
     props: {
-      url: {
+      name: {
         type: String,
-        default: null
+        required: true
       },
-      feature: {
+
+      url: {
         type: String,
         default: null
       }
     },
 
+    data() {
+      return {
+        cookieName: 'new_feature_notification',
+        matomoEvent: 'New_feature_notification',
+        toastId: 'new-feature-toast'
+      };
+    },
+
+    computed: {
+      enabled() {
+        return this.$cookies.get(this.cookieName) !== this.name;
+      }
+    },
+
     created() {
+      if (!this.enabled) {
+        return;
+      }
+
       this.trackEvent('show');
-      this.$cookies.set('new_feature_notification', this.feature, {
+
+      // TODO: why do we set this immediately and not after interaction?
+      this.$cookies.set(this.cookieName, this.name, {
         maxAge: 2678400
       });
     },
 
     methods: {
       hideToast() {
-        this.$bvToast.hide('new-feature-toast');
+        this.$bvToast.hide(this.toastId);
         this.trackEvent('dismissed');
       },
 
       trackEvent(msg) {
         if (this.$matomo) {
-          this.$matomo.trackEvent('New_feature_notification', msg, this.feature);
+          this.$matomo.trackEvent(this.matomoEvent, msg, this.name);
         }
       }
     }

--- a/packages/portal/src/components/generic/NewFeatureNotification.vue
+++ b/packages/portal/src/components/generic/NewFeatureNotification.vue
@@ -16,7 +16,8 @@
       <b-button
         class="mr-2"
         variant="outline-primary"
-        @click="hideToast"
+        data-qa="new feature dismiss"
+        @click="handleClickDismiss"
       >
         {{ $t('newFeatureNotification.dismiss') }}
       </b-button>
@@ -26,7 +27,7 @@
         :href="url"
         target="blank"
         data-qa="new feature read more"
-        @click="trackEvent('click read more')"
+        @click="handleClickReadMore"
       >
         {{ $t('newFeatureNotification.readMore') }}
       </b-button>
@@ -71,16 +72,24 @@
 
       this.trackEvent('show');
 
-      // TODO: why do we set this immediately and not after interaction?
       this.$cookies.set(this.cookieName, this.name, {
         maxAge: 2678400
       });
     },
 
     methods: {
+      handleClickDismiss() {
+        this.hideToast();
+        this.trackEvent('dismissed');
+      },
+
+      handleClickReadMore() {
+        this.hideToast();
+        this.trackEvent('click read more');
+      },
+
       hideToast() {
         this.$bvToast.hide(this.toastId);
-        this.trackEvent('dismissed');
       },
 
       trackEvent(msg) {

--- a/packages/portal/src/features/README.md
+++ b/packages/portal/src/features/README.md
@@ -35,8 +35,8 @@ to be shown to users, its name needs to be set in the environment variable
 
 ```js
 // src/features/notifications.js
-export default [
-  { name: 'sideFilters', url: '/blog/side-filters' }
+const features = [
+  { name: 'immersiveStories', url: '/stories' }
 ];
 ```
 

--- a/packages/portal/src/features/index.js
+++ b/packages/portal/src/features/index.js
@@ -6,11 +6,6 @@ export const featureIsEnabled = (name) => {
   return valueIsTruthy(process.env[envKey]);
 };
 
-export const featureNotificationExpiration = (value) => {
-  const date = new Date(value);
-  return date.toString() === 'Invalid Date' ? null : date;
-};
-
 export const valueIsTruthy = (value) => Boolean(Number(value));
 
 export default () => featureToggles

--- a/packages/portal/src/features/notifications.js
+++ b/packages/portal/src/features/notifications.js
@@ -1,3 +1,32 @@
-export default [
+const features = [
   { name: 'immersiveStories', url: '/stories' }
 ];
+
+export const featureNotificationExpiration = (value) => {
+  const date = new Date(value);
+  return date.toString() === 'Invalid Date' ? null : date;
+};
+
+const featureNotificationExpired = (expiration) => {
+  return expiration && (Date.now() >= expiration);
+};
+
+const featureNotificationSupportsLocale = (configLocales, uiLocale) => {
+  return !configLocales || [].concat(configLocales).includes(uiLocale);
+};
+
+const findFeature = (name) => features.find((feature) => feature.name === name);
+
+export const activeFeatureNotification = ({ $config, i18n } = {}) => {
+  const config = $config?.app?.featureNotification || {};
+
+  const feature = findFeature(config.name);
+
+  const isActive = feature &&
+    !featureNotificationExpired(config.expiration) &&
+    featureNotificationSupportsLocale(config.locales, i18n?.locale);
+
+  return isActive ? feature : null;
+};
+
+export default features;

--- a/packages/portal/src/features/notifications.js
+++ b/packages/portal/src/features/notifications.js
@@ -1,3 +1,3 @@
 export default [
-  { name: 'trendingItems', url: '/collections#trending-items' }
+  { name: 'immersiveStories', url: '/stories' }
 ];

--- a/packages/portal/src/features/notifications.js
+++ b/packages/portal/src/features/notifications.js
@@ -1,5 +1,5 @@
 const features = [
-  { name: 'immersiveStories', url: '/stories' }
+  { name: 'immersiveStories', url: '/stories/claude-cahun' }
 ];
 
 export const featureNotificationExpiration = (value) => {

--- a/packages/portal/src/i18n/lang/en.js
+++ b/packages/portal/src/i18n/lang/en.js
@@ -959,7 +959,7 @@ export default {
     "dismiss": "Dismiss",
     "readMore": "Show me",
     "text": {
-      "immersiveStories": "Check out the new immersive story!"
+      "immersiveStories": "Our stories have a new look — read one to see."
     }
   },
   "newWindow": "opens in new window",

--- a/packages/portal/src/i18n/lang/en.js
+++ b/packages/portal/src/i18n/lang/en.js
@@ -959,7 +959,7 @@ export default {
     "dismiss": "Dismiss",
     "readMore": "Show me",
     "text": {
-      "trendingItems": "Discover which items capture people's attention and gain popularity in real-time. Take advantage of the chance to stay ahead of the curve - see what people view, like, curate and reuse the most right now."
+      "immersiveStories": "Check out the new immersive story!"
     }
   },
   "newWindow": "opens in new window",

--- a/packages/portal/src/layouts/default.vue
+++ b/packages/portal/src/layouts/default.vue
@@ -40,18 +40,13 @@
         id="main"
       />
     </main>
-    <client-only
-      v-if="newFeatureNotificationEnabled"
-    >
+    <client-only>
       <NewFeatureNotification
-        :feature="featureNotification.name"
+        v-if="featureNotification"
+        :name="featureNotification.name"
         :url="featureNotification.url"
         data-qa="new feature notification"
-      >
-        <p>{{ $t(`newFeatureNotification.text.${featureNotification.name}`) }}</p>
-      </NewFeatureNotification>
-    </client-only>
-    <client-only>
+      />
       <PageFooter />
       <DebugApiRequests />
     </client-only>
@@ -79,7 +74,7 @@
   import hotjarMixin from '@/mixins/hotjar.js';
   import klaroMixin from '@/mixins/klaro.js';
   import versions from '../../pkg-versions';
-  import featureNotifications from '@/features/notifications';
+  import { activeFeatureNotification } from '@/features/notifications';
 
   export default {
     name: 'DefaultLayout',
@@ -105,10 +100,8 @@
 
     data() {
       return {
-        dateNow: Date.now(),
         enableAnnouncer: true,
-        featureNotification: featureNotifications.find(feature => feature.name === this.$config?.app?.featureNotification),
-        featureNotificationExpiration: this.$config.app.featureNotificationExpiration,
+        featureNotification: activeFeatureNotification(this.$nuxt?.context),
         hotjarId: this.$config?.hotjar?.id,
         hotjarSv: this.$config?.hotjar?.sv,
         linkGroups: {},
@@ -146,12 +139,6 @@
     computed: {
       breadcrumbs() {
         return this.$store.state.breadcrumb.data;
-      },
-
-      newFeatureNotificationEnabled() {
-        return !!this.featureNotification &&
-          (!this.featureNotificationExpiration || (this.dateNow < this.featureNotificationExpiration)) &&
-          (!this.$cookies.get('new_feature_notification') || this.$cookies.get('new_feature_notification') !== this.featureNotification.name);
       }
     },
 

--- a/packages/portal/tests/unit/components/generic/NewFeatureNotification.spec.js
+++ b/packages/portal/tests/unit/components/generic/NewFeatureNotification.spec.js
@@ -12,6 +12,7 @@ const factory = (propsData = {}) => shallowMount(NewFeatureNotification, {
   mocks: {
     $t: () => {},
     $cookies: {
+      get: () => null,
       set: () => {}
     },
     $matomo: {
@@ -23,14 +24,14 @@ const factory = (propsData = {}) => shallowMount(NewFeatureNotification, {
 describe('components/generic/NewFeatureNotification', () => {
   describe('when a url prop is passed', () => {
     it('shows a "read more" button', () => {
-      const wrapper = factory({ url: 'https://www.example.eu' });
+      const wrapper = factory({ name: 'new', url: 'https://www.example.eu' });
       const readMoreButton = wrapper.find('[data-qa="new feature read more"]');
       expect(readMoreButton.exists()).toBe(true);
     });
   });
   describe('hideToast', () => {
     it('hides the toast', async() => {
-      const wrapper = factory();
+      const wrapper = factory({ name: 'new' });
       const bvToastHide = sinon.spy(wrapper.vm.$bvToast, 'hide');
 
       await wrapper.vm.hideToast();
@@ -38,7 +39,7 @@ describe('components/generic/NewFeatureNotification', () => {
       expect(bvToastHide.calledWith('new-feature-toast')).toBe(true);
     });
     it('tracks the "dismissed" event', async()  => {
-      const wrapper = factory();
+      const wrapper = factory({ name: 'new' });
       const trackEvent = sinon.spy(wrapper.vm, 'trackEvent');
 
       await wrapper.vm.hideToast();
@@ -48,7 +49,7 @@ describe('components/generic/NewFeatureNotification', () => {
   });
   describe('trackEvent', () => {
     it('tracks a matomo event with the event type and feature name', async() => {
-      const wrapper = factory({ feature: 'organisations' });
+      const wrapper = factory({ name: 'organisations' });
       const mtmTrackEvent = wrapper.vm.$matomo.trackEvent;
 
       await wrapper.vm.trackEvent('show');

--- a/packages/portal/tests/unit/features/index.spec.js
+++ b/packages/portal/tests/unit/features/index.spec.js
@@ -1,6 +1,6 @@
 import snakeCase from 'lodash/snakeCase';
 import featureToggles from '@/features/toggles.js';
-import features, { featureNotificationExpiration } from '@/features/index.js';
+import features from '@/features/index.js';
 
 describe('features/index', () => {
   describe('default', () => {
@@ -17,21 +17,6 @@ describe('features/index', () => {
 
       const featuresObject = features();
       expect(featuresObject[enabledFeature]).toBe(true);
-    });
-  });
-
-  describe('featureNotificationExpiration', () => {
-    it('returns a Date if parseable', () => {
-      const expiration = featureNotificationExpiration('2022-01-01');
-
-      expect(expiration instanceof Date).toBe(true);
-      expect(expiration.toString()).toContain('Jan 01 2022');
-    });
-
-    it('returns `null` if not parseable', () => {
-      const expiration = featureNotificationExpiration('typo');
-
-      expect(expiration).toBe(null);
     });
   });
 });

--- a/packages/portal/tests/unit/features/notifications.spec.js
+++ b/packages/portal/tests/unit/features/notifications.spec.js
@@ -1,0 +1,100 @@
+import features, {
+  activeFeatureNotification,
+  featureNotificationExpiration
+} from '@/features/notifications.js';
+
+describe('features/notifications', () => {
+  describe('featureNotificationExpiration', () => {
+    it('returns a Date if parseable', () => {
+      const expiration = featureNotificationExpiration('2022-01-01');
+
+      expect(expiration instanceof Date).toBe(true);
+      expect(expiration.toString()).toContain('Jan 01 2022');
+    });
+
+    it('returns `null` if not parseable', () => {
+      const expiration = featureNotificationExpiration('typo');
+
+      expect(expiration).toBe(null);
+    });
+  });
+
+  describe('activeFeatureNotification', () => {
+    describe('when feature notification is not configured', () => {
+      it('is null', () => {
+        const $config = { app: { featureNotification: { name: undefined } } };
+
+        expect(activeFeatureNotification({ $config })).toBeNull();
+      });
+    });
+
+    describe('when feature notification is configured', () => {
+      describe('but feature is not known', () => {
+        it('is null', () => {
+          const $config = { app: { featureNotification: { name: 'unknown' } } };
+
+          expect(activeFeatureNotification({ $config })).toBeNull();
+        });
+      });
+
+      describe('and feature is known', () => {
+        const feature = features[0];
+        const name = feature.name;
+
+        it('returns feature', () => {
+          const $config = { app: { featureNotification: { name } } };
+
+          expect(activeFeatureNotification({ $config })).toEqual(feature);
+        });
+
+        describe('and expiration is configured', () => {
+          describe('and expiration has passed', () => {
+            const expiration = new Date('2011-11-20');
+
+            it('is null', () => {
+              const $config = { app: { featureNotification: { expiration, name } } };
+
+              expect(activeFeatureNotification({ $config })).toBeNull();
+            });
+          });
+
+          describe('and expiration has not passed', () => {
+            const expiration = new Date('3011-11-20');
+
+            it('returns feature', () => {
+              const $config = { app: { featureNotification: { expiration, name } } };
+
+              expect(activeFeatureNotification({ $config })).toEqual(feature);
+            });
+          });
+        });
+
+        describe('and locales are configured', () => {
+          const locales = ['en', 'nl'];
+
+          describe('and UI locale is not included', () => {
+            const uiLocale = 'de';
+
+            it('is null', () => {
+              const $config = { app: { featureNotification: { locales, name } } };
+              const i18n = { locale: uiLocale };
+
+              expect(activeFeatureNotification({ $config, i18n })).toBeNull();
+            });
+          });
+
+          describe('and UI locale is included', () => {
+            const uiLocale = 'nl';
+
+            it('returns feature', () => {
+              const $config = { app: { featureNotification: { locales, name } } };
+              const i18n = { locale: uiLocale };
+
+              expect(activeFeatureNotification({ $config, i18n })).toEqual(feature);
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/packages/portal/tests/unit/layouts/default.spec.js
+++ b/packages/portal/tests/unit/layouts/default.spec.js
@@ -85,47 +85,19 @@ describe('layouts/default.vue', () => {
   });
 
   describe('NewFeatureNotification', () => {
-    describe('when no feature notification is defined', () => {
-      it('is not loaded', () => {
-        const wrapper = factory({ data: { featureNotification: undefined } });
+    describe('when no feature notification is active', () => {
+      it('is not rendered', () => {
+        const wrapper = factory({ data: { featureNotification: null } });
         const notification = wrapper.find('[data-qa="new feature notification"]');
         expect(notification.exists()).toBe(false);
       });
     });
-    describe('when feature notification is defined', () => {
-      describe('and expiration has not passed', () => {
-        it('is rendered', () => {
-          const wrapper = factory({ data: { featureNotification: { name: 'filters' }, featureNotificationExpiration: new Date('3011-11-20') }, cookies: {} });
+    describe('when a feature notification is active', () => {
+      it('is rendered', () => {
+        const wrapper = factory({ data: { featureNotification: { name: 'filters' } } });
 
-          const notification = wrapper.find('[data-qa="new feature notification"]');
-          expect(notification.exists()).toBe(true);
-        });
-      });
-      describe('and expiration has passed', () => {
-        it('is not loaded', () => {
-          const wrapper = factory({ data: { featureNotification: { name: 'filters' }, featureNotificationExpiration: new Date('2011-11-20') }, cookies: {} });
-
-          const notification = wrapper.find('[data-qa="new feature notification"]');
-          expect(notification.exists()).toBe(false);
-        });
-      });
-      describe('and new_feature_notification cookies are set with the feature`s name', () => {
-        it('is not loaded', () => {
-          const wrapper = factory({ data: { featureNotification: { name: 'filters' } },
-            cookies: { 'new_feature_notification': 'filters' } });
-
-          const notification = wrapper.find('[data-qa="new feature notification"]');
-          expect(notification.exists()).toBe(false);
-        });
-      });
-      describe('and new_feature_notification cookies are set with a different name', () => {
-        it('is rendered', () => {
-          const wrapper = factory({ data: { featureNotification: { name: 'filters' } },
-            cookies: { 'new_feature_notification': 'organisations' } });
-
-          const notification = wrapper.find('[data-qa="new feature notification"]');
-          expect(notification.exists()).toBe(true);
-        });
+        const notification = wrapper.find('[data-qa="new feature notification"]');
+        expect(notification.exists()).toBe(true);
       });
     });
   });


### PR DESCRIPTION
* permit restricting feature notifications by UI locale, like `APP_FEATURE_NOTIFICATION_LOCALES=en,nl`
* refactor feature notification display logic to move most of it out of default layout and into `@/features/notifications`
* move the rendering of the notification text into the component, instead of a slot supplied by the default layout
* when the "show me" link in the notification is clicked, hide the toast
* add a feature notification for the immersive stories