### PR TITLE
refactor: optimise content card image

### DIFF
--- a/packages/portal/src/components/browse/BrowseContentCard.vue
+++ b/packages/portal/src/components/browse/BrowseContentCard.vue
@@ -5,8 +5,6 @@
     :url="destination"
     :image-url="imageUrl"
     :image-content-type="imageContentType"
-    :image-width="imageWidth"
-    :image-height="imageHeight"
     :image-alt="imageAlt"
     :omit-all-uris="true"
     :logo="fields.logo"
@@ -77,12 +75,6 @@
       },
       imageAlt() {
         return this.imageIsContentfulAsset && this.cardFields.image.description ? this.cardFields.image.description : '';
-      },
-      imageWidth() {
-        return this.imageIsContentfulAsset ? this.cardFields.image.width : null;
-      },
-      imageHeight() {
-        return this.imageIsContentfulAsset ? this.cardFields.image.height : null;
       },
       destination() {
         let destination = '';

--- a/packages/portal/src/components/browse/BrowseContentCard.vue
+++ b/packages/portal/src/components/browse/BrowseContentCard.vue
@@ -9,7 +9,6 @@
     :image-height="imageHeight"
     :image-alt="imageAlt"
     :omit-all-uris="true"
-    :image-optimisation-options="{ width: 510 }"
     :logo="fields.logo"
     :variant="variant"
   />

--- a/packages/portal/src/components/content/ContentCard.vue
+++ b/packages/portal/src/components/content/ContentCard.vue
@@ -219,7 +219,7 @@
        */
       contentfulImageCropPresets: {
         type: Object,
-        default: () => ({ 'small': { w: 480, h: 288, fit: 'fill' } })
+        default: () => ({ 'small': { w: 480, h: 288, fit: 'fill', f: 'face' } })
       },
       /**
        * If `true`, image will be lazy-loaded

--- a/packages/portal/src/components/content/ContentCard.vue
+++ b/packages/portal/src/components/content/ContentCard.vue
@@ -198,14 +198,14 @@
        */
       imageWidth: {
         type: Number,
-        default: 480
+        default: 520
       },
       /**
        * Height of the image
        */
       imageHeight: {
         type: Number,
-        default: 288
+        default: 338
       },
       /**
        * Image alt text
@@ -220,7 +220,7 @@
        */
       contentfulImageCropPresets: {
         type: Object,
-        default: () => ({ 'small': { w: 480, h: 288, fit: 'fill', f: 'face' } })
+        default: () => ({ 'small': { w: 520, h: 338, fit: 'fill', f: 'face' } })
       },
       /**
        * Image sizes for optimised images

--- a/packages/portal/src/components/content/ContentCard.vue
+++ b/packages/portal/src/components/content/ContentCard.vue
@@ -21,8 +21,8 @@
       >
         <ImageOptimised
           :src="cardImageUrl"
-          :width="imageWidth"
-          :height="imageHeight"
+          :width="imageWidthPerVariant"
+          :height="imageHeightPerVariant"
           :alt="imageAlt"
           :content-type="imageContentType"
           :contentful-image-crop-presets="contentfulImageCropPresets"

--- a/packages/portal/src/components/content/ContentCard.vue
+++ b/packages/portal/src/components/content/ContentCard.vue
@@ -26,6 +26,7 @@
           :alt="imageAlt"
           :content-type="imageContentType"
           :contentful-image-crop-presets="contentfulImageCropPresets"
+          :image-sizes="imageSizes"
           :picture-source-media-resolutions="[1, 2]"
           :lazy="lazy"
           @error.native="imageNotFound"
@@ -220,6 +221,13 @@
       contentfulImageCropPresets: {
         type: Object,
         default: () => ({ 'small': { w: 480, h: 288, fit: 'fill', f: 'face' } })
+      },
+      /**
+       * Image sizes for optimised images
+       */
+      imageSizes: {
+        type: String,
+        default: null
       },
       /**
        * If `true`, image will be lazy-loaded

--- a/packages/portal/src/components/content/ContentCard.vue
+++ b/packages/portal/src/components/content/ContentCard.vue
@@ -19,25 +19,17 @@
         class="card-img"
         :class="{ logo }"
       >
-        <b-img-lazy
-          v-if="lazy"
-          :src="optimisedImageUrl"
-          :blank-width="blankImageWidth"
-          :blank-height="blankImageHeight"
+        <ImageOptimised
+          :src="cardImageUrl"
           :width="imageWidth"
           :height="imageHeight"
           :alt="imageAlt"
+          :content-type="imageContentType"
+          :contentful-image-crop-presets="contentfulImageCropPresets"
+          :picture-source-media-resolutions="[1, 2]"
+          :lazy="lazy"
           @error.native="imageNotFound"
           @load.native="imageLoaded"
-        />
-        <b-img
-          v-else
-          :src="optimisedImageUrl"
-          :width="imageWidth"
-          :height="imageHeight"
-          :alt="imageAlt"
-          @error="imageNotFound"
-          @load="imageLoaded"
         />
       </div>
       <SmartLink
@@ -134,7 +126,8 @@
     components: {
       ClientOnly,
       SmartLink,
-      MediaDefaultThumbnail: () => import('../media/MediaDefaultThumbnail')
+      MediaDefaultThumbnail: () => import('@/components/media/MediaDefaultThumbnail'),
+      ImageOptimised: () => import('@/components/image/ImageOptimised')
     },
 
     mixins: [
@@ -204,14 +197,14 @@
        */
       imageWidth: {
         type: Number,
-        default: null
+        default: 480
       },
       /**
        * Height of the image
        */
       imageHeight: {
         type: Number,
-        default: null
+        default: 280
       },
       /**
        * Image alt text
@@ -221,13 +214,12 @@
         default: ''
       },
       /**
-       * Image optimisation options
+       * Image crop presets for optimised images
        *
-       * Passed to `optimisedImageUrl` filter
        */
-      imageOptimisationOptions: {
+      contentfulImageCropPresets: {
         type: Object,
-        default: () => ({})
+        default: () => ({ 'small': { w: 480, h: 280, fit: 'fill' } })
       },
       /**
        * If `true`, image will be lazy-loaded
@@ -386,16 +378,6 @@
             return langMapValueForLocale(value, this.$i18n.locale, { omitUrisIfOtherValues: this.omitUrisIfOtherValues, omitAllUris: this.omitAllUris });
           }
         }).filter((displayText) => displayText.values.length > 0);
-      },
-
-      optimisedImageUrl() {
-        if (!this.$contentful.assets.isValidUrl(this.imageUrl)) {
-          return this.imageUrl;
-        }
-        return this.$contentful.assets.optimisedSrc(
-          { url: this.imageUrl, contentType: this.imageContentType },
-          { w: this.imageOptimisationOptions?.width, h: this.imageOptimisationOptions?.height }
-        );
       },
 
       tooltipTexts() {

--- a/packages/portal/src/components/content/ContentCard.vue
+++ b/packages/portal/src/components/content/ContentCard.vue
@@ -204,7 +204,7 @@
        */
       imageHeight: {
         type: Number,
-        default: 280
+        default: 288
       },
       /**
        * Image alt text
@@ -219,7 +219,7 @@
        */
       contentfulImageCropPresets: {
         type: Object,
-        default: () => ({ 'small': { w: 480, h: 280, fit: 'fill' } })
+        default: () => ({ 'small': { w: 480, h: 288, fit: 'fill' } })
       },
       /**
        * If `true`, image will be lazy-loaded
@@ -265,20 +265,6 @@
       limitValuesWithinEachText: {
         type: Number,
         default: -1
-      },
-      /**
-       * Height of image placeholder when lazy-loading image
-       */
-      blankImageHeight: {
-        type: Number,
-        default: null
-      },
-      /**
-       * Width of image placeholder when lazy-loading image
-       */
-      blankImageWidth: {
-        type: Number,
-        default: null
       },
       /**
        * If `true`, the image is a logo and will be styled differently
@@ -392,6 +378,26 @@
           return this.displayTitle?.value || this.tooltipTexts;
         }
         return null;
+      },
+
+      imageWidthPerVariant() {
+        if (this.variant === 'mini') {
+          return 120;
+        } else if (this.variant === 'list') {
+          return 240;
+        } else {
+          return this.imageWidth;
+        }
+      },
+
+      imageHeightPerVariant() {
+        if (this.variant === 'mini') {
+          return 120;
+        } else if (this.variant === 'list') {
+          return 240;
+        } else {
+          return this.imageHeight;
+        }
       }
     },
 

--- a/packages/portal/src/components/content/ContentCardSection.vue
+++ b/packages/portal/src/components/content/ContentCardSection.vue
@@ -32,7 +32,6 @@
             :title="card.name"
             :url="entityRouterLink(card.identifier, card.slug)"
             :image-url="card.entityImage"
-            :image-optimisation-options="{ width: 510 }"
             variant="mini"
           />
         </template>

--- a/packages/portal/src/components/content/ContentHubPage.vue
+++ b/packages/portal/src/components/content/ContentHubPage.vue
@@ -22,7 +22,6 @@
               :url="{ name: cardUrlName, params: { pathMatch: item.identifier || item.slug, exhibition: item.identifier } }"
               :image-url="item.thumbnail || imageUrl(item.primaryImageOfPage)"
               :image-content-type="imageContentType(item.primaryImageOfPage)"
-              :image-optimisation-options="{ width: 510 }"
               :image-alt="imageAlt(item.primaryImageOfPage)"
               :texts="[item.description]"
               :offset="index"

--- a/packages/portal/src/components/home/HomeLatestStories.vue
+++ b/packages/portal/src/components/home/HomeLatestStories.vue
@@ -16,7 +16,6 @@
         :key="card.identifier"
         :title="card.name"
         :image-url="cardImage(card)"
-        :image-optimisation-options="{ width: 960 }"
         :url="contentfulEntryUrl(card)"
       />
     </b-card-group>

--- a/packages/portal/src/components/image/ImageOptimised.vue
+++ b/packages/portal/src/components/image/ImageOptimised.vue
@@ -142,7 +142,8 @@
             memo[key] = {
               ...this.contentfulImageCropPresets[key],
               w: this.contentfulImageCropPresets[key].w * resolution,
-              h: this.contentfulImageCropPresets[key].h * resolution
+              h: this.contentfulImageCropPresets[key].h * resolution,
+              q: this.quality
             };
             return memo;
           }, {});

--- a/packages/portal/src/components/stories/StoriesFeaturedCard.vue
+++ b/packages/portal/src/components/stories/StoriesFeaturedCard.vue
@@ -5,6 +5,7 @@
     :url="contentfulEntryUrl(featuredStory)"
     :image-url="featuredStory.primaryImageOfPage?.image?.url"
     :image-content-type="featuredStory.primaryImageOfPage?.image?.contentType"
+    :image-sizes="imageSizes"
     :contentful-image-crop-presets="imageCropPresets"
     :lazy="false"
     class="featured-story-card"
@@ -42,7 +43,18 @@
           wqhd: { w: 1005, h: 480, fit: 'fill', f: 'face' },
           '4k': { w: 1255, h: 480, fit: 'fill', f: 'face' },
           '4k+': { w: 1485, h: 578, fit: 'fill', f: 'face' }
-        }
+        },
+        imageSizes: [
+          '(max-width: 575px) 545px', // bp-small
+          '(max-width: 767px) 510px', // bp-medium
+          '(max-width: 991px) 345px', // bp-large
+          '(max-width: 1199px) 465px', // bp-xl
+          '(max-width: 1399px) 555px', // bp-xxl
+          '(max-width: 1879px) 805px', // bp-xxxl
+          '(max-width: 2519px) 1005px', // bp-wqhd
+          '(max-width: 3019px) 1255px', // bp-4k
+          '1485px'
+        ].join(',')
       };
     },
 

--- a/packages/portal/src/components/stories/StoriesFeaturedCard.vue
+++ b/packages/portal/src/components/stories/StoriesFeaturedCard.vue
@@ -5,6 +5,7 @@
     :url="contentfulEntryUrl(featuredStory)"
     :image-url="featuredStory.primaryImageOfPage?.image?.url"
     :image-content-type="featuredStory.primaryImageOfPage?.image?.contentType"
+    :contentful-image-crop-presets="imageCropPresets"
     :lazy="false"
     class="featured-story-card"
     data-qa="featured story card"
@@ -27,6 +28,22 @@
         type: Object,
         required: true
       }
+    },
+
+    data() {
+      return {
+        imageCropPresets: {
+          small: { w: 545, h: 288, fit: 'fill', f: 'face' },
+          medium: { w: 510, h: 288, fit: 'fill', f: 'face' },
+          large: { w: 345, h: 288, fit: 'fill', f: 'face' },
+          xl: { w: 465, h: 288, fit: 'fill', f: 'face' },
+          xxl: { w: 555, h: 320, fit: 'fill', f: 'face' },
+          xxxl: { w: 805, h: 320, fit: 'fill', f: 'face' },
+          wqhd: { w: 1005, h: 480, fit: 'fill', f: 'face' },
+          '4k': { w: 1255, h: 480, fit: 'fill', f: 'face' },
+          '4k+': { w: 1485, h: 578, fit: 'fill', f: 'face' }
+        }
+      };
     },
 
     methods: {

--- a/packages/portal/src/components/stories/StoriesFeaturedCard.vue
+++ b/packages/portal/src/components/stories/StoriesFeaturedCard.vue
@@ -5,8 +5,6 @@
     :url="contentfulEntryUrl(featuredStory)"
     :image-url="featuredStory.image && featuredStory.image.url"
     :image-content-type="featuredStory.image && featuredStory.image.contentType"
-    :image-width="featuredStory.image && featuredStory.image.width"
-    :image-height="featuredStory.image && featuredStory.image.height"
     :lazy="false"
     class="featured-story-card"
     data-qa="featured story card"

--- a/packages/portal/src/components/stories/StoriesInterface.vue
+++ b/packages/portal/src/components/stories/StoriesInterface.vue
@@ -64,7 +64,6 @@
           :url="contentfulEntryUrl(entry)"
           :image-url="entry.primaryImageOfPage && entry.primaryImageOfPage.image.url"
           :image-content-type="entry.primaryImageOfPage && entry.primaryImageOfPage.image.contentType"
-          :image-optimisation-options="entry.primaryImageOfPage ? entryImageOptions(entry.primaryImageOfPage.image) : {}"
         />
       </template>
     </b-card-group>
@@ -218,11 +217,7 @@
         this.$scrollTo?.('#header');
       },
 
-      contentfulEntryUrl,
-
-      entryImageOptions(image) {
-        return image.width <= image.height ? { width: 660 } : { height: 620 };
-      }
+      contentfulEntryUrl
     }
   };
 </script>

--- a/packages/portal/tests/unit/components/content/ContentCard.spec.js
+++ b/packages/portal/tests/unit/components/content/ContentCard.spec.js
@@ -352,4 +352,14 @@ describe('components/content/ContentCard', () => {
       });
     });
   });
+
+  describe('when the card variant is list', () => {
+    it('sets the image width and height to 240', () => {
+      const wrapper = factory({ propsData: { imageUrl: 'https://example.org',  variant: 'list' } });
+
+      const image = wrapper.find('[data-qa="content card"] .card-img imageoptimised-stub');
+      expect(image.attributes('width')).toBe('240');
+      expect(image.attributes('height')).toBe('240');
+    });
+  });
 });

--- a/packages/portal/tests/unit/components/content/ContentCard.spec.js
+++ b/packages/portal/tests/unit/components/content/ContentCard.spec.js
@@ -25,7 +25,7 @@ const factory = ({ propsData, mocks } = {}) => mount(ContentCard, {
     $contentful: {
       assets: {
         isValidUrl: (url) => url.includes('images.ctfassets.net'),
-        optimisedSrc: sinon.spy((img) => `${img.url}?optimised`)
+        responsiveImageSrcset: (img) => `${img.url} srcset`
       }
     },
     $i18n: {
@@ -44,7 +44,8 @@ const factory = ({ propsData, mocks } = {}) => mount(ContentCard, {
     $tc: (key) => key,
     $store,
     ...mocks
-  }
+  },
+  stubs: ['ImageOptimised']
 });
 
 describe('components/content/ContentCard', () => {
@@ -205,24 +206,9 @@ describe('components/content/ContentCard', () => {
         const wrapper = factory();
         await wrapper.setProps({ imageUrl: 'https://example.org' });
 
-        const image = wrapper.find('[data-qa="content card"] .card-img img');
+        const image = wrapper.find('[data-qa="content card"] .card-img imageoptimised-stub');
         expect(image).toBeDefined();
         expect(image.attributes('src')).toBe('https://example.org');
-      });
-
-      it('may have an optimised image, if for Contentful asset', () => {
-        const wrapper = factory({ propsData: {
-          imageUrl: 'https://images.ctfassets.net/example/example.jpg',
-          imageContentType: 'image/jpeg',
-          imageOptimisationOptions: { width: 510 }
-        } });
-
-        expect(wrapper.vm.optimisedImageUrl).toContain('?optimised');
-        expect(wrapper.vm.$contentful.assets.optimisedSrc.calledWith({
-          url: 'https://images.ctfassets.net/example/example.jpg',
-          contentType: 'image/jpeg'
-        },
-        { w: 510, h: undefined })).toBe(true);
       });
 
       it('may have no image and is of variant mini', async() => {
@@ -245,11 +231,11 @@ describe('components/content/ContentCard', () => {
         const wrapper = factory();
         await wrapper.setProps({ imageUrl: 'https://example.org', variant: 'mini' });
 
-        let image = wrapper.find('[data-qa="content card"] .card-img img');
+        let image = wrapper.find('[data-qa="content card"] .card-img imageoptimised-stub');
         expect(image.exists()).toBe(true);
         await image.trigger('error');
 
-        image = wrapper.find('[data-qa="content card"] .card-img img');
+        image = wrapper.find('[data-qa="content card"] .card-img imageoptimised-stub');
         expect(image.exists()).toBe(false);
       });
     });

--- a/packages/portal/tests/unit/components/content/ContentHubPage.spec.js
+++ b/packages/portal/tests/unit/components/content/ContentHubPage.spec.js
@@ -19,6 +19,7 @@ const pageOfGalleries = [...identifiers].map(identifier => {
 
 const testPropsData = {
   pageMeta: { title: 'Title' },
+  title: 'Test title',
   items: pageOfItems,
   perPage: 24,
   total: 25,
@@ -27,6 +28,7 @@ const testPropsData = {
 
 const testGalleriesPropsData = {
   pageMeta: { title: 'Galleries title' },
+  title: 'Galleries title',
   items: pageOfGalleries,
   perPage: 24,
   total: 25,

--- a/packages/style/scss/cards.scss
+++ b/packages/style/scss/cards.scss
@@ -84,10 +84,14 @@
       background: $offwhite;
     }
 
+    picture {
+      display: flex;
+    }
+
     img {
       object-fit: cover;
       width: 100%;
-      height: 100%;
+      height: auto;
     }
   }
 

--- a/packages/style/scss/cards.scss
+++ b/packages/style/scss/cards.scss
@@ -87,7 +87,7 @@
     img {
       object-fit: cover;
       width: 100%;
-      height: auto;
+      height: 100%;
     }
   }
 


### PR DESCRIPTION
- handles content card image optimisation for Contentful images in `ContentCard` component. This instead of setting it per `ContentCard` instance.
- Simplifies setting the card image width and height. `ContentCard`s that are not in the masonry layout all have a set height (13rem) and max-width (480px) for default cards. List and mini cards also have set dimensions. Only `ItemPreviewCards` need to pass the image's intrinsic sizes
- adds default image crop settings including face focus for the card image
- adds custom image crop settings for StoriesFeaturedCard