### PR TITLE
fix: max width on entity badges

### DIFF
--- a/packages/portal/src/components/entity/EntityBadges.vue
+++ b/packages/portal/src/components/entity/EntityBadges.vue
@@ -118,6 +118,12 @@
 <style lang="scss" scoped>
   @import '@europeana/style/scss/variables';
 
+  .badges-wrapper {
+    a {
+      max-width: 100%;
+    }
+  }
+
   .related-collections ::v-deep .badge-pill {
     margin-right: 0.5rem;
     margin-bottom: 0.5rem;

--- a/packages/style/scss/badges.scss
+++ b/packages/style/scss/badges.scss
@@ -92,6 +92,7 @@
   padding: 0.25rem 0.75rem;
   height: 2.25rem;
   min-width: 4rem;
+  max-width: 100%;
   display: inline-flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
To prevent badges with long text values from breaking the layout.