### PR TITLE
chore: unscope style in repeated components

### DIFF
--- a/packages/portal/src/components/generic/SmartLink.vue
+++ b/packages/portal/src/components/generic/SmartLink.vue
@@ -2,7 +2,7 @@
   <b-link
     v-if="useRouterLink"
     :to="path"
-    :class="linkClass"
+    :class="[linkClass, 'smart-link']"
     :disabled="disabled"
     :target="null"
     @click.capture.native="logSearchLink && setLoggableInteraction()"
@@ -13,7 +13,7 @@
     v-else
     :href="path"
     :target="isExternalLink ? '_blank' : null"
-    :class="[{ 'is-external-link' : isExternalLink && !hideExternalIcon }, linkClass]"
+    :class="[{ 'is-external-link' : isExternalLink && !hideExternalIcon }, linkClass, 'smart-link']"
     :disabled="disabled"
   >
     <slot /><!-- This comment removes white space which gets underlined
@@ -139,8 +139,10 @@
   };
 </script>
 
-<style lang="scss" scoped>
-.btn .icon-external-link {
-  margin-left: 0.5rem;
-}
+<style lang="scss">
+  .smart-link {
+    .btn .icon-external-link {
+      margin-left: 0.5rem;
+    }
+  }
 </style>

--- a/packages/portal/src/components/item/ItemMediaSwiperThumbnail.vue
+++ b/packages/portal/src/components/item/ItemMediaSwiperThumbnail.vue
@@ -133,7 +133,7 @@
       border: 2px solid $blue;
     }
 
-    ::v-deep .image-container {
+    ::v-deep .media-card-image {
       width: 100%;
       height: 100%;
 

--- a/packages/portal/src/components/media/MediaCardImage.vue
+++ b/packages/portal/src/components/media/MediaCardImage.vue
@@ -1,12 +1,11 @@
 <template>
   <div
-    class="image-container h-100"
+    class="media-card-image h-100"
   >
     <b-link
       v-if="linkable && imageLink && thumbnails.large && !media.forEdmIsShownAt"
       :href="imageLink"
       target="_blank"
-      data-qa="media link"
     >
       <MediaDefaultThumbnail
         v-if="showDefaultThumbnail"
@@ -21,7 +20,6 @@
         :height="thumbnailHeight"
         class="w-auto"
         alt=""
-        data-qa="media preview image"
         @error="imageNotFound"
         @error.native="imageNotFound"
       />
@@ -47,7 +45,6 @@
         :height="thumbnailHeight"
         alt=""
         class="mw-100"
-        data-qa="media preview image"
         @error="imageNotFound"
         @error.native="imageNotFound"
       />
@@ -141,32 +138,32 @@
   };
 </script>
 
-<style lang="scss" scoped>
-@import '@europeana/style/scss/variables';
+<style lang="scss">
+  @import '@europeana/style/scss/variables';
 
-.image-container {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  .media-card-image {
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
-  a {
-    text-decoration: none;
+    a {
+      text-decoration: none;
+    }
+
+    img {
+      height: auto;
+
+      @media (max-height: $bp-medium) {
+        max-height: $swiper-height;
+      }
+
+      @media (min-height: $bp-medium) {
+        max-height: $swiper-height-max;
+      }
+
+      @media (max-width: $bp-medium) {
+        max-height: $swiper-height-medium;
+      }
+    }
   }
-}
-
-img {
-  height: auto;
-
-  @media (max-height: $bp-medium) {
-    max-height: $swiper-height;
-  }
-
-  @media (min-height: $bp-medium) {
-    max-height: $swiper-height-max;
-  }
-
-  @media (max-width: $bp-medium) {
-    max-height: $swiper-height-medium;
-  }
-}
 </style>

--- a/packages/portal/src/components/metadata/MetadataField.vue
+++ b/packages/portal/src/components/metadata/MetadataField.vue
@@ -179,7 +179,7 @@
   };
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
   @import '@europeana/style/scss/variables';
 
   .metadata-row {

--- a/packages/portal/tests/unit/components/media/MediaCardImage.spec.js
+++ b/packages/portal/tests/unit/components/media/MediaCardImage.spec.js
@@ -35,14 +35,16 @@ const factory = () => shallowMount(MediaCardImage, {
 describe('components/media/MediaCardImage', () => {
   it('has a link', () => {
     const wrapper = factory();
-    const link = wrapper.find('[data-qa="media link"]');
+
+    const link = wrapper.find('b-link-stub');
 
     expect(link.exists()).toBe(true);
   });
 
   it('has a preview image', () => {
     const wrapper = factory();
-    const image = wrapper.find('[data-qa="media preview image"]');
+
+    const image = wrapper.find('b-img-stub');
 
     expect(image.exists()).toBe(true);
   });
@@ -51,6 +53,7 @@ describe('components/media/MediaCardImage', () => {
     describe('imageNotFound', () => {
       it('shows the default thumbnail', async() => {
         const wrapper = factory();
+
         await wrapper.vm.imageNotFound();
 
         expect(wrapper.vm.showDefaultThumbnail).toBe(true);


### PR DESCRIPTION
to reduce page weight from repeated data-v- attributes and use nested css selectors instead

also remove a data-qa attribute for same reason