### PR TITLE
refactor: create useItemMediaPresentation composable

### DIFF
--- a/packages/portal/src/components/item/ItemMediaPresentation.vue
+++ b/packages/portal/src/components/item/ItemMediaPresentation.vue
@@ -14,9 +14,7 @@
           id="item-media-sidebar"
           ref="sidebar"
           tabindex="0"
-          :annotation-uri="annotationUri"
-          :annotation-target-id="annotationTargetId"
-          :annotation-text-granularity="annotationTextGranularity"
+          :annotation-list="hasAnnotations"
           :manifest-uri="uri"
           @selectAnno="onSelectAnno"
           @keydown.escape.native="showSidebar = false"
@@ -107,8 +105,6 @@
         id="item-media-thumbnails"
         ref="itemPages"
         tabindex="0"
-        :resources="resources"
-        :selected-index="page -1"
         :edm-type="edmType"
         data-qa="item media thumbnails"
         @keydown.escape.native="showPages = false"
@@ -119,7 +115,7 @@
 
 <script>
   import hideTooltips from '@/mixins/hideTooltips';
-  import EuropeanaMediaPresentation from '@/utils/europeana/media/Presentation.js';
+  import useItemMediaPresentation from '@/composables/itemMediaPresentation.js';
 
   export default {
     name: 'ItemMediaPresentation',
@@ -167,95 +163,60 @@
       }
     },
 
+    setup() {
+      const {
+        fetchPresentation,
+        hasAnnotations,
+        page,
+        resource,
+        resourceCount,
+        setPage,
+        setPresentationFromWebResources
+      } = useItemMediaPresentation();
+      return { fetchPresentation, hasAnnotations, page, resource, resourceCount, setPage, setPresentationFromWebResources };
+    },
+
     data() {
       return {
         activeAnnotation: null,
-        presentation: null,
-        page: 1,
         showSidebar: false,
         showPages: true
       };
     },
 
     async fetch() {
-      let presentation;
+      this.setPage(this.$route.query.page);
 
       if (this.uri) {
-        presentation = await EuropeanaMediaPresentation.from(this.uri);
+        await this.fetchPresentation(this.uri);
       } else if (this.webResources) {
-        presentation = new EuropeanaMediaPresentation({
-          canvases: this.webResources.map((resource) => ({
-            resource
-          }))
-        });
+        this.setPresentationFromWebResources(this.webResources);
       } else {
         throw new Error('No manifest URI or web resources for presentation');
       }
 
-      this.presentation = Object.freeze(presentation);
-
-      this.setPage();
+      this.selectResource();
     },
 
     computed: {
-      /**
-       * Annotation page/list: either a URI as a string, or an object with id
-       * property being the URI
-       */
-      annotationCollection() {
-        return this.canvas?.annotations?.[0];
-      },
-
-      annotationTargetId() {
-        // account for Europeana fulltext annotations incorrectly targeting IIIF
-        // images instead of canvases
-        return this.presentation?.isInEuropeanaDomain ? this.resource?.about : this.canvas?.id;
-      },
-
-      annotationUri() {
-        if (!this.annotationCollection) {
-          return null;
-        } else if (typeof this.annotationCollection === 'string') {
-          return this.annotationCollection;
-        }
-        return this.annotationCollection.id;
-      },
-
-      annotationTextGranularity() {
-        return this.annotationCollection?.textGranularity;
-      },
-
-      canvas() {
-        return this.presentation?.canvases?.[this.page - 1];
-      },
-
-      resource() {
-        return this.canvas?.resource;
-      },
-
-      resources() {
-        return this.presentation?.canvases?.map((canvas) => canvas.resource).filter(Boolean);
-      },
-
-      resourceCount() {
-        return this.resources?.length || 0;
+      hasManifest() {
+        return !!this.uri;
       },
 
       sidebarHasContent() {
-        return !!this.annotationUri || !!this.uri;
-      },
-
-      thumbnail() {
-        return this.thumbnails?.[this.page - 1];
-      },
-
-      thumbnails() {
-        return this.resources?.map((resource) => resource.thumbnails?.(this.$nuxt.context)?.small) || [];
+        return this.hasAnnotations || this.hasManifest;
       }
     },
 
     watch: {
-      '$route.query.page': 'setPage'
+      '$route.query.page'() {
+        this.setPage(this.$route.query.page);
+      },
+
+      resource: {
+        deep: true,
+        handler: 'selectResource'
+      }
     },
 
     methods: {
@@ -270,12 +231,9 @@
         // this.$router.push({ ...this.$route, hash: `#anno=${anno.id}` });
       },
 
-      setPage() {
-        this.page = Number(this.$route.query.page) || 1;
+      selectResource() {
         this.activeAnnotation = null;
-        this.$nextTick(() => {
-          this.$emit('select', this.resource);
-        });
+        this.$emit('select', this.resource);
       },
 
       toggleSidebar() {

--- a/packages/portal/src/components/item/ItemMediaSidebar.vue
+++ b/packages/portal/src/components/item/ItemMediaSidebar.vue
@@ -9,7 +9,7 @@
     >
       <b-tabs vertical>
         <b-tab
-          v-if="annotationUri"
+          v-if="annotationList"
           data-qa="item media sidebar annotations"
           button-id="item-media-sidebar-annotations"
           :title-link-attributes="{ 'aria-label': $t('media.sidebar.annotations') }"
@@ -25,9 +25,6 @@
           </template>
           <h2>{{ $t('media.sidebar.annotations') }}</h2>
           <MediaAnnotationList
-            :uri="annotationUri"
-            :target-id="annotationTargetId"
-            :text-granularity="annotationTextGranularity"
             class="iiif-viewer-sidebar-panel"
             @selectAnno="onSelectAnno"
           />
@@ -79,17 +76,9 @@
     mixins: [hideTooltips],
 
     props: {
-      annotationTargetId: {
-        type: String,
-        default: null
-      },
-      annotationTextGranularity: {
-        type: Array, String,
-        default: null
-      },
-      annotationUri: {
-        type: String,
-        default: null
+      annotationList: {
+        type: Boolean,
+        default: false
       },
       manifestUri: {
         type: String,

--- a/packages/portal/src/components/item/ItemMediaThumbnails.vue
+++ b/packages/portal/src/components/item/ItemMediaThumbnails.vue
@@ -29,6 +29,7 @@
 </template>
 
 <script>
+  import useItemMediaPresentation from '@/composables/itemMediaPresentation.js';
   import useScrollTo from '@/composables/scrollTo.js';
   import ItemMediaThumbnail from './ItemMediaThumbnail.vue';
 
@@ -40,27 +41,27 @@
     },
 
     props: {
-      resources: {
-        type: Array,
-        required: true
-      },
       edmType: {
         type: String,
         default: null
-      },
-      selectedIndex: {
-        type: Number,
-        required: true
       }
     },
 
     setup() {
+      const { page, resources } = useItemMediaPresentation();
       const { scrollElementToCentre } = useScrollTo();
-      return { scrollElementToCentre };
+
+      return { page, resources, scrollElementToCentre };
+    },
+
+    computed: {
+      selectedIndex() {
+        return this.page - 1;
+      }
     },
 
     watch: {
-      selectedIndex() {
+      page() {
         this.updateThumbnailScroll();
       }
     },
@@ -70,7 +71,7 @@
     },
 
     mounted() {
-      if (this.selectedIndex > 0) {
+      if (this.page > 1) {
         this.$nextTick(() => {
           // instant scroll when first loaded, so that browser skips loading of
           // images not in view

--- a/packages/portal/src/composables/itemMediaPresentation.js
+++ b/packages/portal/src/composables/itemMediaPresentation.js
@@ -109,11 +109,11 @@ const setPage = (value) => {
 export default function useItemMediaPresentation() {
   return {
     annotations,
-    annotationCollection,
-    annotationTargetId,
+    // annotationCollection,
+    // annotationTargetId,
     annotationUri,
-    annotationTextGranularity,
-    canvas,
+    // annotationTextGranularity,
+    // canvas,
     fetchAnnotations,
     fetchPresentation,
     hasAnnotations,
@@ -121,7 +121,7 @@ export default function useItemMediaPresentation() {
     resource,
     resources,
     resourceCount,
-    presentation,
+    // presentation,
     setPage,
     setPresentationFromWebResources
   };

--- a/packages/portal/src/composables/itemMediaPresentation.js
+++ b/packages/portal/src/composables/itemMediaPresentation.js
@@ -3,7 +3,7 @@ import { computed, ref } from 'vue';
 import EuropeanaMediaAnnotationList from '@/utils/europeana/media/AnnotationList.js';
 import EuropeanaMediaPresentation from '@/utils/europeana/media/Presentation.js';
 
-const page = ref(null);
+const page = ref(1);
 const presentation = ref(null);
 const annotations = ref([]);
 
@@ -121,7 +121,7 @@ export default function useItemMediaPresentation() {
     resource,
     resources,
     resourceCount,
-    // presentation,
+    presentation,
     setPage,
     setPresentationFromWebResources
   };

--- a/packages/portal/src/composables/itemMediaPresentation.js
+++ b/packages/portal/src/composables/itemMediaPresentation.js
@@ -1,0 +1,128 @@
+import { computed, ref } from 'vue';
+
+import EuropeanaMediaAnnotationList from '@/utils/europeana/media/AnnotationList.js';
+import EuropeanaMediaPresentation from '@/utils/europeana/media/Presentation.js';
+
+const page = ref(null);
+const presentation = ref(null);
+const annotations = ref([]);
+
+/**
+ * Annotation page/list: either a URI as a string, or an object with id
+ * property being the URI
+ */
+const annotationCollection = computed(() => {
+  return canvas.value?.annotations?.[0];
+});
+
+const annotationTargetId = computed(() => {
+  // account for Europeana fulltext annotations incorrectly targeting IIIF
+  // images instead of canvases
+  return presentation.value?.isInEuropeanaDomain ? resource.value?.about : canvas.value?.id;
+});
+
+const annotationTextGranularity = computed(() => {
+  return annotationCollection.value?.textGranularity;
+});
+
+const annotationUri = computed(() => {
+  if (!annotationCollection.value) {
+    return null;
+  } else if (typeof annotationCollection.value === 'string') {
+    return annotationCollection.value;
+  }
+  return annotationCollection.value.id;
+});
+
+const canvas = computed(() => {
+  return canvases.value?.[page.value - 1];
+});
+
+const canvases = computed(() => {
+  return presentation.value?.canvases;
+});
+
+const hasAnnotations = computed(() => {
+  return !!annotationUri.value;
+});
+
+const resource = computed(() => {
+  return canvas.value?.resource;
+});
+
+const resources = computed(() => {
+  return canvases.value?.map((canvas) => canvas.resource).filter(Boolean);
+});
+
+const resourceCount = computed(() => {
+  return resources?.value?.length || 0;
+});
+
+const fetchPresentation = async(uri) => {
+  presentation.value = await EuropeanaMediaPresentation.from(uri);
+};
+
+const setPresentationFromWebResources = (webResources) => {
+  presentation.value = new EuropeanaMediaPresentation({
+    canvases: webResources.map((resource) => ({
+      resource
+    }))
+  });
+};
+
+// TODO: default param to using annotationUri?
+const fetchAnnotations = async(uri) => {
+  if (!uri || !annotationTargetId.value) {
+    return;
+  }
+
+  // TODO: make into a new computed?
+  let textGranularity;
+  if (Array.isArray(annotationTextGranularity.value)) {
+    textGranularity = annotationTextGranularity.value.includes('line') ? 'line' : annotationTextGranularity.value[0];
+  } else {
+    textGranularity = annotationTextGranularity.value;
+  }
+
+  const list = await EuropeanaMediaAnnotationList.from(uri, { params: { textGranularity } });
+  const annos = list.annotationsForTarget(annotationTargetId.value);
+
+  // NOTE: this may result in duplicate network requests for the same body resource
+  //       if there are multiple external annotations with the same resource URL,
+  //       e.g. with just a different hash char selector.
+  //       use an axios caching interceptor to avoid this.
+  await Promise.all(annos.map((anno) => anno.embedBodies()));
+
+  for (const anno of annos) {
+    if (Array.isArray(anno.body)) {
+      anno.body = anno.body[0];
+    }
+  }
+
+  annotations.value = annos;
+};
+
+const setPage = (value) => {
+  page.value = Number(value) || 1;
+};
+
+export default function useItemMediaPresentation() {
+  return {
+    annotations,
+    annotationCollection,
+    annotationTargetId,
+    annotationUri,
+    annotationTextGranularity,
+    canvas,
+    fetchAnnotations,
+    fetchPresentation,
+    hasAnnotations,
+    page,
+    resource,
+    resources,
+    resourceCount,
+    presentation,
+    setPage,
+    setPresentationFromWebResources
+  };
+}

--- a/packages/portal/tests/unit/components/item/ItemMediaPresentation.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemMediaPresentation.spec.js
@@ -1,9 +1,11 @@
 import { createLocalVue } from '@vue/test-utils';
-import { shallowMountNuxt } from '../../utils';
 import BootstrapVue from 'bootstrap-vue';
-import ItemMediaPresentation from '@/components/item/ItemMediaPresentation';
 import nock from 'nock';
 import sinon from 'sinon';
+
+import { shallowMountNuxt } from '../../utils';
+import ItemMediaPresentation from '@/components/item/ItemMediaPresentation';
+import * as itemMediaPresentation from '@/composables/itemMediaPresentation.js';
 
 const localVue = createLocalVue();
 localVue.use(BootstrapVue);
@@ -40,12 +42,33 @@ const factory = ({ data = {}, propsData = {}, mocks = {} } = {}) => shallowMount
   stubs: ['MediaAudioVisualPlayer', 'MediaImageViewer', 'PaginationNavInput', 'ItemMediaThumbnails']
 });
 
+const fetchPresentationStub = sinon.stub();
+const setPresentationFromWebResourcesStub = sinon.stub();
+const setPageStub = sinon.stub();
+
+const stubItemMediaPresentationComposable = (stubs = {}) => {
+  sinon.stub(itemMediaPresentation, 'default').returns({
+    fetchPresentation: fetchPresentationStub,
+    presentation: {
+      canvases: [
+        { annotations: ['https://example.org/anno'], resource: {} },
+        { resource: {} }
+      ]
+    },
+    resourceCount: 2,
+    setPage: setPageStub,
+    setPresentationFromWebResources: setPresentationFromWebResourcesStub,
+    ...stubs
+  });
+};
+
 describe('components/item/ItemMediaPresentation', () => {
   beforeAll(() => {
     nock.disableNetConnect();
   });
   afterEach(() => {
     nock.cleanAll();
+    sinon.restore();
   });
   afterAll(() => {
     nock.enableNetConnect();
@@ -53,6 +76,7 @@ describe('components/item/ItemMediaPresentation', () => {
 
   describe('template', () => {
     it('renders a viewer wrapper', () => {
+      stubItemMediaPresentationComposable();
       const wrapper = factory();
 
       const viewerWrapper = wrapper.find('.iiif-viewer-wrapper');
@@ -63,6 +87,7 @@ describe('components/item/ItemMediaPresentation', () => {
     describe('sidebar toggle button', () => {
       describe('when there is a manifest uri', () => {
         it('is visible', () => {
+          stubItemMediaPresentationComposable();
           const wrapper = factory({ propsData: { uri: 'https://example.org/manifest' } });
 
           const sidebarToggle = wrapper.find('[data-qa="iiif viewer toolbar sidebar toggle"]');
@@ -73,13 +98,8 @@ describe('components/item/ItemMediaPresentation', () => {
 
       describe('or when there are annotations', () => {
         it('is visible', () => {
-          const wrapper = factory({ data: {
-            presentation: {
-              canvases: [
-                { annotations: ['https://example.org/anno'] }
-              ]
-            }
-          } });
+          stubItemMediaPresentationComposable({ hasAnnotations: true });
+          const wrapper = factory();
 
           const sidebarToggle = wrapper.find('[data-qa="iiif viewer toolbar sidebar toggle"]');
 
@@ -89,6 +109,7 @@ describe('components/item/ItemMediaPresentation', () => {
 
       describe('on click', () => {
         it('opens the sidebar', () => {
+          stubItemMediaPresentationComposable();
           const wrapper = factory({ propsData: { uri: 'https://example.org/manifest' } });
 
           wrapper.find('[data-qa="iiif viewer toolbar sidebar toggle"]').trigger('click');
@@ -97,6 +118,7 @@ describe('components/item/ItemMediaPresentation', () => {
         });
 
         it('sets focus to the sidebar', async() => {
+          stubItemMediaPresentationComposable();
           const wrapper = factory({ propsData: { uri: 'https://example.org/manifest' } });
           wrapper.vm.$refs.sidebar.$el.focus = sinon.spy();
 
@@ -110,16 +132,10 @@ describe('components/item/ItemMediaPresentation', () => {
     });
 
     describe('pages toggle button', () => {
-      const presentation = {
-        canvases: [
-          { resource: {} },
-          { resource: {} }
-        ]
-      };
-
       describe('when there are two or more pages', () => {
         it('is visible', () => {
-          const wrapper = factory({ data: { presentation } });
+          stubItemMediaPresentationComposable();
+          const wrapper = factory();
 
           const pagesToggle = wrapper.find('[data-qa="iiif viewer toolbar pages toggle"]');
 
@@ -129,7 +145,8 @@ describe('components/item/ItemMediaPresentation', () => {
 
       describe('on click', () => {
         it('closes and opens the item media thumbnails sidebar', () => {
-          const wrapper = factory({ data: { presentation } });
+          stubItemMediaPresentationComposable();
+          const wrapper = factory();
 
           wrapper.find('[data-qa="iiif viewer toolbar pages toggle"]').trigger('click');
           expect(wrapper.vm.showPages).toBe(false);
@@ -138,7 +155,8 @@ describe('components/item/ItemMediaPresentation', () => {
         });
 
         it('sets focus to the item media thumbnails sidebar', async() => {
-          const wrapper = factory({ data: { presentation } });
+          stubItemMediaPresentationComposable();
+          const wrapper = factory();
 
           wrapper.vm.$refs.itemPages.$el.focus = sinon.spy();
           wrapper.vm.showPages = false;
@@ -155,78 +173,15 @@ describe('components/item/ItemMediaPresentation', () => {
 
   describe('fetch', () => {
     describe('when supplied a manifest URI', () => {
-      const origin = 'https://iiif.europeana.eu';
-      const path = '/presentation/123/abc/manifest';
-      const uri = `${origin}${path}`;
-      const responseData = {
-        '@context': ['http://www.w3.org/ns/anno.jsonld', 'http://iiif.io/api/presentation/3/context.json'],
-        id: 'https://iiif.europeana.eu/presentation/123/abc/manifest',
-        type: 'Manifest',
-        service: [
-          {
-            '@context': 'http://iiif.io/api/search/1/context.json',
-            id: 'https://iiif.europeana.eu/presentation/123/abc/search',
-            profile: 'http://iiif.io/api/search/1/search'
-          }
-        ],
-        items: [
-          {
-            type: 'Canvas',
-            id: 'https://iiif.europeana.eu/presentation/123/abc/canvas/1',
-            items: [
-              {
-                type: 'AnnotationPage',
-                items: [
-                  {
-                    type: 'Annotation',
-                    motivation: 'painting',
-                    body: {
-                      id: 'https://iiif.europeana.eu/presentation/123/abc/image1.jpg',
-                      format: 'image/jpeg',
-                      service: {
-                        id: 'https://iiif.europeana.eu/image/123/abc/image1.jpg'
-                      }
-                    }
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      };
-      const propsData = {
-        uri
-      };
+      const uri = 'https://iiif.europeana.eu/presentation/123/abc/manifest';
 
-      it('fetches it and stores the parsed data to `presentation`', async() => {
-        const wrapper = factory({ propsData });
-        nock(origin).get(path).reply(200, responseData);
+      it('fetches manifest via itemMediaPresentation composable', async() => {
+        stubItemMediaPresentationComposable();
+        const wrapper = factory({ propsData: { uri } });
 
         await wrapper.vm.fetch();
 
-        expect(nock.isDone()).toBe(true);
-        expect(wrapper.vm.presentation).toEqual({
-          id: 'https://iiif.europeana.eu/presentation/123/abc/manifest',
-          search: [
-            {
-              context: 'http://iiif.io/api/search/1/context.json',
-              id: 'https://iiif.europeana.eu/presentation/123/abc/search',
-              profile: 'http://iiif.io/api/search/1/search'
-            }
-          ],
-          canvases: [
-            {
-              id: 'https://iiif.europeana.eu/presentation/123/abc/canvas/1',
-              resource: {
-                about: 'https://iiif.europeana.eu/presentation/123/abc/image1.jpg',
-                ebucoreHasMimeType: 'image/jpeg',
-                svcsHasService: {
-                  id: 'https://iiif.europeana.eu/image/123/abc/image1.jpg'
-                }
-              }
-            }
-          ]
-        });
+        expect(fetchPresentationStub.calledWith(uri)).toBe(true);
       });
     });
 
@@ -242,16 +197,13 @@ describe('components/item/ItemMediaPresentation', () => {
       ];
       const propsData = { itemId, webResources };
 
-      it('stores them to `presentation`', async() => {
+      it('initialises presentation from them via itemMediaPresentation composable', async() => {
+        stubItemMediaPresentationComposable();
         const wrapper = factory({ propsData });
 
         await wrapper.vm.fetch();
 
-        expect(wrapper.vm.presentation).toEqual({
-          canvases: [
-            { resource: webResources[0] }
-          ]
-        });
+        expect(setPresentationFromWebResourcesStub.calledWith(webResources)).toBe(true);
       });
     });
   });

--- a/packages/portal/tests/unit/components/item/ItemMediaSidebar.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemMediaSidebar.spec.js
@@ -23,9 +23,9 @@ describe('components/item/ItemMediaSidebar', () => {
       expect(sidebar.exists()).toBe(true);
     });
 
-    describe('when there is an annotation URI', () => {
+    describe('when there is an annotation list', () => {
       it('has a tab for annotations', () => {
-        const wrapper = factory({ annotationUri: 'https://example.com/iiif/123/annotations' });
+        const wrapper = factory({ annotationList: true });
 
         const annotationsTab = wrapper.find('[data-qa="item media sidebar annotations"]');
 

--- a/packages/portal/tests/unit/components/item/ItemMediaThumbnails.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemMediaThumbnails.spec.js
@@ -1,35 +1,31 @@
 import { createLocalVue, shallowMount } from '@vue/test-utils';
-import ItemMediaThumbnails from '@/components/item/ItemMediaThumbnails';
 import sinon from 'sinon';
+
+import ItemMediaThumbnails from '@/components/item/ItemMediaThumbnails';
+import * as itemMediaPresentation from '@/composables/itemMediaPresentation.js';
 
 const localVue = createLocalVue();
 
-const props = {
-  edmType: 'image',
-  selectedIndex: 0,
-  resources: [
-    { edmType: '' },
-    { edmType: '' },
-    { edmType: '' },
-    { edmType: '' },
-    { edmType: '' }
-  ]
-};
-
-const factory = (propsData = props) => shallowMount(ItemMediaThumbnails, {
+const factory = ({ mocks = {}, propsData = {} } = {}) => shallowMount(ItemMediaThumbnails, {
   localVue,
   attachTo: document.body,
-  propsData,
+  propsData: {
+    edmType: 'image',
+    ...propsData
+  },
   mocks: {
-    $t: (key) => key
+    $t: (key) => key,
+    ...mocks
   }
 });
 
 describe('components/item/ItemMediaThumbnail', () => {
+  afterEach(sinon.resetHistory);
+  afterAll(sinon.restore);
+
   describe('template', () => {
-    it('renders a item media thumbnail', () => {
+    it('renders media thumbnails', () => {
       const wrapper = factory();
-      wrapper.vm.$refs.mediaThumbnails.scroll = sinon.spy();
 
       const thumbnail = wrapper.find('.media-thumbnails');
 
@@ -38,8 +34,21 @@ describe('components/item/ItemMediaThumbnail', () => {
   });
 
   describe('when the selected page is after the first page', () => {
+    beforeAll(() => {
+      sinon.stub(itemMediaPresentation, 'default').returns({
+        page: 2,
+        resources: [
+          {},
+          {}
+        ]
+      });
+    });
+    afterAll(() => {
+      itemMediaPresentation.default.restore();
+    });
+
     it('instant-scrolls the thumbnails bar to the active position', async() => {
-      const wrapper = factory({ ...props, selectedIndex: 2 });
+      const wrapper = factory({ mocks: { page: 2 } });
       wrapper.vm.scrollElementToCentre = sinon.spy();
 
       await wrapper.vm.$nextTick();
@@ -52,7 +61,7 @@ describe('components/item/ItemMediaThumbnail', () => {
 
     describe('when the media thumbnails element is not yet available', () => {
       it('does not scroll the thumbnails bar', () => {
-        const wrapper = factory({ ...props, selectedIndex: 2 });
+        const wrapper = factory({ mocks: { page: 2 } });
         wrapper.vm.scrollElementToCentre = sinon.spy();
         wrapper.vm.$refs.mediaThumbnails = null;
 

--- a/packages/portal/tests/unit/composables/itemMediaPresentation.spec.js
+++ b/packages/portal/tests/unit/composables/itemMediaPresentation.spec.js
@@ -171,4 +171,23 @@ describe('useItemMediaPresentation', () => {
       });
     });
   });
+
+  describe('setPresentationFromWebResources', () => {
+    it('initialises presentation value from web resources', () => {
+      const { presentation, setPresentationFromWebResources } = useItemMediaPresentation();
+      const webResources = [
+        { about: 'https://example.org/video.mp4', ebucoreMimeType: 'video/mp4' }
+      ];
+
+      setPresentationFromWebResources(webResources);
+
+      expect(presentation.value).toEqual({
+        canvases: [
+          {
+            resource: webResources[0]
+          }
+        ]
+      });
+    });
+  });
 });

--- a/packages/portal/tests/unit/composables/itemMediaPresentation.spec.js
+++ b/packages/portal/tests/unit/composables/itemMediaPresentation.spec.js
@@ -1,0 +1,174 @@
+import nock from 'nock';
+import sinon from 'sinon';
+
+import useItemMediaPresentation from '@/composables/itemMediaPresentation.js';
+import EuropeanaMediaPresentation from '@/utils/europeana/media/Presentation.js';
+
+const origin = 'https://iiif.example.org';
+const canvasId = `${origin}/canvas/1`;
+const bodyPath = '/fulltext/1';
+const bodyUri = `${origin}${bodyPath}`;
+const bodyResponseData = {
+  id: bodyUri,
+  type: 'TextualBody',
+  value: 'full text'
+};
+const listPath = '/annos/1';
+const listUri = `${origin}${listPath}`;
+const listResponseData = {
+  id: listUri,
+  type: 'AnnotationPage',
+  items: [{
+    type: 'Annotation',
+    body: {
+      id: bodyUri
+    },
+    target: [{
+      id: canvasId
+    }]
+  }]
+};
+const manifestPath = '/presentation/123/abc/manifest';
+const manifestUri = `${origin}${manifestPath}`;
+const manifestResponseData = {
+  '@context': ['http://www.w3.org/ns/anno.jsonld', 'http://iiif.io/api/presentation/3/context.json'],
+  id: 'https://iiif.example.org/presentation/123/abc/manifest',
+  type: 'Manifest',
+  service: [
+    {
+      '@context': 'http://iiif.io/api/search/1/context.json',
+      id: 'https://iiif.example.org/presentation/123/abc/search',
+      profile: 'http://iiif.io/api/search/1/search'
+    }
+  ],
+  items: [
+    {
+      type: 'Canvas',
+      id: 'https://iiif.example.org/presentation/123/abc/canvas/1',
+      items: [
+        {
+          type: 'AnnotationPage',
+          items: [
+            {
+              type: 'Annotation',
+              motivation: 'painting',
+              body: {
+                id: 'https://iiif.example.org/presentation/123/abc/image1.jpg',
+                format: 'image/jpeg',
+                service: {
+                  id: 'https://iiif.example.org/image/123/abc/image1.jpg'
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+const textGranularity = 'line';
+
+const presentationValue = new EuropeanaMediaPresentation({
+  canvases: [
+    {
+      id: canvasId,
+      annotations: [
+        {
+          id: listUri,
+          textGranularity
+        }
+      ],
+      resource: {}
+    }
+  ]
+});
+
+describe('useItemMediaPresentation', () => {
+  beforeAll(() => {
+    nock.disableNetConnect();
+  });
+  afterEach(() => {
+    sinon.resetHistory();
+    nock.cleanAll();
+  });
+  afterAll(() => {
+    sinon.restore();
+    nock.enableNetConnect();
+  });
+
+  describe('fetchAnnotations', () => {
+    beforeEach(() => {
+      nock(origin).get(listPath).query({ textGranularity }).reply(200, listResponseData);
+      nock(origin).get(bodyPath).reply(200, bodyResponseData);
+    });
+
+    it('fetches annotation list w/ text granularity and embeds bodies', async() => {
+      const { presentation, fetchAnnotations } = useItemMediaPresentation();
+      presentation.value = presentationValue;
+
+      await fetchAnnotations(listUri);
+
+      expect(nock.isDone()).toBe(true);
+    });
+
+    it('stores relevant annotations', async() => {
+      const { annotations, presentation, fetchAnnotations } = useItemMediaPresentation();
+      presentation.value = presentationValue;
+
+      await fetchAnnotations(listUri);
+
+      expect(annotations.value).toEqual([
+        {
+          body: {
+            id: 'https://iiif.example.org/fulltext/1',
+            value: 'full text'
+          },
+          target: [{ id: 'https://iiif.example.org/canvas/1' }]
+        }
+      ]);
+    });
+  });
+
+  describe('fetchPresentation', () => {
+    beforeEach(() => {
+      nock(origin).get(manifestPath).reply(200, manifestResponseData);
+    });
+
+    it('fetches the manifest', async() => {
+      const { fetchPresentation } = useItemMediaPresentation();
+
+      await fetchPresentation(manifestUri);
+
+      expect(nock.isDone()).toBe(true);
+    });
+
+    it('stores the parsed data to `presentation`', async() => {
+      const { fetchPresentation, presentation } = useItemMediaPresentation();
+
+      await fetchPresentation(manifestUri);
+
+      expect(presentation.value).toEqual({
+        id: 'https://iiif.example.org/presentation/123/abc/manifest',
+        search: [
+          {
+            context: 'http://iiif.io/api/search/1/context.json',
+            id: 'https://iiif.example.org/presentation/123/abc/search',
+            profile: 'http://iiif.io/api/search/1/search'
+          }
+        ],
+        canvases: [
+          {
+            id: 'https://iiif.example.org/presentation/123/abc/canvas/1',
+            resource: {
+              about: 'https://iiif.example.org/presentation/123/abc/image1.jpg',
+              ebucoreHasMimeType: 'image/jpeg',
+              svcsHasService: {
+                id: 'https://iiif.example.org/image/123/abc/image1.jpg'
+              }
+            }
+          }
+        ]
+      });
+    });
+  });
+});


### PR DESCRIPTION
with global refs and computed properties for current item's media presentation, to be shared by components that use it

following the pattern from [Vue.js - State Management](https://vuejs.org/guide/scaling-up/state-management.html#simple-state-management-with-reactivity-api)

* alleviates prop drilling
* acts as SSOT for media presentation data provision
* reduces data manipulation logic in components