### PR TITLE
fix: workaround to not have aria-expanded on searchbox

### DIFF
--- a/packages/portal/src/components/search/SearchQueryBuilderRuleTermInput.vue
+++ b/packages/portal/src/components/search/SearchQueryBuilderRuleTermInput.vue
@@ -16,7 +16,6 @@
       role="searchbox"
       aria-autocomplete="list"
       :aria-owns="showSearchOptions ? optionsId : null"
-      :aria-expanded="showSearchOptions"
       :aria-controls="showSearchOptions ? optionsId : null"
       @input="handleInput"
       @blur="handleBlur"

--- a/packages/portal/src/components/search/SearchQueryBuilderRuleTermInput.vue
+++ b/packages/portal/src/components/search/SearchQueryBuilderRuleTermInput.vue
@@ -16,7 +16,7 @@
       role="searchbox"
       aria-autocomplete="list"
       :aria-owns="showSearchOptions ? optionsId : null"
-      :aria-expanded="showSearchOptions ? 'true' : 'false'"
+      :aria-expanded="showSearchOptions"
       :aria-controls="showSearchOptions ? optionsId : null"
       @input="handleInput"
       @blur="handleBlur"

--- a/packages/portal/src/components/stories/StoriesTagsDropdown.vue
+++ b/packages/portal/src/components/stories/StoriesTagsDropdown.vue
@@ -32,7 +32,6 @@
           aria-autocomplete="list"
           :aria-owns="showDropdown ? 'tags-options' : null"
           :aria-controls="showDropdown ? 'tags-options' : null"
-          :aria-expanded="showDropdown"
           :aria-label="$t('categories.label')"
           @focusin="handleFocusin"
         />

--- a/packages/portal/src/components/stories/StoriesTagsDropdown.vue
+++ b/packages/portal/src/components/stories/StoriesTagsDropdown.vue
@@ -32,7 +32,7 @@
           aria-autocomplete="list"
           :aria-owns="showDropdown ? 'tags-options' : null"
           :aria-controls="showDropdown ? 'tags-options' : null"
-          :aria-expanded="showDropdown ? 'true' : 'false'"
+          :aria-expanded="showDropdown"
           :aria-label="$t('categories.label')"
           @focusin="handleFocusin"
         />


### PR DESCRIPTION
`aria-expanded` is not allowed on element with role `searchbox`.
This is a workaround to let the e2e tests pass.
Proper solution will need a refactor of the searchbox into a combobox with correct child elements and roles. WIP: [#2433 ](https://github.com/europeana/portal.js/pull/2433)