### PR TITLE
chore: separate Docker Compose file to run app

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ To build the Docker image, run:
 docker build -t europeana/portal.js -f packages/portal/Dockerfile .
 ```
 
+### Docker Compose
+
+To run everything with Docker Compose, including the app:
+
+```shell
+docker compose -f docker-compose.app.yml up
+```
+
+The app will be exposed on the host on port 8080.
+
 ## Testing
 
 To run end-to-end tests, you will need Docker Engine and [Compose](https://docs.docker.com/compose/)

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -1,0 +1,21 @@
+include:
+  - docker-compose.yml
+services:
+  app:
+    image: europeana/portal.js:${TAG:-latest}
+    build:
+      context: .
+      dockerfile: ./packages/portal/Dockerfile
+      args:
+        IIIF_PRESENTATION_PLUGIN: ${IIIF_PRESENTATION_PLUGIN:-open-layers}
+    depends_on:
+      - postgres
+      - redis
+    env_file: packages/portal/.env
+    environment:
+      IIIF_PRESENTATION_PLUGIN: ${IIIF_PRESENTATION_PLUGIN:-open-layers}
+      POSTGRES_URL: postgres://postgres:${POSTGRES_PASSWORD:-postgres-password}@postgres/europeana_www
+      PORTAL_BASE_URL: http://localhost:8080
+      REDIS_URL: redis://redis
+    ports:
+      - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   pgadmin:
     image: dpage/pgadmin4

--- a/packages/portal/Dockerfile
+++ b/packages/portal/Dockerfile
@@ -26,6 +26,8 @@ COPY *.md ./
 COPY packages/portal/*.js ./packages/portal/
 COPY packages/portal/src ./packages/portal/src
 
+ARG IIIF_PRESENTATION_PLUGIN
+
 RUN npm run build
 RUN rm -rf node_modules packages/*/node_modules packages/mirador packages/style
 RUN rm -rf packages/portal/src/lang


### PR DESCRIPTION
1. Adds a a new Docker Compose YAML file to run the app along with the rest of the services.

    Run with `docker compose -f docker-compose.app.yml up`
 
    App will be exposed on port 8080 on the host.

    Example: run with different published image tags:

    ```sh
    # v1.154.0
    TAG=1.154.0 docker compose -f docker-compose.app.yml up

    # v1.155.0
    TAG=1.155.0 docker compose -f docker-compose.app.yml up
    ```

2. Adds IIIF_PRESENTATION_PLUGIN as a build argument for the app Docker image.

    Example: build & run local branch with different IIIF Presentation plugins:

    ```sh
    # mirador
    IIIF_PRESENTATION_PLUGIN=mirador TAG=${IIIF_PRESENTATION_PLUGIN} \
      docker compose -f docker-compose.app.yml up --build

    # list-props
    IIIF_PRESENTATION_PLUGIN=list-props TAG=${IIIF_PRESENTATION_PLUGIN} \
      docker compose -f docker-compose.app.yml up --build
    ```