### PR TITLE
refactor: instant scroll on mounted

### DIFF
--- a/packages/portal/src/components/item/ItemMediaThumbnails.vue
+++ b/packages/portal/src/components/item/ItemMediaThumbnails.vue
@@ -60,31 +60,39 @@
     },
 
     watch: {
-      selectedIndex: 'updateThumbnailScroll'
+      selectedIndex() {
+        this.updateThumbnailScroll();
+      }
     },
 
     created() {
-      window.addEventListener('resize', this.updateThumbnailScroll);
+      window.addEventListener('resize', this.handleWindowResize);
     },
 
     mounted() {
       if (this.selectedIndex > 0) {
         this.$nextTick(() => {
-          this.updateThumbnailScroll();
+          // instant scroll when first loaded, so that browser skips loading of
+          // images not in view
+          this.updateThumbnailScroll('instant');
         });
       }
     },
 
     destroyed() {
-      window.removeEventListener('resize', this.updateThumbnailScroll);
+      window.removeEventListener('resize', this.handleWindowResize);
     },
 
     methods: {
-      updateThumbnailScroll() {
+      handleWindowResize() {
+        this.updateThumbnailScroll();
+      },
+
+      updateThumbnailScroll(behavior = 'smooth') {
         this.scrollElementToCentre(
           this.$refs.mediaThumbnails?.[this.selectedIndex],
           {
-            behavior: 'smooth',
+            behavior,
             container: this.$refs.mediaThumbnailsContainer
           }
         );

--- a/packages/portal/tests/unit/components/item/ItemMediaThumbnails.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemMediaThumbnails.spec.js
@@ -38,13 +38,16 @@ describe('components/item/ItemMediaThumbnail', () => {
   });
 
   describe('when the selected page is after the first page', () => {
-    it('scrolls the thumbnails bar to the active position', async() => {
+    it('instant-scrolls the thumbnails bar to the active position', async() => {
       const wrapper = factory({ ...props, selectedIndex: 2 });
       wrapper.vm.scrollElementToCentre = sinon.spy();
 
       await wrapper.vm.$nextTick();
 
-      expect(wrapper.vm.scrollElementToCentre.called).toBe(true);
+      expect(wrapper.vm.scrollElementToCentre.calledWith(
+        sinon.match.any,
+        sinon.match.has('behavior', 'instant')
+      )).toBe(true);
     });
 
     describe('when the media thumbnails element is not yet available', () => {
@@ -59,13 +62,16 @@ describe('components/item/ItemMediaThumbnail', () => {
   });
 
   describe('on resize', () => {
-    it('scrolls the thumbnails bar to the active position', () => {
+    it('smooth-scrolls the thumbnails bar to the active position', () => {
       const wrapper = factory();
       wrapper.vm.scrollElementToCentre = sinon.spy();
 
       window.dispatchEvent(new Event('resize'));
 
-      expect(wrapper.vm.scrollElementToCentre.called).toBe(true);
+      expect(wrapper.vm.scrollElementToCentre.calledWith(
+        sinon.match.any,
+        sinon.match.has('behavior', 'smooth')
+      )).toBe(true);
     });
   });
 


### PR DESCRIPTION
to prevent browser loading all in-between images while smooth scrolling