### PR TITLE
chore: update swiper package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12877,14 +12877,6 @@
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
-    "node_modules/dom7": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.6.tgz",
-      "integrity": "sha512-emjdpPLhpNubapLFdjNL9tP06Sr+GZkrIHEXLWvOGsytACUrkbeIdjO5g77m00BrHTznnlcNqgmn7pCN192TBA==",
-      "dependencies": {
-        "ssr-window": "^4.0.0"
-      }
-    },
     "node_modules/domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -31061,11 +31053,6 @@
       "resolved": "https://registry.npmjs.org/sql-summary/-/sql-summary-1.0.1.tgz",
       "integrity": "sha512-IpCr2tpnNkP3Jera4ncexsZUp0enJBLr+pHCyTweMUBrbJsTgQeLWx1FXLhoBj/MvcnUQpkgOn2EY8FKOkUzww=="
     },
-    "node_modules/ssr-window": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
-      "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ=="
-    },
     "node_modules/ssri": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
@@ -32025,9 +32012,9 @@
       }
     },
     "node_modules/swiper": {
-      "version": "8.4.7",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.7.tgz",
-      "integrity": "sha512-VwO/KU3i9IV2Sf+W2NqyzwWob4yX9Qdedq6vBtS0rFqJ6Fa5iLUJwxQkuD4I38w0WDJwmFl8ojkdcRFPHWD+2g==",
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.1.5.tgz",
+      "integrity": "sha512-JJQWFXdxiMGC2j6ZGTYat5Z7NN9JORJBgHp0/joX9uPod+cRj0wr5H5VnWSNIz9JeAamQvYKaG7aFrGHIF9OEg==",
       "funding": [
         {
           "type": "patreon",
@@ -32038,11 +32025,6 @@
           "url": "http://opencollective.com/swiper"
         }
       ],
-      "hasInstallScript": true,
-      "dependencies": {
-        "dom7": "^4.0.4",
-        "ssr-window": "^4.0.2"
-      },
       "engines": {
         "node": ">= 4.7.0"
       }
@@ -36190,7 +36172,7 @@
         "redis": "^4.6.8",
         "redux": "^4.0.5",
         "redux-saga": "^1.1.3",
-        "swiper": "^8.2.4",
+        "swiper": "^11.1.5",
         "v-click-outside": "^3.2.0",
         "vue": "^2.7.10",
         "vue-client-only": "^2.1.0",

--- a/packages/portal/jest.config.js
+++ b/packages/portal/jest.config.js
@@ -11,8 +11,6 @@ export default {
     'vue'
   ],
   moduleNameMapper: {
-    // TODO: Ignore swiper in transformIgnorePatterns instead?
-    '^swiper$': '<rootDir>/tests/unit/swiperMock.js',
     '^@/(.*)$': '<rootDir>/src/$1',
     '\\.css$': '<rootDir>/tests/unit/styleMock.js'
   },
@@ -26,7 +24,7 @@ export default {
     '<rootDir>/tmp/'
   ],
   transformIgnorePatterns: [
-    '/node_modules/(?!decamelize)'
+    '/node_modules/(?!decamelize|swiper)'
   ],
   transform: {
     '^.+\\.(js|mjs)$': 'babel-jest',

--- a/packages/portal/nuxt.config.js
+++ b/packages/portal/nuxt.config.js
@@ -472,7 +472,7 @@ export default {
 
     publicPath: buildPublicPath(),
 
-    // swiper v8 (and its dependencies) is pure ESM and needs to be transpiled to be used by Vue2
+    // swiper v11 (and its dependencies) is pure ESM and needs to be transpiled to be used by Vue2
     // same with some of our custom packages
     transpile: [
       'dom7',

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -52,7 +52,7 @@
     "redis": "^4.6.8",
     "redux": "^4.0.5",
     "redux-saga": "^1.1.3",
-    "swiper": "^8.2.4",
+    "swiper": "^11.1.5",
     "v-click-outside": "^3.2.0",
     "vue": "^2.7.10",
     "vue-client-only": "^2.1.0",

--- a/packages/portal/src/components/generic/StackedCardsSwiper.vue
+++ b/packages/portal/src/components/generic/StackedCardsSwiper.vue
@@ -20,11 +20,11 @@
           class="swiper-slide text-center"
         >
           <img
-            :data-src="imageSrc(slide.image)"
-            :data-srcset="imageSrcset(slide.image)"
-            :data-sizes="imageSizes"
+            :src="imageSrc(slide.image)"
+            :srcset="imageSrcset(slide.image)"
+            :sizes="imageSizes"
             :alt="slide.image && slide.image.description || ''"
-            class="image-overlay position-absolute swiper-lazy"
+            class="image-overlay position-absolute"
           >
           <div
             class="card-body h-100 d-flex flex-column align-items-center position-relative"
@@ -62,7 +62,7 @@
 
 <script>
   import swiperMixin from '@/mixins/swiper';
-  import { EffectCoverflow, Keyboard, Lazy } from 'swiper';
+  import { EffectCoverflow, Keyboard } from 'swiper/modules';
 
   const SRCSET_PRESETS = {
     small: { w: 245, h: 440, fit: 'fill' },
@@ -100,15 +100,12 @@
     data() {
       return {
         swiperOptions: {
-          modules: [EffectCoverflow, Keyboard, Lazy],
+          modules: [EffectCoverflow, Keyboard],
           effect: 'coverflow',
           grabCursor: true,
           centeredSlides: true,
+          initialSlide: Math.floor(this.slides.length / 2),
           slideToClickedSlide: true,
-          preloadImages: false,
-          lazy: {
-            loadPrevNextAmount: 10
-          },
           breakpoints: {
             0: {
               spaceBetween: -150
@@ -141,14 +138,9 @@
       };
     },
 
-    mounted() {
-      const middleCardIndex = Math.floor(this.slides.length / 2);
-      this.swiper.slideTo(middleCardIndex);
-    },
-
     methods: {
       setFocusOnActiveSlideLink() {
-        this.$refs.slideLink[this.swiper.activeIndex].focus();
+        this.swiper && this.$refs.slideLink[this.swiper.activeIndex].focus();
       },
       imageSrc(image) {
         if (image?.url && this.$contentful.assets.isValidUrl(image.url)) {

--- a/packages/portal/src/components/generic/StackedCardsSwiper.vue
+++ b/packages/portal/src/components/generic/StackedCardsSwiper.vue
@@ -62,7 +62,7 @@
 
 <script>
   import swiperMixin from '@/mixins/swiper';
-  import { EffectCoverflow, Keyboard } from 'swiper/modules';
+  import { A11y, EffectCoverflow, Keyboard } from 'swiper/modules';
 
   const SRCSET_PRESETS = {
     small: { w: 245, h: 440, fit: 'fill' },
@@ -100,7 +100,7 @@
     data() {
       return {
         swiperOptions: {
-          modules: [EffectCoverflow, Keyboard],
+          modules: [A11y, EffectCoverflow, Keyboard],
           effect: 'coverflow',
           grabCursor: true,
           centeredSlides: true,

--- a/packages/portal/src/components/generic/StackedCardsSwiper.vue
+++ b/packages/portal/src/components/generic/StackedCardsSwiper.vue
@@ -25,13 +25,15 @@
           :index="i"
           class="swiper-slide text-center"
         >
-          <img
-            :src="imageSrc(slide.image)"
-            :srcset="imageSrcset(slide.image)"
+          <ImageOptimised
+            :src="slide.image.url"
+            :contentful-image-crop-presets="SRCSET_PRESETS"
             :sizes="imageSizes"
+            :width="slide.image.width"
+            :height="slide.image.height"
             :alt="slide.image && slide.image.description || ''"
             class="image-overlay position-absolute"
-          >
+          />
           <div
             class="card-body h-100 d-flex flex-column align-items-center position-relative"
           >
@@ -67,21 +69,16 @@
 </template>
 
 <script>
+  import ImageOptimised from '@/components/image/ImageOptimised';
   import swiperMixin from '@/mixins/swiper';
   import { A11y, EffectCoverflow, Keyboard } from 'swiper/modules';
 
-  const SRCSET_PRESETS = {
-    small: { w: 245, h: 440, fit: 'fill' },
-    medium: { w: 260, h: 420, fit: 'fill' },
-    large: { w: 280, h: 400, fit: 'fill' },
-    xl: { w: 300, h: 400, fit: 'fill' },
-    xxl: { w: 320, h: 370, fit: 'fill' },
-    '4k': { w: 355, h: 345, fit: 'fill' },
-    '4k+': { w: 480, h: 470, fit: 'fill' }
-  };
-
   export default {
     name: 'StackedCardsSwiper',
+
+    components: {
+      ImageOptimised
+    },
 
     mixins: [swiperMixin],
 
@@ -147,7 +144,16 @@
           '(max-width: 1399px) 320px', // bp-xxl
           '(max-width: 3019px) 355px', // bp-4k
           '480px'
-        ].join(',')
+        ].join(','),
+        SRCSET_PRESETS: {
+          small: { w: 245, h: 440, fit: 'fill' },
+          medium: { w: 260, h: 420, fit: 'fill' },
+          large: { w: 280, h: 400, fit: 'fill' },
+          xl: { w: 300, h: 400, fit: 'fill' },
+          xxl: { w: 320, h: 370, fit: 'fill' },
+          '4k': { w: 355, h: 345, fit: 'fill' },
+          '4k+': { w: 480, h: 470, fit: 'fill' }
+        }
       };
     },
 
@@ -175,18 +181,6 @@
         } else if (['pointerdown', 'touchstart'].includes(event.type) || (activeKeyboardNavigation && event.type === 'keydown')) {
           this.swiperComponentClasses = '';
         }
-      },
-      imageSrc(image) {
-        if (image?.url && this.$contentful.assets.isValidUrl(image.url)) {
-          return this.$contentful.assets.optimisedSrc(image, { w: 245, h: 440, fit: 'fill' });
-        } else if (image?.url) {
-          return image.url;
-        } else {
-          return null;
-        }
-      },
-      imageSrcset(image) {
-        return this.$contentful.assets.responsiveImageSrcset(image, SRCSET_PRESETS);
       }
     }
   };
@@ -357,12 +351,17 @@
     .image-overlay {
       height: 100%;
       width: 100%;
-      object-fit: cover;
       left: -50%;
       right: -50%;
       margin: 0 auto;
-      border-radius: $border-radius-small;
       transition: transform 400ms ease-out;
+
+      ::v-deep img {
+        height: 100%;
+        width: 100%;
+        object-fit: cover;
+        border-radius: $border-radius-small;
+      }
     }
   }
 

--- a/packages/portal/src/components/item/ItemMediaSwiper.vue
+++ b/packages/portal/src/components/item/ItemMediaSwiper.vue
@@ -53,7 +53,7 @@
   import swiperMixin from '@/mixins/swiper';
   import MediaCard from '../media/MediaCard';
   import WebResource from '@/plugins/europeana/edm/WebResource';
-  import { Pagination, Navigation } from 'swiper/modules';
+  import { A11y, Pagination, Navigation } from 'swiper/modules';
 
   export default {
     name: 'ItemMediaSwiper',
@@ -84,7 +84,7 @@
       const singleMediaResource = this.displayableMedia.length === 1;
       return {
         swiperOptions: {
-          modules: [Navigation, Pagination],
+          modules: [A11y, Navigation, Pagination],
           threshold: singleMediaResource ? 5000000 :  null,
           spaceBetween: singleMediaResource ? null : 40,
           centeredSlides: true,

--- a/packages/portal/src/components/item/ItemMediaSwiper.vue
+++ b/packages/portal/src/components/item/ItemMediaSwiper.vue
@@ -53,7 +53,7 @@
   import swiperMixin from '@/mixins/swiper';
   import MediaCard from '../media/MediaCard';
   import WebResource from '@/plugins/europeana/edm/WebResource';
-  import { Pagination, Navigation } from 'swiper';
+  import { Pagination, Navigation } from 'swiper/modules';
 
   export default {
     name: 'ItemMediaSwiper',
@@ -85,7 +85,6 @@
       return {
         swiperOptions: {
           modules: [Navigation, Pagination],
-          init: true,
           threshold: singleMediaResource ? 5000000 :  null,
           spaceBetween: singleMediaResource ? null : 40,
           centeredSlides: true,

--- a/packages/portal/src/components/landing/LandingIllustrationGroup.vue
+++ b/packages/portal/src/components/landing/LandingIllustrationGroup.vue
@@ -137,6 +137,10 @@
 
         swiperOptions: {
           modules: [A11y, Grid, Keyboard, Navigation, Pagination],
+          a11y: {
+            paginationBulletMessage: this.$t('swiper.a11y.paginationBulletGroupedSlides', { page: '{{index}}' })
+
+          },
           centerInsufficientSlides: true,
           grid: {
             fill: 'row',

--- a/packages/portal/src/components/landing/LandingIllustrationGroup.vue
+++ b/packages/portal/src/components/landing/LandingIllustrationGroup.vue
@@ -70,7 +70,7 @@
   import ImageOptimised from '@/components/image/ImageOptimised';
   import parseMarkdownHtmlMixin from '@/mixins/parseMarkdownHtml';
   import swiperMixin from '@/mixins/swiper';
-  import { Grid, Keyboard, Lazy, Navigation, Pagination } from 'swiper';
+  import { Grid, Keyboard, Navigation, Pagination } from 'swiper/modules';
 
   export default {
     name: 'LandingIllustrationGroup',
@@ -136,16 +136,13 @@
         ].join(','),
 
         swiperOptions: {
-          modules: [Grid, Keyboard, Lazy, Navigation, Pagination],
+          modules: [Grid, Keyboard, Navigation, Pagination],
           centerInsufficientSlides: true,
           grid: {
             fill: 'row',
             rows: 2
           },
-          lazy: {
-            loadPrevNextAmount: 4
-          },
-          preloadImages: false,
+          lazyPreloadPrevNext: 4,
           slidesPerGroup: 2,
           slidesPerView: 2,
           speed: 600,
@@ -164,9 +161,6 @@
               slidesPerGroup: 5,
               slidesPerView: 5
             }
-          },
-          on: {
-            activeIndexChange: this.setFocusOnActiveSlideLink
           }
         }
       };

--- a/packages/portal/src/components/landing/LandingIllustrationGroup.vue
+++ b/packages/portal/src/components/landing/LandingIllustrationGroup.vue
@@ -70,7 +70,7 @@
   import ImageOptimised from '@/components/image/ImageOptimised';
   import parseMarkdownHtmlMixin from '@/mixins/parseMarkdownHtml';
   import swiperMixin from '@/mixins/swiper';
-  import { Grid, Keyboard, Navigation, Pagination } from 'swiper/modules';
+  import { A11y, Grid, Keyboard, Navigation, Pagination } from 'swiper/modules';
 
   export default {
     name: 'LandingIllustrationGroup',
@@ -136,7 +136,7 @@
         ].join(','),
 
         swiperOptions: {
-          modules: [Grid, Keyboard, Navigation, Pagination],
+          modules: [A11y, Grid, Keyboard, Navigation, Pagination],
           centerInsufficientSlides: true,
           grid: {
             fill: 'row',

--- a/packages/portal/src/i18n/lang/en.js
+++ b/packages/portal/src/i18n/lang/en.js
@@ -1238,7 +1238,15 @@ export default {
     "storiesHaveLoaded": "{0} stories found"
   },
   "swiper": {
-    "paginationBulletLabel": "Slide group {page}"
+    "a11y": {
+      "firstSlide": "This is the first slide",
+      "lastSlide": "This is the last slide",
+      "nextSlide": "Next slide",
+      "paginationBullet": "Slide {page}",
+      "paginationBulletGroupedSlides": "Slide group {page}",
+      "previousSlide": "Previous slide",
+      "slideLabel": "Slide {slide} of {totalSlides}"
+    }
   },
   "themes": {
     "themes": "Themes",

--- a/packages/portal/src/mixins/swiper.js
+++ b/packages/portal/src/mixins/swiper.js
@@ -7,7 +7,13 @@ export default {
     return {
       swiper: null,
       swiperDefaultOptions: {
-        a11y: true,
+        a11y: { enabled: true,
+          firstSlideMessage: this.$t('swiper.a11y.firstSlide'),
+          lastSlideMessage: this.$t('swiper.a11y.lastSlide'),
+          nextSlideMessage: this.$t('swiper.a11y.nextSlide'),
+          paginationBulletMessage: this.$t('swiper.a11y.paginationBullet', { page: '{{index}}' }),
+          prevSlideMessage: this.$t('swiper.a11y.previousSlide'),
+          slideLabelMessage: this.$t('swiper.a11y.slideLabel', { slide: '{{index}}', totalSlides: '{{slidesLength}}' }) },
         keyboard: {
           enabled: true,
           pageUpDown: false
@@ -23,8 +29,7 @@ export default {
         pagination: {
           clickable: true,
           el: '.swiper-pagination',
-          type: 'bullets',
-          renderBullet: (index, className) => `<button aria-label="${this.$t('swiper.paginationBulletLabel', { page: index + 1 })}" class="${className}"></button>`
+          type: 'bullets'
         },
         slidesPerView: 'auto'
       },

--- a/packages/portal/src/mixins/swiper.js
+++ b/packages/portal/src/mixins/swiper.js
@@ -11,11 +11,7 @@ export default {
           enabled: true,
           pageUpDown: false
         },
-        lazy: {
-          enabled: true,
-          checkInView: true,
-          loadPrevNext: true
-        },
+        lazy: true,
         navigation: {
           nextEl: '.swiper-button-next',
           prevEl: '.swiper-button-prev'

--- a/packages/portal/src/mixins/swiper.js
+++ b/packages/portal/src/mixins/swiper.js
@@ -7,6 +7,7 @@ export default {
     return {
       swiper: null,
       swiperDefaultOptions: {
+        a11y: true,
         keyboard: {
           enabled: true,
           pageUpDown: false

--- a/packages/portal/tests/unit/mixins/swiper.spec.js
+++ b/packages/portal/tests/unit/mixins/swiper.spec.js
@@ -20,7 +20,7 @@ describe('mixins/swiper', () => {
   describe('when swiper package is available', () => {
     it('initialises new swiper', () => {
       const wrapper = factory();
-      expect(wrapper.vm.swiper).toEqual({ element: '.swiper' });
+      expect(wrapper.vm.swiper.el).toEqual('.swiper');
     });
   });
   describe('swiperOnAfterInit()', () => {


### PR DESCRIPTION
- Updates the Swiper package to the latest version 11.1.5
  - `Lazy` no longer is a separate Swiper module but relies on native image lazy loading
  - `A11y` module is introduced
- Adds translation strings for Swiper a11y labels
- Updates all swiper instances to work with the new version (StackedCardsSwiper, LandingIllustrationGroup, ItemMediaSwiper)
- Refactor StackedCardsSwiper to use ImageOptimised