### PR TITLE
feat: add scrollTo composable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9159,12 +9159,6 @@
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "dev": true
     },
-    "node_modules/bezier-easing": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/bezier-easing/-/bezier-easing-2.1.0.tgz",
-      "integrity": "sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig==",
-      "dev": true
-    },
     "node_modules/bfj": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/bfj/-/bfj-7.0.2.tgz",
@@ -33973,15 +33967,6 @@
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.6.5.tgz",
       "integrity": "sha512-VYXZQLtjuvKxxcshuRAwjHnciqZVoXAjTjcqBTz4rKc8qih9g9pI3hbDjmqXaHdgL3v8pV6P8Z335XvHzESxLQ=="
     },
-    "node_modules/vue-scrollto": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/vue-scrollto/-/vue-scrollto-2.20.0.tgz",
-      "integrity": "sha512-7i+AGKJTThZnMEkhIPgrZjyAX+fXV7/rGdg+CV283uZZwCxwiMXaBLTmIc5RTA4uwGnT+E6eJle3mXQfM2OD3A==",
-      "dev": true,
-      "dependencies": {
-        "bezier-easing": "2.1.0"
-      }
-    },
     "node_modules/vue-server-renderer": {
       "version": "2.7.14",
       "resolved": "https://registry.npmjs.org/vue-server-renderer/-/vue-server-renderer-2.7.14.tgz",
@@ -36371,7 +36356,6 @@
         "svg-url-loader": "^7.1.1",
         "vue-masonry": "^0.13.0",
         "vue-matomo": "^4.2.0",
-        "vue-scrollto": "^2.20.0",
         "vuedraggable": "^2.24.3"
       },
       "peerDependencies": {

--- a/packages/portal/nuxt.config.js
+++ b/packages/portal/nuxt.config.js
@@ -303,7 +303,6 @@ export default {
     '~/plugins/vue-session.client',
     '~/plugins/vue-announcer.client',
     '~/plugins/vue-masonry.client',
-    '~/plugins/vue-scrollto.client',
     '~/plugins/features',
     `~/plugins/media/${process.env.BUILD_MEDIA_PRESENTATION_PLUGIN || 'switch'}`
   ],

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -77,7 +77,6 @@
     "svg-url-loader": "^7.1.1",
     "vue-masonry": "^0.13.0",
     "vue-matomo": "^4.2.0",
-    "vue-scrollto": "^2.20.0",
     "vuedraggable": "^2.24.3"
   },
   "peerDependencies": {

--- a/packages/portal/src/components/search/SearchInterface.vue
+++ b/packages/portal/src/components/search/SearchInterface.vue
@@ -178,6 +178,7 @@
   import { addContentTierFilter, filtersFromQf } from '@/plugins/europeana/search';
   import advancedSearchMixin from '@/mixins/advancedSearch.js';
   import itemPreviewCardGroupViewMixin from '@/mixins/europeana/item/itemPreviewCardGroupView';
+  import useScrollTo from '@/composables/scrollTo.js';
 
   export default {
     name: 'SearchInterface',
@@ -222,6 +223,11 @@
       }
     },
 
+    setup() {
+      const { scrollToSelector } = useScrollTo();
+      return { scrollToSelector };
+    },
+
     data() {
       return {
         apiParams: {},
@@ -240,7 +246,7 @@
 
       // NOTE: this helps prevent lazy-loading issues when paginating in Chrome 103
       await this.$nextTick();
-      this.$scrollTo && await this.$scrollTo('#header', { cancelable: false });
+      process.client && this.scrollToSelector('#header');
 
       // Remove cleared rules
       const qaRules = this.advancedSearchRulesFromRouteQuery();

--- a/packages/portal/src/components/stories/StoriesInterface.vue
+++ b/packages/portal/src/components/stories/StoriesInterface.vue
@@ -1,6 +1,5 @@
 <template>
   <div
-    ref="container"
     data-qa="stories interface"
   >
     <client-only>

--- a/packages/portal/src/components/stories/StoriesInterface.vue
+++ b/packages/portal/src/components/stories/StoriesInterface.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    ref="container"
     data-qa="stories interface"
   >
     <client-only>
@@ -93,6 +94,7 @@
   import LoadingSpinner from '@/components/generic/LoadingSpinner';
   import StoriesTypeFilter from '@/components/stories/StoriesTypeFilter';
   import { contentfulEntryUrl } from '@/utils/contentful/entry-url.js';
+  import useScrollTo from '@/composables/scrollTo.js';
 
   const CTA_BANNER = 'cta-banner';
 
@@ -119,6 +121,11 @@
         type: Object,
         default: () => {}
       }
+    },
+
+    setup() {
+      const { scrollToSelector } = useScrollTo();
+      return { scrollToSelector };
     },
 
     data() {
@@ -189,7 +196,7 @@
     watch: {
       async page() {
         await this.$fetch();
-        this.$scrollTo?.('#header');
+        this.scrollToSelector('#header');
       },
       selectedTags: '$fetch',
       selectedType: '$fetch'

--- a/packages/portal/src/composables/scrollTo.js
+++ b/packages/portal/src/composables/scrollTo.js
@@ -26,7 +26,7 @@ export default function useScrollTo() {
   };
 
   const scrollToSelector = (selector, options = {}) => {
-    scrollToElement(document.querySelector(selector, options));
+    scrollToElement(document.querySelector(selector), options);
   };
 
   const scrollToElement = (element, options = {}) => {

--- a/packages/portal/src/composables/scrollTo.js
+++ b/packages/portal/src/composables/scrollTo.js
@@ -1,0 +1,42 @@
+function scrollToSelector(selector, options = {}) {
+  scrollToElement(document.querySelector(selector, options));
+}
+
+function scrollToElement(element, options = {}) {
+  const { container, offsetLeft, offsetTop } = {
+    container: window,
+    offsetLeft: 0,
+    offsetTop: 0,
+    ...options
+  };
+
+  if (!element || !container) {
+    return;
+  }
+
+  const left = element.offsetLeft + offsetLeft;
+  const top = element.offsetTop + offsetTop;
+
+  container.scroll({ behavior: 'smooth', left, top });
+}
+
+function scrollElementToCentre(element, options = {}) {
+  const { container } = { container: window, ...options };
+
+  if (!element || !container) {
+    return;
+  }
+
+  const offsetLeft = -((container.offsetWidth - element.offsetWidth) / 2);
+  const offsetTop = -((container.offsetHeight - element.offsetHeight) / 2);
+
+  scrollToElement(element, { ...options, offsetLeft, offsetTop });
+}
+
+export default function useScrollTo() {
+  return {
+    scrollElementToCentre,
+    scrollToElement,
+    scrollToSelector
+  };
+}

--- a/packages/portal/src/composables/scrollTo.js
+++ b/packages/portal/src/composables/scrollTo.js
@@ -36,7 +36,7 @@ export default function useScrollTo() {
     }
     scrolling.value = true;
 
-    const { container, offsetLeft, offsetTop } = {
+    const { behavior, container, offsetLeft, offsetTop } = {
       container: window,
       offsetLeft: 0,
       offsetTop: 0,
@@ -50,7 +50,12 @@ export default function useScrollTo() {
     const left = element.offsetLeft + offsetLeft;
     const top = element.offsetTop + offsetTop;
 
-    container.scroll({ behavior: 'smooth', left, top });
+    const scrollOptions = { left, top };
+    if (behavior) {
+      scrollOptions.behavior = behavior;
+    }
+
+    container.scroll(scrollOptions);
 
     // debounce, e.g. if triggered by window resize event
     setTimeout(finishScrolling, 300);

--- a/packages/portal/src/composables/scrollTo.js
+++ b/packages/portal/src/composables/scrollTo.js
@@ -1,40 +1,77 @@
-function scrollToSelector(selector, options = {}) {
-  scrollToElement(document.querySelector(selector, options));
-}
-
-function scrollToElement(element, options = {}) {
-  const { container, offsetLeft, offsetTop } = {
-    container: window,
-    offsetLeft: 0,
-    offsetTop: 0,
-    ...options
-  };
-
-  if (!element || !container) {
-    return;
-  }
-
-  const left = element.offsetLeft + offsetLeft;
-  const top = element.offsetTop + offsetTop;
-
-  container.scroll({ behavior: 'smooth', left, top });
-}
-
-function scrollElementToCentre(element, options = {}) {
-  const { container } = { container: window, ...options };
-
-  if (!element || !container) {
-    return;
-  }
-
-  const offsetLeft = -((container.offsetWidth - element.offsetWidth) / 2);
-  const offsetTop = -((container.offsetHeight - element.offsetHeight) / 2);
-
-  scrollToElement(element, { ...options, offsetLeft, offsetTop });
-}
+import { ref } from 'vue';
 
 export default function useScrollTo() {
+  const scrolling = ref(false);
+  const queue = ref([]);
+
+  const finishScrolling = () => {
+    scrolling.value = false;
+    if (queue.value.length > 0) {
+      const { element, options } = queue.value.shift();
+      scrollToElement(element, options);
+    }
+  };
+
+  const enqueue = (element, options = {}) => {
+    let toEnqueue = true;
+
+    // don't enqueue if element is already next in the queue to scroll to
+    if (queue.value.length > 0) {
+      toEnqueue = (element !== queue.value[0].element);
+    }
+
+    if (toEnqueue) {
+      queue.value.push({ element, options });
+    }
+  };
+
+  const scrollToSelector = (selector, options = {}) => {
+    scrollToElement(document.querySelector(selector, options));
+  };
+
+  const scrollToElement = (element, options = {}) => {
+    if (scrolling.value) {
+      enqueue(element, options);
+      return;
+    }
+    scrolling.value = true;
+
+    const { container, offsetLeft, offsetTop } = {
+      container: window,
+      offsetLeft: 0,
+      offsetTop: 0,
+      ...options
+    };
+
+    if (!element || !container) {
+      return;
+    }
+
+    const left = element.offsetLeft + offsetLeft;
+    const top = element.offsetTop + offsetTop;
+
+    container.scroll({ behavior: 'smooth', left, top });
+
+    // debounce, e.g. if triggered by window resize event
+    setTimeout(finishScrolling, 300);
+  };
+
+  const scrollElementToCentre = (element, options = {}) => {
+    const { container } = { container: window, ...options };
+
+    if (!element || !container) {
+      return;
+    }
+
+    const offsetLeft = -((container.offsetWidth - element.offsetWidth) / 2);
+    const offsetTop = -((container.offsetHeight - element.offsetHeight) / 2);
+
+    scrollToElement(element, { ...options, offsetLeft, offsetTop });
+  };
+
   return {
+    queue,
+    scrolling,
     scrollElementToCentre,
     scrollToElement,
     scrollToSelector

--- a/packages/portal/src/pages/collections/persons-or-places.vue
+++ b/packages/portal/src/pages/collections/persons-or-places.vue
@@ -36,6 +36,7 @@
   import { getEntityTypeApi, getEntityTypeHumanReadable } from '@/plugins/europeana/entity';
   import { getLabelledSlug } from '@/plugins/europeana/utils.js';
   import pageMetaMixin from '@/mixins/pageMeta';
+  import useScrollTo from '@/composables/scrollTo.js';
 
   import ContentHeader from '@/components/content/ContentHeader';
   import ContentCard from '@/components/content/ContentCard';
@@ -53,6 +54,11 @@
     mixins: [pageMetaMixin],
 
     middleware: 'sanitisePageQuery',
+
+    setup() {
+      const { scrollToSelector } = useScrollTo();
+      return { scrollToSelector };
+    },
 
     data() {
       return {
@@ -80,7 +86,7 @@
         this.entities = response.entities;
         this.total = response.total;
       } finally {
-        this.$scrollTo?.('#header');
+        process.client && this.scrollToSelector('#header');
       }
     },
 
@@ -105,7 +111,10 @@
     },
 
     watch: {
-      '$route.query.page': '$fetch'
+      async '$route.query.page'() {
+        await this.$fetch();
+        this.scrollToSelector('#header');
+      }
     },
 
     methods: {

--- a/packages/portal/src/pages/galleries/index.vue
+++ b/packages/portal/src/pages/galleries/index.vue
@@ -39,6 +39,7 @@
   import { getLabelledSlug } from '@/plugins/europeana/utils.js';
   import ContentHubPage from '@/components/content/ContentHubPage.vue';
   import pageMetaMixin from '@/mixins/pageMeta';
+  import useScrollTo from '@/composables/scrollTo.js';
 
   const PER_PAGE = 24;
 
@@ -51,6 +52,10 @@
     },
     mixins: [pageMetaMixin],
     middleware: 'sanitisePageQuery',
+    setup() {
+      const { scrollToSelector } = useScrollTo();
+      return { scrollToSelector };
+    },
     data() {
       return {
         galleries: [],
@@ -71,8 +76,6 @@
       this.galleries = setResponse.items && this.parseSets(setResponse.items);
       this.total = setResponse.partOf.total;
       this.perPage = PER_PAGE;
-
-      this.$scrollTo?.('#header');
     },
     computed: {
       pageMeta() {
@@ -90,7 +93,10 @@
       }
     },
     watch: {
-      '$route.query.page': '$fetch'
+      async '$route.query.page'() {
+        await this.$fetch();
+        this.scrollToSelector('#header');
+      }
     },
     methods: {
       parseSets(sets) {

--- a/packages/portal/src/plugins/vue-scrollto.client.js
+++ b/packages/portal/src/plugins/vue-scrollto.client.js
@@ -1,4 +1,0 @@
-import Vue from 'vue';
-import VueScrollTo from 'vue-scrollto';
-
-Vue.use(VueScrollTo);

--- a/packages/portal/tests/unit/components/search/SearchInterface.spec.js
+++ b/packages/portal/tests/unit/components/search/SearchInterface.spec.js
@@ -81,6 +81,7 @@ const factory = ({ $fetchState = {}, mocks = {}, propsData = {}, data = {} } = {
 
 describe('components/search/SearchInterface', () => {
   afterEach(sinon.resetHistory);
+  afterAll(sinon.restore);
 
   describe('fetch', () => {
     it('activates the search in the store', async() => {
@@ -150,11 +151,12 @@ describe('components/search/SearchInterface', () => {
 
     it('scrolls to the page header element', async() => {
       const wrapper = factory();
-      wrapper.vm.$scrollTo = sinon.spy();
+      process.client = true;
+      wrapper.vm.scrollToSelector = sinon.spy();
 
       await wrapper.vm.fetch();
 
-      expect(wrapper.vm.$scrollTo.calledWith('#header')).toBe(true);
+      expect(wrapper.vm.scrollToSelector.calledWith('#header')).toBe(true);
     });
 
     it('logs the search interaction to APM', async() => {

--- a/packages/portal/tests/unit/components/stories/StoriesInterface.spec.js
+++ b/packages/portal/tests/unit/components/stories/StoriesInterface.spec.js
@@ -159,7 +159,6 @@ const factory = ({ data = {}, propsData = {}, $fetchState = {}, mocks = {} } = {
         page: '1'
       }
     },
-    $scrollTo: sinon.stub(),
     $fetchState,
     $t: (key) => key,
     $tc: (key) => key,
@@ -496,10 +495,11 @@ describe('components/stories/StoriesInterface', () => {
   describe('when paginating', () => {
     it('scrolls to the top of the page', async() => {
       const wrapper = factory();
+      wrapper.vm.scrollToSelector = sinon.spy();
 
       await wrapper.vm.watch.page.call(wrapper.vm, { page: 2 });
 
-      expect(wrapper.vm.$scrollTo.calledWith('#header')).toBe(true);
+      expect(wrapper.vm.scrollToSelector.calledWith('#header')).toBe(true);
     });
   });
 });

--- a/packages/portal/tests/unit/composables/scrollTo.spec.js
+++ b/packages/portal/tests/unit/composables/scrollTo.spec.js
@@ -28,7 +28,7 @@ describe('useScrollTo', () => {
       expect(typeof scrollToElement).toBe('function');
     });
 
-    it('smooth scrolls container to element', () => {
+    it('scrolls container to element', () => {
       const container = {
         scroll: sinon.spy()
       };
@@ -40,7 +40,7 @@ describe('useScrollTo', () => {
       const { scrollToElement } = useScrollTo();
       scrollToElement(element, { container });
 
-      expect(container.scroll.calledWith({ behavior: 'smooth', left: 10, top: 20 })).toBe(true);
+      expect(container.scroll.calledWith({ left: 10, top: 20 })).toBe(true);
     });
 
     it('applies optional offsets if given', () => {
@@ -55,7 +55,23 @@ describe('useScrollTo', () => {
       const { scrollToElement } = useScrollTo();
       scrollToElement(element, { container, offsetLeft: 5, offsetTop: -5 });
 
-      expect(container.scroll.calledWith({ behavior: 'smooth', left: 15, top: 15 })).toBe(true);
+      expect(container.scroll.calledWith({ left: 15, top: 15 })).toBe(true);
+    });
+
+    it('sets scroll behavior if given', () => {
+      const container = {
+        scroll: sinon.spy()
+      };
+      const element = {
+        offsetLeft: 10,
+        offsetTop: 20
+      };
+      const behavior = 'smooth';
+
+      const { scrollToElement } = useScrollTo();
+      scrollToElement(element, { behavior, container });
+
+      expect(container.scroll.calledWith({ behavior, left: 10, top: 20 })).toBe(true);
     });
 
     it('enqueues additional scroll requests, once per element', () => {
@@ -88,7 +104,7 @@ describe('useScrollTo', () => {
       expect(typeof scrollElementToCentre).toBe('function');
     });
 
-    it('smooth scrolls container to centre element', () => {
+    it('scrolls container to centre element', () => {
       const container = {
         offsetHeight: 200,
         offsetWidth: 100,
@@ -104,7 +120,7 @@ describe('useScrollTo', () => {
       const { scrollElementToCentre } = useScrollTo();
       scrollElementToCentre(element, { container });
 
-      expect(container.scroll.calledWith({ behavior: 'smooth', left: 15, top: 20 })).toBe(true);
+      expect(container.scroll.calledWith({ left: 15, top: 20 })).toBe(true);
     });
   });
 });

--- a/packages/portal/tests/unit/composables/scrollTo.spec.js
+++ b/packages/portal/tests/unit/composables/scrollTo.spec.js
@@ -62,17 +62,22 @@ describe('useScrollTo', () => {
       const container = {
         scroll: sinon.spy()
       };
-      const element = {
+      const element1 = {
         offsetLeft: 10,
         offsetTop: 20
       };
+      const element2 = {
+        offsetLeft: 20,
+        offsetTop: 10
+      };
 
       const { queue, scrollToElement } = useScrollTo();
-      scrollToElement(element, { container });
-      scrollToElement(element, { container });
-      scrollToElement(element, { container });
+      scrollToElement(element1, { container });
+      scrollToElement(element1, { container });
+      scrollToElement(element1, { container });
+      scrollToElement(element2, { container });
 
-      expect(queue.value.length).toBe(1);
+      expect(queue.value.length).toBe(2);
     });
   });
 

--- a/packages/portal/tests/unit/composables/scrollTo.spec.js
+++ b/packages/portal/tests/unit/composables/scrollTo.spec.js
@@ -5,6 +5,22 @@ describe('useScrollTo', () => {
   afterEach(sinon.resetHistory);
   afterAll(sinon.restore);
 
+  describe('queue array', () => {
+    it('is included in return value', () => {
+      const { queue } = useScrollTo();
+
+      expect(queue.value).toEqual([]);
+    });
+  });
+
+  describe('scrolling boolean', () => {
+    it('is included in return value', () => {
+      const { scrolling } = useScrollTo();
+
+      expect(scrolling.value).toBe(false);
+    });
+  });
+
   describe('scrollToElement function', () => {
     it('is included in return value', () => {
       const { scrollToElement } = useScrollTo();

--- a/packages/portal/tests/unit/composables/scrollTo.spec.js
+++ b/packages/portal/tests/unit/composables/scrollTo.spec.js
@@ -57,6 +57,23 @@ describe('useScrollTo', () => {
 
       expect(container.scroll.calledWith({ behavior: 'smooth', left: 15, top: 15 })).toBe(true);
     });
+
+    it('enqueues additional scroll requests, once per element', () => {
+      const container = {
+        scroll: sinon.spy()
+      };
+      const element = {
+        offsetLeft: 10,
+        offsetTop: 20
+      };
+
+      const { queue, scrollToElement } = useScrollTo();
+      scrollToElement(element, { container });
+      scrollToElement(element, { container });
+      scrollToElement(element, { container });
+
+      expect(queue.value.length).toBe(1);
+    });
   });
 
   describe('scrollElementToCentre function', () => {

--- a/packages/portal/tests/unit/composables/scrollTo.spec.js
+++ b/packages/portal/tests/unit/composables/scrollTo.spec.js
@@ -1,0 +1,72 @@
+import sinon from 'sinon';
+import useScrollTo from '@/composables/scrollTo.js';
+
+describe('useScrollTo', () => {
+  afterEach(sinon.resetHistory);
+  afterAll(sinon.restore);
+
+  describe('scrollToElement function', () => {
+    it('is included in return value', () => {
+      const { scrollToElement } = useScrollTo();
+
+      expect(typeof scrollToElement).toBe('function');
+    });
+
+    it('smooth scrolls container to element', () => {
+      const container = {
+        scroll: sinon.spy()
+      };
+      const element = {
+        offsetLeft: 10,
+        offsetTop: 20
+      };
+
+      const { scrollToElement } = useScrollTo();
+      scrollToElement(element, { container });
+
+      expect(container.scroll.calledWith({ behavior: 'smooth', left: 10, top: 20 })).toBe(true);
+    });
+
+    it('applies optional offsets if given', () => {
+      const container = {
+        scroll: sinon.spy()
+      };
+      const element = {
+        offsetLeft: 10,
+        offsetTop: 20
+      };
+
+      const { scrollToElement } = useScrollTo();
+      scrollToElement(element, { container, offsetLeft: 5, offsetTop: -5 });
+
+      expect(container.scroll.calledWith({ behavior: 'smooth', left: 15, top: 15 })).toBe(true);
+    });
+  });
+
+  describe('scrollElementToCentre function', () => {
+    it('is included in return value', () => {
+      const { scrollElementToCentre } = useScrollTo();
+
+      expect(typeof scrollElementToCentre).toBe('function');
+    });
+
+    it('smooth scrolls container to centre element', () => {
+      const container = {
+        offsetHeight: 200,
+        offsetWidth: 100,
+        scroll: sinon.spy()
+      };
+      const element = {
+        offsetHeight: 40,
+        offsetLeft: 50,
+        offsetTop: 100,
+        offsetWidth: 30
+      };
+
+      const { scrollElementToCentre } = useScrollTo();
+      scrollElementToCentre(element, { container });
+
+      expect(container.scroll.calledWith({ behavior: 'smooth', left: 15, top: 20 })).toBe(true);
+    });
+  });
+});

--- a/packages/portal/tests/unit/pages/collections/persons-or-places.spec.js
+++ b/packages/portal/tests/unit/pages/collections/persons-or-places.spec.js
@@ -84,11 +84,12 @@ describe('pages/collections/persons-or-places', () => {
 
     it('scrolls to the page header element', async() => {
       const wrapper = factory();
-      wrapper.vm.$scrollTo = sinon.spy();
+      process.client = true;
+      wrapper.vm.scrollToSelector = sinon.spy();
 
       await wrapper.vm.fetch();
 
-      expect(wrapper.vm.$scrollTo.calledWith('#header')).toBe(true);
+      expect(wrapper.vm.scrollToSelector.calledWith('#header')).toBe(true);
     });
   });
 


### PR DESCRIPTION
* adds a new Vue composable for scrolling to an element, or scrolling so that an element is centred in its container
* the composable will keep a queue of scroll requests and do one at a time, with a pause of 300 ms between, and only permitting each element to be on the queue once at a time
* replaces the use of vue-scrollto plugin with this composable