### PR TITLE
feat: item media annotation search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34123,6 +34123,24 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
+    "node_modules/vue2-helpers": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/vue2-helpers/-/vue2-helpers-2.1.1.tgz",
+      "integrity": "sha512-ujYiQ5xfO8qKP3ly8hMqtNA/QGoJCTmKdYErsL3Oxr3nURJ5axah3IV4ztC/Y3zR6qsST0yVwuG1nEneQ9jXQQ==",
+      "peerDependencies": {
+        "vue": "~2.7.0",
+        "vue-router": "^3",
+        "vuex": "^3"
+      },
+      "peerDependenciesMeta": {
+        "vue-router": {
+          "optional": true
+        },
+        "vuex": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vuedraggable": {
       "version": "2.24.3",
       "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-2.24.3.tgz",
@@ -36351,6 +36369,7 @@
         "vue": "^2.7.10",
         "vue-client-only": "^2.1.0",
         "vue-i18n": "^8.26.7",
+        "vue2-helpers": "^2.1.1",
         "vuex": "^3.6.2"
       },
       "devDependencies": {

--- a/packages/portal/jest.config.js
+++ b/packages/portal/jest.config.js
@@ -24,7 +24,7 @@ export default {
     '<rootDir>/tmp/'
   ],
   transformIgnorePatterns: [
-    '/node_modules/(?!decamelize|swiper|ol|color-space|color-parse|color-rgba|color-name|rbush|quickselect)'
+    '/node_modules/(?!decamelize|swiper|ol|color-space|color-parse|color-rgba|color-name|rbush|quickselect|vue2-helpers)'
   ],
   transform: {
     '^.+\\.(js|mjs)$': 'babel-jest',

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -59,6 +59,7 @@
     "vue": "^2.7.10",
     "vue-client-only": "^2.1.0",
     "vue-i18n": "^8.26.7",
+    "vue2-helpers": "^2.1.1",
     "vuex": "^3.6.2"
   },
   "devDependencies": {

--- a/packages/portal/src/components/iiif/IIIFMiradorViewer.vue
+++ b/packages/portal/src/components/iiif/IIIFMiradorViewer.vue
@@ -44,11 +44,6 @@
         default: null
       },
 
-      searchQuery: {
-        type: String,
-        default: null
-      },
-
       providerUrl: {
         type: String,
         default: null
@@ -62,6 +57,7 @@
         imageToCanvasMap: {},
         memoisedImageToCanvasMap: false,
         miradorViewer: null,
+        searchQuery: this.$route.query.query,
         showAnnotations: false,
         isMobileViewport: false,
         isMiradorLoaded: process.client ? !!window.Mirador : false,

--- a/packages/portal/src/components/iiif/IIIFMiradorViewer.vue
+++ b/packages/portal/src/components/iiif/IIIFMiradorViewer.vue
@@ -57,7 +57,7 @@
         imageToCanvasMap: {},
         memoisedImageToCanvasMap: false,
         miradorViewer: null,
-        searchQuery: this.$route.query.query,
+        searchQuery: this.$route.query.fulltext,
         showAnnotations: false,
         isMobileViewport: false,
         isMiradorLoaded: process.client ? !!window.Mirador : false,

--- a/packages/portal/src/components/item/ItemHero.vue
+++ b/packages/portal/src/components/item/ItemHero.vue
@@ -7,7 +7,6 @@
     <client-only>
       <ItemMediaPresentation
         :uri="iiifPresentationManifest"
-        :search-query="fulltextSearchQuery"
         :item-id="identifier"
         :provider-url="providerUrl"
         :web-resources="media"
@@ -77,7 +76,6 @@
   import ShareButton from '../share/ShareButton';
   import WebResource from '@/plugins/europeana/edm/WebResource';
 
-  import advancedSearchMixin from '@/mixins/advancedSearch';
   import rightsStatementMixin from '@/mixins/rightsStatement';
 
   const TRANSCRIBATHON_URL_ROOT = /^https?:\/\/europeana\.transcribathon\.eu\//;
@@ -95,7 +93,6 @@
     },
 
     mixins: [
-      advancedSearchMixin,
       rightsStatementMixin
     ],
 
@@ -166,20 +163,6 @@
           return this.edmRights;
         }
         return '';
-      },
-      fulltextSearchQuery() {
-        let query = [];
-
-        if (this.$nuxt.context.from) {
-          if (this.$nuxt.context.from.query.qa) {
-            const advSearchRules = this.advancedSearchRulesFromRouteQuery(this.$nuxt.context.from.query.qa);
-            query = advSearchRules
-              .filter((rule) => (rule.field === 'fulltext') && (['contains', 'exact'].includes(rule.modifier)))
-              .map((rule) => rule.term);
-          }
-        }
-
-        return query.join(' ');
       },
       showPins() {
         return this.userIsEntitiesEditor && this.userIsSetsEditor && this.entities.length > 0;

--- a/packages/portal/src/components/item/ItemMediaLegacy.vue
+++ b/packages/portal/src/components/item/ItemMediaLegacy.vue
@@ -50,11 +50,6 @@
         default: null
       },
 
-      searchQuery: {
-        type: String,
-        default: null
-      },
-
       providerUrl: {
         type: String,
         default: null

--- a/packages/portal/src/components/item/ItemMediaLegacy.vue
+++ b/packages/portal/src/components/item/ItemMediaLegacy.vue
@@ -5,7 +5,6 @@
   >
     <IIIFMiradorViewer
       :uri="uri"
-      :search-query="searchQuery"
       :item-id="itemId"
       :provider-url="providerUrl"
       :aria-label="$t('actions.viewDocument')"

--- a/packages/portal/src/components/item/ItemMediaPresentation.vue
+++ b/packages/portal/src/components/item/ItemMediaPresentation.vue
@@ -18,6 +18,7 @@
           :annotation-target-id="annotationTargetId"
           :annotation-text-granularity="annotationTextGranularity"
           :manifest-uri="uri"
+          :search-uri="searchUri"
           @selectAnno="onSelectAnno"
           @keydown.escape.native="showSidebar = false"
         />
@@ -239,6 +240,10 @@
 
       resourceCount() {
         return this.resources?.length || 0;
+      },
+
+      searchUri() {
+        return [].concat(this.presentation?.search).filter(Boolean)[0]?.id;
       },
 
       sidebarHasContent() {

--- a/packages/portal/src/components/item/ItemMediaPresentation.vue
+++ b/packages/portal/src/components/item/ItemMediaPresentation.vue
@@ -12,7 +12,6 @@
           <ItemMediaSidebar
             v-if="sidebarHasContent"
             v-show="showSidebar"
-            id="item-media-sidebar"
             ref="sidebar"
             tabindex="0"
             :annotation-list="hasAnnotations"
@@ -52,8 +51,8 @@
             <pre
               :style="{ color: 'white' }"
             ><!--
-          -->{{ JSON.stringify(resource, null, 2) }}
-          </pre>
+              -->{{ JSON.stringify(resource, null, 2) }}
+            </pre>
           </code>
         </div>
         <div
@@ -148,6 +147,12 @@
 
     mixins: [hideTooltips],
 
+    provide() {
+      return {
+        annotationScrollToContainerSelector: `#${this.sidebarId}__BV_tab_container_`
+      };
+    },
+
     props: {
       uri: {
         type: String,
@@ -205,6 +210,7 @@
       return {
         showSidebar: !!this.$route.hash,
         showPages: true,
+        sidebarId: 'item-media-sidebar',
         fullscreen: false
       };
     },

--- a/packages/portal/src/components/item/ItemMediaPresentation.vue
+++ b/packages/portal/src/components/item/ItemMediaPresentation.vue
@@ -157,11 +157,6 @@
         default: null
       },
 
-      searchQuery: {
-        type: String,
-        default: null
-      },
-
       providerUrl: {
         type: String,
         default: null

--- a/packages/portal/src/components/item/ItemMediaPresentation.vue
+++ b/packages/portal/src/components/item/ItemMediaPresentation.vue
@@ -182,10 +182,8 @@
         hasAnnotations,
         hasSearchService,
         page,
-        pageForAnnotationTarget,
         resource,
         resourceCount,
-        selectAnnotation,
         setPage,
         setPresentationFromWebResources
       } = useItemMediaPresentation();
@@ -196,10 +194,8 @@
         hasAnnotations,
         hasSearchService,
         page,
-        pageForAnnotationTarget,
         resource,
         resourceCount,
-        selectAnnotation,
         setPage,
         setPresentationFromWebResources
       };
@@ -215,7 +211,6 @@
 
     async fetch() {
       this.setPage(this.$route.query.page);
-      // this.selectAnnotation(this.$route.query.anno);
 
       if (this.uri) {
         await this.fetchPresentation(this.uri);

--- a/packages/portal/src/components/item/ItemMediaPresentation.vue
+++ b/packages/portal/src/components/item/ItemMediaPresentation.vue
@@ -198,6 +198,12 @@
       this.setPage();
     },
 
+    mounted() {
+      const annoHashParam = EuropeanaMediaPresentation.getHashParam(this.$route.hash, 'anno');
+      this.annotation
+      console.log('annoHashParam', annoHashParam)
+    },
+
     computed: {
       /**
        * Annotation page/list: either a URI as a string, or an object with id
@@ -271,8 +277,33 @@
 
       onSelectAnno(anno) {
         this.activeAnnotation = anno;
+
         // store the annotation id in the route hash, to pre-highlight it on page reload
-        // this.$router.push({ ...this.$route, hash: `#anno=${anno.id}` });
+        this.$router.push({
+          ...this.$route,
+          hash: `#anno=${anno.id}`,
+          query: {
+            ...this.$route.query,
+            page: this.pageForTarget(anno.target)
+          }
+        });
+      },
+
+      pageForTarget(annoTarget) {
+        const annoTargets = [].concat(annoTarget).filter(Boolean);
+        let targetIds;
+        if (this.presentation?.isInEuropeanaDomain) {
+          targetIds = this.resources.map((resource) => resource.about);
+        } else {
+          targetIds = this.canvases.map((canvas) => canvas.id);
+        }
+
+        const i = targetIds.findIndex((id) => annoTargets.some((at) => (at === id) || at.startsWith(`${id}#`)));
+
+        if (i === -1) {
+          return undefined;
+        }
+        return i + 1;
       },
 
       setPage() {

--- a/packages/portal/src/components/item/ItemMediaPresentation.vue
+++ b/packages/portal/src/components/item/ItemMediaPresentation.vue
@@ -17,18 +17,17 @@
           :annotation-list="hasAnnotations"
           :annotation-search="hasSearchService"
           :manifest-uri="uri"
-          @selectAnno="onSelectAnno"
           @keydown.escape.native="showSidebar = false"
         />
         <MediaImageViewer
           v-if="resource?.ebucoreHasMimeType?.startsWith('image/')"
           :url="resource.about"
+          :annotation="activeAnnotation"
           :item-id="itemId"
           :width="resource.ebucoreWidth"
           :height="resource.ebucoreHeight"
           :format="resource.ebucoreHasMimeType"
           :service="resource.svcsHasService"
-          :annotation="activeAnnotation"
         />
         <MediaPDFViewer
           v-else-if="resource?.ebucoreHasMimeType === 'application/pdf'"
@@ -171,6 +170,7 @@
 
     setup() {
       const {
+        activeAnnotation,
         fetchPresentation,
         hasAnnotations,
         hasSearchService,
@@ -178,11 +178,13 @@
         pageForAnnotationTarget,
         resource,
         resourceCount,
+        selectAnnotation,
         setPage,
         setPresentationFromWebResources
       } = useItemMediaPresentation();
 
       return {
+        activeAnnotation,
         fetchPresentation,
         hasAnnotations,
         hasSearchService,
@@ -190,6 +192,7 @@
         pageForAnnotationTarget,
         resource,
         resourceCount,
+        selectAnnotation,
         setPage,
         setPresentationFromWebResources
       };
@@ -197,14 +200,14 @@
 
     data() {
       return {
-        activeAnnotation: null,
-        showSidebar: false,
+        showSidebar: !!this.$route.hash,
         showPages: true
       };
     },
 
     async fetch() {
       this.setPage(this.$route.query.page);
+      // this.selectAnnotation(this.$route.query.anno);
 
       if (this.uri) {
         await this.fetchPresentation(this.uri);
@@ -215,12 +218,6 @@
       }
 
       this.selectResource();
-    },
-
-    mounted() {
-      // const annoHashParam = EuropeanaMediaPresentation.getHashParam(this.$route.hash, 'anno');
-      // this.annotation
-      // console.log('annoHashParam', annoHashParam)
     },
 
     computed: {
@@ -250,23 +247,7 @@
         this.$router.push({ ...this.$route, query: { ...this.$route.query, page } });
       },
 
-      // TODO: move this to MediaAnnotationList!
-      onSelectAnno(anno) {
-        this.activeAnnotation = anno;
-
-        // store the annotation id in the route hash, to pre-highlight it on page reload
-        this.$router.push({
-          ...this.$route,
-          hash: `#anno=${anno.id}`,
-          query: {
-            ...this.$route.query,
-            page: this.pageForAnnotationTarget(anno.target)
-          }
-        });
-      },
-
       selectResource() {
-        this.activeAnnotation = null;
         this.$emit('select', this.resource);
       },
 

--- a/packages/portal/src/components/item/ItemMediaSidebar.vue
+++ b/packages/portal/src/components/item/ItemMediaSidebar.vue
@@ -8,13 +8,16 @@
       data-qa="item media sidebar"
     >
       <!-- TODO: fetch requests from child components of the tabs run before
-                 the tab is shown; prevent that -->
-      <b-tabs vertical>
+                 the tab is shown; prevent that? -->
+      <b-tabs
+        v-model="activeTabIndex"
+        vertical
+      >
         <b-tab
           v-if="annotationList"
           data-qa="item media sidebar annotations"
           button-id="item-media-sidebar-annotations"
-          :title-link-attributes="{ 'aria-label': $t('media.sidebar.annotations') }"
+          :title-link-attributes="{ 'aria-label': $t('media.sidebar.annotations'), href: '#annotations' }"
           @mouseleave.native="hideTooltips"
         >
           <b-tooltip
@@ -28,14 +31,13 @@
           <h2>{{ $t('media.sidebar.annotations') }}</h2>
           <MediaAnnotationList
             class="iiif-viewer-sidebar-panel"
-            @selectAnno="onSelectAnno"
           />
         </b-tab>
         <b-tab
           v-if="!!annotationSearch"
           data-qa="item media sidebar search"
           button-id="item-media-sidebar-search"
-          :title-link-attributes="{ 'aria-label': $t('media.sidebar.search') }"
+          :title-link-attributes="{ 'aria-label': $t('media.sidebar.search'), href: '#search' }"
           @mouseleave.native="hideTooltips"
         >
           <b-tooltip
@@ -50,14 +52,14 @@
           </template>
           <h2>{{ $t('media.sidebar.search') }}</h2>
           <MediaAnnotationSearch
-            @selectAnno="onSelectAnno"
+            class="iiif-viewer-sidebar-panel"
           />
         </b-tab>
         <b-tab
           v-if="!!manifestUri"
           data-qa="item media sidebar links"
           button-id="item-media-sidebar-links"
-          :title-link-attributes="{ 'aria-label': $t('media.sidebar.links') }"
+          :title-link-attributes="{ 'aria-label': $t('media.sidebar.links'), href: '#links' }"
           @mouseleave.native="hideTooltips"
         >
           <b-tooltip
@@ -86,6 +88,8 @@
 
 <script>
   import { BTab, BTabs } from 'bootstrap-vue';
+
+  import useActiveTab from '@/composables/activeTab.js';
   import hideTooltips from '@/mixins/hideTooltips';
 
   export default {
@@ -115,10 +119,20 @@
       }
     },
 
-    methods: {
-      onSelectAnno(anno) {
-        this.$emit('selectAnno', anno);
+    setup(props) {
+      const tabHashes = [];
+      if (props.annotationList) {
+        tabHashes.push('#annotations');
       }
+      if (props.annotationSearch) {
+        tabHashes.push('#search');
+      }
+      if (props.manifestUri) {
+        tabHashes.push('#links');
+      }
+
+      const { activeTabIndex } = useActiveTab(tabHashes);
+      return { activeTabIndex };
     }
   };
 </script>

--- a/packages/portal/src/components/item/ItemMediaSidebar.vue
+++ b/packages/portal/src/components/item/ItemMediaSidebar.vue
@@ -7,6 +7,8 @@
       class="iiif-viewer-sidebar border-bottom"
       data-qa="item media sidebar"
     >
+      <!-- TODO: fetch requests from child components of the tabs run before
+                 the tab is shown; prevent that -->
       <b-tabs vertical>
         <b-tab
           v-if="annotationUri"

--- a/packages/portal/src/components/item/ItemMediaSidebar.vue
+++ b/packages/portal/src/components/item/ItemMediaSidebar.vue
@@ -50,12 +50,11 @@
             />
           </template>
           <h2>{{ $t('media.sidebar.search') }}</h2>
-          <b-link
-            :href="searchUri"
-            target="_blank"
-          >
-            {{ searchUri }}
-          </b-link>
+          <MediaAnnotationSearch
+            :uri="searchUri"
+            :target-id="annotationTargetId"
+            :text-granularity="annotationTextGranularity"
+          />
         </b-tab>
         <b-tab
           v-if="!!manifestUri"
@@ -98,7 +97,8 @@
     components: {
       BTab,
       BTabs,
-      MediaAnnotationList: () => import('../media/MediaAnnotationList.vue')
+      MediaAnnotationList: () => import('../media/MediaAnnotationList.vue'),
+      MediaAnnotationSearch: () => import('../media/MediaAnnotationSearch.vue')
     },
 
     mixins: [hideTooltips],

--- a/packages/portal/src/components/item/ItemMediaSidebar.vue
+++ b/packages/portal/src/components/item/ItemMediaSidebar.vue
@@ -116,6 +116,10 @@
       manifestUri: {
         type: String,
         default: null
+      },
+      query: {
+        type: String,
+        default: null
       }
     },
 

--- a/packages/portal/src/components/item/ItemMediaSidebar.vue
+++ b/packages/portal/src/components/item/ItemMediaSidebar.vue
@@ -28,7 +28,11 @@
           <template #title>
             <span class="icon icon-annotations" />
           </template>
-          <h2>{{ $t('media.sidebar.annotations') }}</h2>
+          <h2
+            class="px-3"
+          >
+            {{ $t('media.sidebar.annotations') }}
+          </h2>
           <MediaAnnotationList
             v-if="activeTabHistory.includes('#annotations')"
             :active="activeTabHash === '#annotations'"
@@ -52,7 +56,11 @@
               class="icon icon-search-in-text"
             />
           </template>
-          <h2>{{ $t('media.sidebar.search') }}</h2>
+          <h2
+            class="px-3"
+          >
+            {{ $t('media.sidebar.search') }}
+          </h2>
           <MediaAnnotationSearch
             v-if="activeTabHistory.includes('#search')"
             :active="activeTabHash === '#search'"
@@ -168,7 +176,7 @@
     }
 
     ::v-deep .tab-content {
-      padding: 1rem 1.5rem 4rem 0.875rem;
+      padding: 1rem 0 4rem 0;
       overflow: auto;
 
       h2 {

--- a/packages/portal/src/components/item/ItemMediaSidebar.vue
+++ b/packages/portal/src/components/item/ItemMediaSidebar.vue
@@ -33,6 +33,31 @@
           />
         </b-tab>
         <b-tab
+          v-if="!!searchUri"
+          data-qa="item media sidebar search"
+          button-id="item-media-sidebar-search"
+          :title-link-attributes="{ 'aria-label': $t('media.sidebar.search') }"
+          @mouseleave.native="hideTooltips"
+        >
+          <b-tooltip
+            target="item-media-sidebar-search"
+            :title="$t('media.sidebar.search')"
+            boundary=".iiif-viewer-sidebar"
+          />
+          <template #title>
+            <span
+              class="icon icon-search-in-text"
+            />
+          </template>
+          <h2>{{ $t('media.sidebar.search') }}</h2>
+          <b-link
+            :href="searchUri"
+            target="_blank"
+          >
+            {{ searchUri }}
+          </b-link>
+        </b-tab>
+        <b-tab
           v-if="!!manifestUri"
           data-qa="item media sidebar links"
           button-id="item-media-sidebar-links"
@@ -92,6 +117,10 @@
         default: null
       },
       manifestUri: {
+        type: String,
+        default: null
+      },
+      searchUri: {
         type: String,
         default: null
       }

--- a/packages/portal/src/components/item/ItemMediaSidebar.vue
+++ b/packages/portal/src/components/item/ItemMediaSidebar.vue
@@ -56,6 +56,7 @@
             :uri="searchUri"
             :target-id="annotationTargetId"
             :text-granularity="annotationTextGranularity"
+            @selectAnno="onSelectAnno"
           />
         </b-tab>
         <b-tab

--- a/packages/portal/src/components/item/ItemMediaSidebar.vue
+++ b/packages/portal/src/components/item/ItemMediaSidebar.vue
@@ -7,9 +7,8 @@
       class="iiif-viewer-sidebar border-bottom"
       data-qa="item media sidebar"
     >
-      <!-- TODO: fetch requests from child components of the tabs run before
-                 the tab is shown; prevent that? -->
       <b-tabs
+        id="item-media-sidebar"
         v-model="activeTabIndex"
         vertical
       >
@@ -17,6 +16,7 @@
           v-if="annotationList"
           data-qa="item media sidebar annotations"
           button-id="item-media-sidebar-annotations"
+          lazy
           :title-link-attributes="{ 'aria-label': $t('media.sidebar.annotations'), href: '#annotations' }"
           @mouseleave.native="hideTooltips"
         >
@@ -30,11 +30,13 @@
           </template>
           <h2>{{ $t('media.sidebar.annotations') }}</h2>
           <MediaAnnotationList
+            v-if="activeTabHistory.includes('#annotations')"
+            :active="activeTabHash === '#annotations'"
             class="iiif-viewer-sidebar-panel"
           />
         </b-tab>
         <b-tab
-          v-if="!!annotationSearch"
+          v-if="annotationSearch"
           data-qa="item media sidebar search"
           button-id="item-media-sidebar-search"
           :title-link-attributes="{ 'aria-label': $t('media.sidebar.search'), href: '#search' }"
@@ -52,6 +54,8 @@
           </template>
           <h2>{{ $t('media.sidebar.search') }}</h2>
           <MediaAnnotationSearch
+            v-if="activeTabHistory.includes('#search')"
+            :active="activeTabHash === '#search'"
             class="iiif-viewer-sidebar-panel"
           />
         </b-tab>
@@ -59,6 +63,7 @@
           v-if="!!manifestUri"
           data-qa="item media sidebar links"
           button-id="item-media-sidebar-links"
+          lazy
           :title-link-attributes="{ 'aria-label': $t('media.sidebar.links'), href: '#links' }"
           @mouseleave.native="hideTooltips"
         >
@@ -135,8 +140,8 @@
         tabHashes.push('#links');
       }
 
-      const { activeTabIndex } = useActiveTab(tabHashes);
-      return { activeTabIndex };
+      const { activeTabHash, activeTabHistory, activeTabIndex } = useActiveTab(tabHashes);
+      return { activeTabHash, activeTabHistory, activeTabIndex };
     }
   };
 </script>
@@ -146,7 +151,7 @@
   @import '@europeana/style/scss/transitions';
 
   .iiif-viewer-sidebar {
-    width: 230px;
+    width: 300px;
     position: absolute;
     top: 0;
     left: 0;

--- a/packages/portal/src/components/item/ItemMediaSidebar.vue
+++ b/packages/portal/src/components/item/ItemMediaSidebar.vue
@@ -10,12 +10,20 @@
       <b-tabs vertical>
         <b-tab
           v-if="annotationUri"
+          data-qa="item media sidebar annotations"
+          button-id="item-media-sidebar-annotations"
+          :title-link-attributes="{ 'aria-label': $t('media.sidebar.annotations') }"
+          @mouseleave.native="hideTooltips"
         >
+          <b-tooltip
+            target="item-media-sidebar-annotations"
+            :title="$t('media.sidebar.annotations')"
+            boundary=".iiif-viewer-sidebar"
+          />
           <template #title>
-            <!-- TODO: label for a11y -->
-            <!-- TODO: replace with new icon for annotations -->
-            <span class="icon icon-text-bold" />
+            <span class="icon icon-annotations" />
           </template>
+          <h2>{{ $t('media.sidebar.annotations') }}</h2>
           <MediaAnnotationList
             :uri="annotationUri"
             :target-id="annotationTargetId"

--- a/packages/portal/src/components/item/ItemMediaSwitch.vue
+++ b/packages/portal/src/components/item/ItemMediaSwitch.vue
@@ -5,7 +5,6 @@
     :web-resources="webResources"
     :item-id="itemId"
     :edm-type="edmType"
-    :search-query="searchQuery"
     :provider-url="providerUrl"
     @select="selectMedia"
   />
@@ -15,7 +14,6 @@
     :web-resources="webResources"
     :item-id="itemId"
     :edm-type="edmType"
-    :search-query="searchQuery"
     :provider-url="providerUrl"
     @select="selectMedia"
   />
@@ -47,11 +45,6 @@
       },
 
       edmType: {
-        type: String,
-        default: null
-      },
-
-      searchQuery: {
         type: String,
         default: null
       },

--- a/packages/portal/src/components/item/ItemPreviewCard.vue
+++ b/packages/portal/src/components/item/ItemPreviewCard.vue
@@ -220,7 +220,7 @@
 
       url() {
         return {
-          hash: this.fulltextSearchQuery ? '#search' : null,
+          hash: this.fulltextSearchQuery ? '#search' : undefined,
           name: 'item-all',
           params: { pathMatch: this.identifier.slice(1) },
           query: { query: this.fulltextSearchQuery }
@@ -236,7 +236,7 @@
             .map((rule) => rule.term);
           return query.join(' ');
         } else {
-          return null;
+          return undefined;
         }
       },
 

--- a/packages/portal/src/components/item/ItemPreviewCard.vue
+++ b/packages/portal/src/components/item/ItemPreviewCard.vue
@@ -71,7 +71,6 @@
 <script>
   import { langMapValueForLocale } from '@europeana/i18n';
 
-  import advancedSearchMixin from '@/mixins/advancedSearch';
   import ContentCard from '../content/ContentCard';
 
   export default {
@@ -83,10 +82,6 @@
       UserButtons: () => import('../user/UserButtons'),
       RightsStatement: () => import('../generic/RightsStatement')
     },
-
-    mixins: [
-      advancedSearchMixin
-    ],
 
     props: {
       /**
@@ -179,6 +174,20 @@
       onAuxClickCard: {
         type: Function,
         default: null
+      },
+      /**
+       * Hash to include in router link to item
+       */
+      routeHash: {
+        type: String,
+        default: undefined
+      },
+      /**
+       * Query to include in router link to item
+       */
+      routeQuery: {
+        type: [Object, String],
+        default: undefined
       }
     },
 
@@ -220,24 +229,11 @@
 
       url() {
         return {
-          hash: this.fulltextSearchQuery ? '#search' : undefined,
+          hash: this.routeHash,
           name: 'item-all',
           params: { pathMatch: this.identifier.slice(1) },
-          query: { query: this.fulltextSearchQuery }
+          query: this.routeQuery
         };
-      },
-
-      // TODO: this will be computed for each preview card; move to a composable?
-      fulltextSearchQuery() {
-        if (this.$route.query?.qa) {
-          const advSearchRules = this.advancedSearchRulesFromRouteQuery(this.$route.query.qa);
-          const query = advSearchRules
-            .filter((rule) => (rule.field === 'fulltext') && (['contains', 'exact'].includes(rule.modifier)))
-            .map((rule) => rule.term);
-          return query.join(' ');
-        } else {
-          return undefined;
-        }
       },
 
       imageUrl() {

--- a/packages/portal/src/components/item/ItemPreviewCard.vue
+++ b/packages/portal/src/components/item/ItemPreviewCard.vue
@@ -71,6 +71,7 @@
 <script>
   import { langMapValueForLocale } from '@europeana/i18n';
 
+  import advancedSearchMixin from '@/mixins/advancedSearch';
   import ContentCard from '../content/ContentCard';
 
   export default {
@@ -82,6 +83,10 @@
       UserButtons: () => import('../user/UserButtons'),
       RightsStatement: () => import('../generic/RightsStatement')
     },
+
+    mixins: [
+      advancedSearchMixin
+    ],
 
     props: {
       /**
@@ -214,7 +219,25 @@
       },
 
       url() {
-        return { name: 'item-all', params: { pathMatch: this.identifier.slice(1) } };
+        return {
+          hash: this.fulltextSearchQuery ? '#search' : null,
+          name: 'item-all',
+          params: { pathMatch: this.identifier.slice(1) },
+          query: { query: this.fulltextSearchQuery }
+        };
+      },
+
+      // TODO: this will be computed for each preview card; move to a composable?
+      fulltextSearchQuery() {
+        if (this.$route.query?.qa) {
+          const advSearchRules = this.advancedSearchRulesFromRouteQuery(this.$route.query.qa);
+          const query = advSearchRules
+            .filter((rule) => (rule.field === 'fulltext') && (['contains', 'exact'].includes(rule.modifier)))
+            .map((rule) => rule.term);
+          return query.join(' ');
+        } else {
+          return null;
+        }
       },
 
       imageUrl() {

--- a/packages/portal/src/components/item/ItemPreviewCardGroup.vue
+++ b/packages/portal/src/components/item/ItemPreviewCardGroup.vue
@@ -58,6 +58,8 @@
             :lazy="true"
             :enable-accept-recommendation="enableAcceptRecommendations"
             :enable-reject-recommendation="enableRejectRecommendations"
+            :route-hash="routeHash"
+            :route-query="routeQuery"
             :show-pins="showPins"
             :show-move="useDraggable"
             :show-remove="userEditableItems"
@@ -119,6 +121,8 @@
             class="item"
             :hit-selector="itemHitSelector(card)"
             :variant="cardVariant"
+            :route-hash="routeHash"
+            :route-query="routeQuery"
             :show-pins="showPins"
             :show-move="useDraggable"
             :show-remove="userEditableItems"
@@ -134,6 +138,7 @@
 </template>
 
 <script>
+  import advancedSearchMixin from '@/mixins/advancedSearch';
   import ItemPreviewCard from './ItemPreviewCard';
 
   export default {
@@ -143,6 +148,10 @@
       draggable: () => import('vuedraggable'),
       ItemPreviewCard
     },
+
+    mixins: [
+      advancedSearchMixin
+    ],
 
     props: {
       items: {
@@ -209,6 +218,22 @@
 
       cardVariant() {
         return this.view === 'grid' ? 'default' : this.view;
+      },
+
+      routeHash() {
+        return this.routeQuery ? '#search' : undefined;
+      },
+
+      routeQuery() {
+        if (this.$route.query?.qa) {
+          const fulltext = this.advancedSearchRulesFromRouteQuery(this.$route.query.qa)
+            .filter((rule) => (rule.field === 'fulltext') && (['contains', 'exact'].includes(rule.modifier)))
+            .map((rule) => rule.term)
+            .join(' ');
+          return { fulltext };
+        } else {
+          return undefined;
+        }
       },
 
       masonryActive() {

--- a/packages/portal/src/components/media/MediaAnnotationList.vue
+++ b/packages/portal/src/components/media/MediaAnnotationList.vue
@@ -76,7 +76,7 @@
     //       the component has been hidden/shown/whatever in the meantime,
     //       i.e. in the itemMediaPresentation composable
     async fetch() {
-      await (this.searching ? this.searchAnnotations(this.query) : this.fetchCanvasAnnotations());
+      await (this.searching ? this.searchAnnotations(`"${this.query}"`) : this.fetchCanvasAnnotations());
 
       if (this.$route.query.anno) {
         this.selectAnnotation(this.$route.query.anno);

--- a/packages/portal/src/components/media/MediaAnnotationList.vue
+++ b/packages/portal/src/components/media/MediaAnnotationList.vue
@@ -23,7 +23,18 @@
         :lang="anno.body.language"
         @click="handleClickListItem(anno)"
       >
-        {{ anno.body.value }}
+        <template
+          v-if="searching"
+        >
+          {{ annotationSearchHitSelectorFor(anno.id).prefix }}<!--
+          --><strong class="has-text-highlight">{{ annotationSearchHitSelectorFor(anno.id).exact }}</strong><!--
+          -->{{ annotationSearchHitSelectorFor(anno.id).suffix }}
+        </template>
+        <template
+          v-else
+        >
+          {{ anno.body.value }}
+        </template>
       </b-list-group-item>
     </b-list-group>
   </div>
@@ -50,6 +61,7 @@
     setup() {
       const {
         annotations,
+        annotationSearchHitSelectorFor,
         annotationSearchResults,
         activeAnnotation,
         annotationUri,
@@ -61,6 +73,7 @@
 
       return {
         annotations,
+        annotationSearchHitSelectorFor,
         annotationSearchResults,
         annotationUri,
         activeAnnotation,
@@ -121,7 +134,10 @@
           page = this.pageForAnnotationTarget(this.activeAnnotation.target);
         }
 
-        this.$router.push({ ...this.$route, query: { ...this.$route.query, anno, page } });
+        // use replace, not push, so that the back button will leave the page,
+        // and e.g. go back to search results instead of through myriad
+        // previously selected annotations
+        this.$router.replace({ ...this.$route, query: { ...this.$route.query, anno, page } });
       }
     }
   };

--- a/packages/portal/src/components/media/MediaAnnotationList.vue
+++ b/packages/portal/src/components/media/MediaAnnotationList.vue
@@ -51,7 +51,7 @@
       },
       uri: {
         type: String,
-        default: null
+        required: true
       }
     },
 
@@ -65,9 +65,6 @@
     // TODO: filter by motivation(s)
     async fetch() {
       this.activeAnnotation = null;
-      if (!this.uri || !this.targetId) {
-        return;
-      }
 
       let textGranularity;
       if (Array.isArray(this.textGranularity)) {
@@ -77,7 +74,7 @@
       }
 
       const list = await EuropeanaMediaAnnotationList.from(this.uri, { params: { textGranularity } });
-      const annos = list.annotationsForTarget(this.targetId);
+      const annos = this.targetId ? list.annotationsForTarget(this.targetId) : list.items;
 
       // NOTE: this may result in duplicate network requests for the same body resource
       //       if there are multiple external annotations with the same resource URL,

--- a/packages/portal/src/components/media/MediaAnnotationList.vue
+++ b/packages/portal/src/components/media/MediaAnnotationList.vue
@@ -93,7 +93,7 @@
 
       if (this.$route.query.anno) {
         this.selectAnnotation(this.$route.query.anno);
-        // TODO: would be nice to scroll to the active annotation, but that is
+        // TODO: it would be nice to scroll to the active annotation, but that is
         //       made awkward by the scrollbar being on the ancestor sidebar component...
       }
     },

--- a/packages/portal/src/components/media/MediaAnnotationList.vue
+++ b/packages/portal/src/components/media/MediaAnnotationList.vue
@@ -19,9 +19,9 @@
         v-for="(anno, index) in annotationList"
         :key="index"
         :action="true"
-        :active="activeAnnotation === anno.id"
+        :active="anno.id === activeAnnotation?.id"
         :lang="anno.body.language"
-        @click="selectAnno(anno)"
+        @click="handleClickListItem(anno)"
       >
         {{ anno.body.value }}
       </b-list-group-item>
@@ -48,13 +48,26 @@
     },
 
     setup() {
-      const { annotations, annotationSearchResults, fetchCanvasAnnotations, searchAnnotations } = useItemMediaPresentation();
-      return { annotations, annotationSearchResults, fetchCanvasAnnotations, searchAnnotations };
-    },
+      const {
+        annotations,
+        annotationSearchResults,
+        activeAnnotation,
+        annotationUri,
+        fetchCanvasAnnotations,
+        pageForAnnotationTarget,
+        searchAnnotations,
+        selectAnnotation
+      } = useItemMediaPresentation();
 
-    data() {
       return {
-        activeAnnotation: null
+        annotations,
+        annotationSearchResults,
+        annotationUri,
+        activeAnnotation,
+        fetchCanvasAnnotations,
+        pageForAnnotationTarget,
+        searchAnnotations,
+        selectAnnotation
       };
     },
 
@@ -63,9 +76,13 @@
     //       the component has been hidden/shown/whatever in the meantime,
     //       i.e. in the itemMediaPresentation composable
     async fetch() {
-      this.activeAnnotation = null;
+      await (this.searching ? this.searchAnnotations(this.query) : this.fetchCanvasAnnotations());
 
-      await this.searching ? this.searchAnnotations(this.query) : this.fetchCanvasAnnotations();
+      if (this.$route.query.anno) {
+        this.selectAnnotation(this.$route.query.anno);
+        // TODO: would be nice to scroll to the active annotation, but that is
+        //       made awkward by the scrollbar being on the ancestor sidebar component...
+      }
     },
 
     computed: {
@@ -80,14 +97,31 @@
 
     watch: {
       // TODO: should this watcher go into useItemMediaPresentation?
-      annotationUri: '$fetch',
-      uri: '$fetch'
+      annotationUri() {
+        !this.searching && this.$fetch();
+      },
+      query() {
+        this.searching && this.$fetch();
+      }
     },
 
     methods: {
-      selectAnno(anno) {
-        this.activeAnnotation = anno.id;
-        this.$emit('selectAnno', anno);
+      handleClickListItem(anno) {
+        this.selectAnnotation(anno);
+        this.updateAnnoRoute();
+      },
+
+      updateAnnoRoute() {
+        let page = null;
+        let anno = null;
+        if (this.activeAnnotation) {
+          // store the annotation id in the route, to pre-highlight it on page reload
+          // TODO: md5 this else the url will too long
+          anno = this.activeAnnotation.id;
+          page = this.pageForAnnotationTarget(this.activeAnnotation.target);
+        }
+
+        this.$router.push({ ...this.$route, query: { ...this.$route.query, anno, page } });
       }
     }
   };

--- a/packages/portal/src/components/media/MediaAnnotationList.vue
+++ b/packages/portal/src/components/media/MediaAnnotationList.vue
@@ -149,6 +149,7 @@
           return;
         }
         await this.$nextTick();
+
         if (this.activeAnnotation && this.annotationScrollToContainerSelector && this.$refs.annotationListItems) {
           this.scrollElementToCentre(
             this.$refs.annotationListItems[this.annotationList.indexOf(this.activeAnnotation)],

--- a/packages/portal/src/components/media/MediaAnnotationSearch.vue
+++ b/packages/portal/src/components/media/MediaAnnotationSearch.vue
@@ -1,11 +1,10 @@
 <template>
   <div>
     <b-form
+      id="media-annotation-search-form"
       @submit.prevent="handleSubmitForm"
     >
-      <b-form-group
-        id="input-group-1"
-      >
+      <b-form-group>
         <b-form-input
           id="media-annotation-search-query"
           v-model="query"

--- a/packages/portal/src/components/media/MediaAnnotationSearch.vue
+++ b/packages/portal/src/components/media/MediaAnnotationSearch.vue
@@ -32,20 +32,20 @@
 
     data() {
       return {
-        annoQuery: this.$route.query.query || null,
-        query: this.$route.query.query || null
+        annoQuery: this.$route.query.fulltext || null,
+        query: this.$route.query.fulltext || null
       };
     },
 
     watch: {
-      '$route.query.query'() {
-        this.annoQuery = this.$route.query.query || null;
+      '$route.query.fulltext'() {
+        this.annoQuery = this.$route.query.fulltext || null;
       }
     },
 
     methods: {
       handleSubmitForm() {
-        this.$router.push({ ...this.$route, query: { ...this.$route.query, query: this.query } });
+        this.$router.push({ ...this.$route, query: { ...this.$route.query, fulltext: this.query } });
       }
     }
   };

--- a/packages/portal/src/components/media/MediaAnnotationSearch.vue
+++ b/packages/portal/src/components/media/MediaAnnotationSearch.vue
@@ -18,6 +18,7 @@
       v-if="query"
       :uri="uriWithQuery"
       :text-granularity="textGranularity"
+      @selectAnno="onSelectAnno"
     />
   </div>
 </template>
@@ -73,6 +74,10 @@
       handleSubmitForm() {
         // console.log
         this.$router.push({ ...this.$route, query: { ...this.$route.query, query: this.query } });
+      },
+
+      onSelectAnno(anno) {
+        this.$emit('selectAnno', anno);
       }
     }
   };

--- a/packages/portal/src/components/media/MediaAnnotationSearch.vue
+++ b/packages/portal/src/components/media/MediaAnnotationSearch.vue
@@ -15,6 +15,7 @@
     </b-form>
     <MediaAnnotationList
       v-if="annoQuery"
+      :active="active"
       :query="annoQuery"
     />
   </div>
@@ -28,6 +29,13 @@
 
     components: {
       MediaAnnotationList
+    },
+
+    props: {
+      active: {
+        type: Boolean,
+        default: true
+      }
     },
 
     data() {

--- a/packages/portal/src/components/media/MediaAnnotationSearch.vue
+++ b/packages/portal/src/components/media/MediaAnnotationSearch.vue
@@ -2,6 +2,7 @@
   <div>
     <b-form
       id="media-annotation-search-form"
+      class="px-3"
       @submit.prevent="handleSubmitForm"
     >
       <b-form-group>

--- a/packages/portal/src/components/media/MediaAnnotationSearch.vue
+++ b/packages/portal/src/components/media/MediaAnnotationSearch.vue
@@ -1,0 +1,79 @@
+<template>
+  <div>
+    <b-form
+      @submit.prevent="handleSubmitForm"
+    >
+      <b-form-group
+        id="input-group-1"
+      >
+        <b-form-input
+          id="media-annotation-search-query"
+          v-model="query"
+          name="query"
+          type="text"
+        />
+      </b-form-group>
+    </b-form>
+    <MediaAnnotationList
+      v-if="query"
+      :uri="uriWithQuery"
+      :text-granularity="textGranularity"
+    />
+  </div>
+</template>
+
+<script>
+  import MediaAnnotationList from './MediaAnnotationList.vue';
+
+  export default {
+    name: 'MediaAnnotationSearch',
+
+    components: {
+      MediaAnnotationList
+    },
+
+    props: {
+      targetId: {
+        type: String,
+        default: null
+      },
+
+      textGranularity: {
+        type: [Array, String],
+        default: null
+      },
+
+      uri: {
+        type: String,
+        required: true
+      }
+    },
+
+    data() {
+      return {
+        query: this.$route.query.query || null
+      };
+    },
+
+    computed: {
+      uriWithQuery() {
+        const url = new URL(this.uri);
+        url.searchParams.set('query', this.query);
+        return url.toString();
+      }
+    },
+
+    watch: {
+      '$route.query.query'() {
+        this.query = this.$route.query.query || null;
+      }
+    },
+
+    methods: {
+      handleSubmitForm() {
+        // console.log
+        this.$router.push({ ...this.$route, query: { ...this.$route.query, query: this.query } });
+      }
+    }
+  };
+</script>

--- a/packages/portal/src/components/media/MediaAnnotationSearch.vue
+++ b/packages/portal/src/components/media/MediaAnnotationSearch.vue
@@ -15,9 +15,8 @@
       </b-form-group>
     </b-form>
     <MediaAnnotationList
-      v-if="query"
-      :query="query"
-      @selectAnno="onSelectAnno"
+      v-if="annoQuery"
+      :query="annoQuery"
     />
   </div>
 </template>
@@ -34,23 +33,20 @@
 
     data() {
       return {
+        annoQuery: this.$route.query.query || null,
         query: this.$route.query.query || null
       };
     },
 
     watch: {
       '$route.query.query'() {
-        this.query = this.$route.query.query || null;
+        this.annoQuery = this.$route.query.query || null;
       }
     },
 
     methods: {
       handleSubmitForm() {
         this.$router.push({ ...this.$route, query: { ...this.$route.query, query: this.query } });
-      },
-
-      onSelectAnno(anno) {
-        this.$emit('selectAnno', anno);
       }
     }
   };

--- a/packages/portal/src/components/media/MediaImageViewer.vue
+++ b/packages/portal/src/components/media/MediaImageViewer.vue
@@ -139,6 +139,10 @@
         //        others' correct modelling
         const target = annotation.targetFor(this.url)[0];
         const targetId = target?.id || target;
+        if (!targetId) {
+          return;
+        }
+
         const targetHash = new URL(targetId).hash;
         const xywhSelector = annotation.getHashParam(targetHash, 'xywh');
         if (xywhSelector) {

--- a/packages/portal/src/composables/activeTab.js
+++ b/packages/portal/src/composables/activeTab.js
@@ -4,9 +4,9 @@ import { computed, onBeforeMount, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue2-helpers/vue-router';
 
 export default function useActiveTab(tabHashes) {
-  const activeTabIndex = ref(-1);
   const router = useRouter();
   const route = useRoute();
+  const activeTabIndex = ref(-1);
 
   const setActiveTabIndexFromRouteHash = () => {
     if (tabHashes.includes(route?.hash)) {

--- a/packages/portal/src/composables/activeTab.js
+++ b/packages/portal/src/composables/activeTab.js
@@ -7,6 +7,7 @@ export default function useActiveTab(tabHashes) {
   const router = useRouter();
   const route = useRoute();
   const activeTabIndex = ref(-1);
+  const activeTabHistory = ref([]);
 
   const setActiveTabIndexFromRouteHash = () => {
     if (tabHashes.includes(route?.hash)) {
@@ -20,6 +21,7 @@ export default function useActiveTab(tabHashes) {
 
   watch(activeTabIndex, () => {
     if (activeTabIndex.value !== -1) {
+      activeTabHistory.value.push(activeTabHash.value);
       router.push({ ...route, hash: activeTabHash.value });
     }
   });
@@ -36,6 +38,7 @@ export default function useActiveTab(tabHashes) {
 
   return {
     activeTabHash,
+    activeTabHistory,
     activeTabIndex
   };
 }

--- a/packages/portal/src/composables/activeTab.js
+++ b/packages/portal/src/composables/activeTab.js
@@ -9,7 +9,7 @@ export default function useActiveTab(tabHashes) {
   const route = useRoute();
 
   const setActiveTabIndexFromRouteHash = () => {
-    if (tabHashes.includes(route.hash)) {
+    if (tabHashes.includes(route?.hash)) {
       activeTabIndex.value = tabHashes.indexOf(route.hash);
     }
   };
@@ -24,9 +24,11 @@ export default function useActiveTab(tabHashes) {
     }
   });
 
-  watch(route, () => {
-    setActiveTabIndexFromRouteHash();
-  });
+  if (route) {
+    watch(route, () => {
+      setActiveTabIndexFromRouteHash();
+    });
+  }
 
   onBeforeMount(() => {
     setActiveTabIndexFromRouteHash();

--- a/packages/portal/src/composables/activeTab.js
+++ b/packages/portal/src/composables/activeTab.js
@@ -1,0 +1,39 @@
+import { computed, onBeforeMount, ref, watch } from 'vue';
+// vue-router for vue 2 does not export useRoute and useRouter as in v3;
+// vue2-helpers provides helpers that do
+import { useRoute, useRouter } from 'vue2-helpers/vue-router';
+
+export default function useActiveTab(tabHashes) {
+  const activeTabIndex = ref(-1);
+  const router = useRouter();
+  const route = useRoute();
+
+  const setActiveTabIndexFromRouteHash = () => {
+    if (tabHashes.includes(route.hash)) {
+      activeTabIndex.value = tabHashes.indexOf(route.hash);
+    }
+  };
+
+  const activeTabHash = computed(() => {
+    return tabHashes[activeTabIndex.value];
+  });
+
+  watch(activeTabIndex, () => {
+    if (activeTabIndex.value !== -1) {
+      router.push({ ...route, hash: activeTabHash.value });
+    }
+  });
+
+  watch(route, () => {
+    setActiveTabIndexFromRouteHash();
+  });
+
+  onBeforeMount(() => {
+    setActiveTabIndexFromRouteHash();
+  });
+
+  return {
+    activeTabHash,
+    activeTabIndex
+  };
+}

--- a/packages/portal/src/composables/itemMediaPresentation.js
+++ b/packages/portal/src/composables/itemMediaPresentation.js
@@ -32,6 +32,7 @@ const annotationTextGranularity = computed(() => {
   return annotationCollection.value?.textGranularity;
 });
 
+// TODO: ambiguous name; rename `annotationCollectionUri`
 const annotationUri = computed(() => {
   if (!annotationCollection.value) {
     return null;
@@ -144,12 +145,8 @@ const searchAnnotations = async(query) => {
   annotationSearchHits.value = list.hits || [];
 };
 
-const selectAnnotation = (active) => {
-  if (typeof active === 'string') {
-    activeAnnotation.value = annotations.value?.find((anno) => anno.id === active) || null;
-  } else {
-    activeAnnotation.value = active;
-  }
+const setActiveAnnotation = (active) => {
+  activeAnnotation.value = active;
 };
 
 const setPage = (value) => {
@@ -181,7 +178,7 @@ export default function useItemMediaPresentation() {
     presentation,
     searchAnnotations,
     searchServiceUri,
-    selectAnnotation,
+    setActiveAnnotation,
     setPage,
     setPresentationFromWebResources
   };

--- a/packages/portal/src/composables/itemMediaPresentation.js
+++ b/packages/portal/src/composables/itemMediaPresentation.js
@@ -5,6 +5,7 @@ import EuropeanaMediaPresentation from '@/utils/europeana/media/Presentation.js'
 
 const annotations = ref([]);
 const annotationSearchResults = ref([]);
+const activeAnnotation = ref(null);
 const page = ref(1);
 const presentation = ref(null);
 
@@ -135,9 +136,16 @@ const pageForAnnotationTarget = (annoTarget) => {
 
 const searchAnnotations = async(query) => {
   const annos = await fetchAnnotations(searchServiceUri.value, { params: { query } });
-  console.log('search annos', annos)
   annotationSearchResults.value = annos;
   return annotationSearchResults;
+};
+
+const selectAnnotation = (active) => {
+  if (typeof active === 'string') {
+    activeAnnotation.value = annotations.value?.find((anno) => anno.id === active) || null;
+  } else {
+    activeAnnotation.value = active;
+  }
 };
 
 const setPage = (value) => {
@@ -152,6 +160,7 @@ export default function useItemMediaPresentation() {
     annotationTargetId,
     annotationUri,
     annotationTextGranularity,
+    activeAnnotation,
     canvas,
     fetchAnnotations,
     fetchCanvasAnnotations,
@@ -166,6 +175,7 @@ export default function useItemMediaPresentation() {
     presentation,
     searchAnnotations,
     searchServiceUri,
+    selectAnnotation,
     setPage,
     setPresentationFromWebResources
   };

--- a/packages/portal/src/i18n/lang/en.js
+++ b/packages/portal/src/i18n/lang/en.js
@@ -942,6 +942,7 @@ export default {
       "zoomOut": "Zoom out"
     },
     "sidebar": {
+      "annotations": "Annotations",
       "hide": "Hide sidebar",
       "IIIFManifest": "IIIF Manifest",
       "links": "Links",

--- a/packages/portal/src/i18n/lang/en.js
+++ b/packages/portal/src/i18n/lang/en.js
@@ -946,6 +946,7 @@ export default {
       "hide": "Hide sidebar",
       "IIIFManifest": "IIIF Manifest",
       "links": "Links",
+      "search": "Search",
       "show": "Show sidebar"
     },
     "pages": {

--- a/packages/portal/src/utils/europeana/media/AnnotationList.js
+++ b/packages/portal/src/utils/europeana/media/AnnotationList.js
@@ -1,5 +1,6 @@
 import Base from './Base.js';
 import Annotation from './Annotation.js';
+import SearchHit from './SearchHit.js';
 
 export default class EuropeanaMediaAnnotationList extends Base {
   parseData(data) {
@@ -7,6 +8,7 @@ export default class EuropeanaMediaAnnotationList extends Base {
 
     const parsed = {
       id: data.id,
+      hits: (data.hits || []).map((hit) => SearchHit.parse(hit)),
       language: data.language,
       textGranularity: data.textGranularity
     };

--- a/packages/portal/src/utils/europeana/media/Base.js
+++ b/packages/portal/src/utils/europeana/media/Base.js
@@ -67,6 +67,14 @@ export default class EuropeanaMediaBase {
     });
   }
 
+  static getHashParam(hash, key) {
+    if (hash?.startsWith?.('#')) {
+      return new URLSearchParams(hash.slice(1)).get(key);
+    } else {
+      return undefined;
+    }
+  }
+
   constructor(idOrData) {
     if (typeof idOrData === 'string') {
       this.id = idOrData;
@@ -114,6 +122,10 @@ export default class EuropeanaMediaBase {
     } else {
       return undefined;
     }
+  }
+
+  getHashParam(hash, key) {
+    return this.constructor.getHashParam(hash, key);
   }
 
   fetch({ params } = {}) {

--- a/packages/portal/src/utils/europeana/media/Base.js
+++ b/packages/portal/src/utils/europeana/media/Base.js
@@ -117,14 +117,6 @@ export default class EuropeanaMediaBase {
   }
 
   getHashParam(hash, key) {
-    if (hash?.startsWith?.('#')) {
-      return new URLSearchParams(hash.slice(1)).get(key);
-    } else {
-      return undefined;
-    }
-  }
-
-  getHashParam(hash, key) {
     return this.constructor.getHashParam(hash, key);
   }
 

--- a/packages/portal/src/utils/europeana/media/SearchHit.js
+++ b/packages/portal/src/utils/europeana/media/SearchHit.js
@@ -1,0 +1,4 @@
+import Base from './Base.js';
+
+export default class EuropeanaMediaSearchHit extends Base {
+}

--- a/packages/portal/tests/size/.size-limit.json
+++ b/packages/portal/tests/size/.size-limit.json
@@ -19,7 +19,7 @@
   {
     "name": "portal.js server",
     "running": false,
-    "limit": "1450 KB",
+    "limit": "1470 KB",
     "path": [
       ".nuxt/dist/server/*.js"
     ]

--- a/packages/portal/tests/unit/components/iiif/IIIFMiradorViewer.spec.js
+++ b/packages/portal/tests/unit/components/iiif/IIIFMiradorViewer.spec.js
@@ -56,6 +56,7 @@ const factory = ({ propsData = {}, data = {} } = {}) => shallowMountNuxt(IIIFMir
       }
     },
     $axios: axios,
+    $route: { query: {} },
     $t: key => key
   }
 });

--- a/packages/portal/tests/unit/components/item/ItemHero.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemHero.spec.js
@@ -175,19 +175,6 @@ describe('components/item/ItemHero', () => {
     });
   });
 
-  describe('fulltextSearchQuery', () => {
-    it('includes adv search fulltext contains terms from Nuxt context from route', () => {
-      const query = 'hamburger';
-      const qa = ['fulltext:(theater)', 'fulltext:(zeitung)', 'NOT fulltext:(direktor)', 'when:1901'];
-      const mocks = { $nuxt: { context: { from: { query: { qa, query } } } } };
-      const wrapper = factory({ propsData: { identifier }, mocks });
-
-      const fulltextSearchQuery = wrapper.vm.fulltextSearchQuery;
-
-      expect(fulltextSearchQuery).toBe('theater zeitung');
-    });
-  });
-
   describe('showTranscribathonLink', () => {
     describe('when the linkForContributingAnnotation goes to a transcribathon URL', () => {
       it('is true', async() => {

--- a/packages/portal/tests/unit/components/item/ItemMediaSidebar.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemMediaSidebar.spec.js
@@ -10,7 +10,7 @@ const factory = (propsData = {}) => shallowMount(ItemMediaSidebar, {
   mocks: {
     $t: (key) => key
   },
-  stubs: ['b-link', 'b-tooltip']
+  stubs: ['b-link', 'b-tooltip', 'MediaAnnotationList']
 });
 
 describe('components/item/ItemMediaSidebar', () => {
@@ -21,6 +21,16 @@ describe('components/item/ItemMediaSidebar', () => {
       const sidebar = wrapper.find('[data-qa="item media sidebar"]');
 
       expect(sidebar.exists()).toBe(true);
+    });
+
+    describe('when there is an annotation URI', () => {
+      it('has a tab for annotations', () => {
+        const wrapper = factory({ annotationUri: 'https://example.com/iiif/123/annotations' });
+
+        const annotationsTab = wrapper.find('[data-qa="item media sidebar annotations"]');
+
+        expect(annotationsTab.exists()).toBe(true);
+      });
     });
 
     describe('when there is a manifest URI', () => {

--- a/packages/portal/tests/unit/components/item/ItemMediaSidebar.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemMediaSidebar.spec.js
@@ -10,7 +10,7 @@ const factory = (propsData = {}) => shallowMount(ItemMediaSidebar, {
   mocks: {
     $t: (key) => key
   },
-  stubs: ['b-link', 'b-tooltip', 'MediaAnnotationList']
+  stubs: ['b-link', 'b-tooltip', 'MediaAnnotationList', 'MediaAnnotationSearch']
 });
 
 describe('components/item/ItemMediaSidebar', () => {

--- a/packages/portal/tests/unit/components/item/ItemMediaSidebar.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemMediaSidebar.spec.js
@@ -33,6 +33,16 @@ describe('components/item/ItemMediaSidebar', () => {
       });
     });
 
+    describe('when there is a search URI', () => {
+      it('has a tab for search', () => {
+        const wrapper = factory({ searchUri: 'https://example.com/iiif/123/search' });
+
+        const searchTab = wrapper.find('[data-qa="item media sidebar search"]');
+
+        expect(searchTab.exists()).toBe(true);
+      });
+    });
+
     describe('when there is a manifest URI', () => {
       it('has a tab for links', () => {
         const wrapper = factory({ manifestUri: 'https://example.com/iiif/123/manifest' });

--- a/packages/portal/tests/unit/components/item/ItemMediaSidebar.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemMediaSidebar.spec.js
@@ -10,11 +10,7 @@ const factory = (propsData = {}) => shallowMount(ItemMediaSidebar, {
   mocks: {
     $t: (key) => key
   },
-<<<<<<< HEAD
   stubs: ['b-link', 'b-tooltip', 'MediaAnnotationList', 'MediaAnnotationSearch']
-=======
-  stubs: ['b-link', 'b-tooltip', 'MediaAnnotationList']
->>>>>>> master
 });
 
 describe('components/item/ItemMediaSidebar', () => {
@@ -27,15 +23,9 @@ describe('components/item/ItemMediaSidebar', () => {
       expect(sidebar.exists()).toBe(true);
     });
 
-<<<<<<< HEAD
-    describe('when there is an annotation URI', () => {
-      it('has a tab for annotations', () => {
-        const wrapper = factory({ annotationUri: 'https://example.com/iiif/123/annotations' });
-=======
     describe('when there is an annotation list', () => {
       it('has a tab for annotations', () => {
         const wrapper = factory({ annotationList: true });
->>>>>>> master
 
         const annotationsTab = wrapper.find('[data-qa="item media sidebar annotations"]');
 
@@ -43,10 +33,9 @@ describe('components/item/ItemMediaSidebar', () => {
       });
     });
 
-<<<<<<< HEAD
-    describe('when there is a search URI', () => {
+    describe('when there is an annotation search service', () => {
       it('has a tab for search', () => {
-        const wrapper = factory({ searchUri: 'https://example.com/iiif/123/search' });
+        const wrapper = factory({ annotationSearch: true });
 
         const searchTab = wrapper.find('[data-qa="item media sidebar search"]');
 
@@ -54,8 +43,6 @@ describe('components/item/ItemMediaSidebar', () => {
       });
     });
 
-=======
->>>>>>> master
     describe('when there is a manifest URI', () => {
       it('has a tab for links', () => {
         const wrapper = factory({ manifestUri: 'https://example.com/iiif/123/manifest' });

--- a/packages/portal/tests/unit/components/item/ItemPreviewCard.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemPreviewCard.spec.js
@@ -19,7 +19,7 @@ const item = {
   type: 'IMAGE'
 };
 
-const factory = (propsData) => {
+const factory = ({ mocks, propsData } = {}) => {
   return shallowMount(ItemPreviewCard, {
     localVue,
     propsData,
@@ -36,6 +36,7 @@ const factory = (propsData) => {
       $i18n: {
         locale: 'en'
       },
+      $route: { query: {} },
       $t: () => {},
       $store: {
         state: {
@@ -45,7 +46,8 @@ const factory = (propsData) => {
           'set/isLiked': storeIsLikedGetter,
           'entity/isPinned': storeIsPinnedGetter
         }
-      }
+      },
+      ...mocks
     }
   });
 };
@@ -53,7 +55,7 @@ const factory = (propsData) => {
 describe('components/item/ItemPreviewCard', () => {
   describe('default card', () => {
     it('renders a default content card without any recommendation buttons', () => {
-      const wrapper = factory({ item });
+      const wrapper = factory({ propsData: { item } });
 
       expect(wrapper.vm.texts).toEqual([item.dcCreatorLangAware, item.dataProvider]);
     });
@@ -68,7 +70,7 @@ describe('components/item/ItemPreviewCard', () => {
           prefix: 'Prefix text ',
           suffix: 'suffix text.'
         };
-        const wrapper = factory({ item, variant: 'list', hitSelector });
+        const wrapper = factory({ propsData: { item, variant: 'list', hitSelector } });
 
         expect(wrapper.vm.texts).toEqual([]);
         expect(wrapper.vm.hitText).toEqual(hitSelector);
@@ -76,28 +78,28 @@ describe('components/item/ItemPreviewCard', () => {
     });
     describe('when no hit-selector is present, but there is a description', () => {
       it('renders a list content card with description text', () => {
-        const wrapper = factory({ item, variant: 'list' });
+        const wrapper = factory({ propsData: { item, variant: 'list' } });
 
         expect(wrapper.vm.texts).toEqual([item.dcDescriptionLangAware]);
       });
     });
     it('renders a list content card with license label', () => {
-      const wrapper = factory({ item, variant: 'list' });
+      const wrapper = factory({ propsData: { item, variant: 'list' } });
 
       expect(wrapper.vm.rights).toEqual(item.rights[0]);
     });
     it('renders a list content card with type label', () => {
-      const wrapper = factory({ item, variant: 'list' });
+      const wrapper = factory({ propsData: { item, variant: 'list' } });
 
       expect(wrapper.vm.type).toEqual(item.type);
     });
   });
 
-  describe('event listeneres', () => {
+  describe('event listeners', () => {
     describe('onClickCard', () => {
       it('is called with item ID when card receives `click` event', () => {
         const onClickCard = sinon.spy();
-        const wrapper = factory({ item, onClickCard });
+        const wrapper = factory({ propsData: { item, onClickCard } });
 
         wrapper.vm.$refs.card.$el.dispatchEvent(new Event('click'));
 
@@ -108,12 +110,25 @@ describe('components/item/ItemPreviewCard', () => {
     describe('onAuxClickCard', () => {
       it('is called with item ID when card receives `click` event', () => {
         const onAuxClickCard = sinon.spy();
-        const wrapper = factory({ item, onAuxClickCard });
+        const wrapper = factory({ propsData: { item, onAuxClickCard } });
 
         wrapper.vm.$refs.card.$el.dispatchEvent(new Event('auxclick'));
 
         expect(onAuxClickCard.calledWith(item.id)).toBe(true);
       });
+    });
+  });
+
+  describe('fulltextSearchQuery', () => {
+    it('includes adv search fulltext contains terms from Nuxt context from route', () => {
+      const query = 'hamburger';
+      const qa = ['fulltext:(theater)', 'fulltext:(zeitung)', 'NOT fulltext:(direktor)', 'when:1901'];
+      const mocks = { $route: { query: { qa, query } } };
+      const wrapper = factory({ propsData: { item }, mocks });
+
+      const fulltextSearchQuery = wrapper.vm.fulltextSearchQuery;
+
+      expect(fulltextSearchQuery).toBe('theater zeitung');
     });
   });
 });

--- a/packages/portal/tests/unit/components/item/ItemPreviewCard.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemPreviewCard.spec.js
@@ -118,17 +118,4 @@ describe('components/item/ItemPreviewCard', () => {
       });
     });
   });
-
-  describe('fulltextSearchQuery', () => {
-    it('includes adv search fulltext contains terms from Nuxt context from route', () => {
-      const query = 'hamburger';
-      const qa = ['fulltext:(theater)', 'fulltext:(zeitung)', 'NOT fulltext:(direktor)', 'when:1901'];
-      const mocks = { $route: { query: { qa, query } } };
-      const wrapper = factory({ propsData: { item }, mocks });
-
-      const fulltextSearchQuery = wrapper.vm.fulltextSearchQuery;
-
-      expect(fulltextSearchQuery).toBe('theater zeitung');
-    });
-  });
 });

--- a/packages/portal/tests/unit/components/item/ItemPreviewCardGroup.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemPreviewCardGroup.spec.js
@@ -26,6 +26,7 @@ const factory = ({ propsData } = {}) => {
       $i18n: {
         locale: 'en'
       },
+      $route: { query: {} },
       $t: () => {},
       $store: {
         state: {
@@ -144,6 +145,19 @@ describe('components/item/ItemPreviewCardGroup', () => {
 
           expect(wrapper.vm.cardGroupClass).toMatch('card-group-list');
         });
+      });
+    });
+
+    describe('routeQuery', () => {
+      it('includes adv search fulltext contains terms from route', () => {
+        const query = 'hamburger';
+        const qa = ['fulltext:(theater)', 'fulltext:(zeitung)', 'NOT fulltext:(direktor)', 'when:1901'];
+        const mocks = { $route: { query: { qa, query } } };
+        const wrapper = factory({ propsData: { item }, mocks });
+
+        const routeQuery = wrapper.vm.routeQuery;
+
+        expect(routeQuery).toBe('theater zeitung');
       });
     });
   });

--- a/packages/portal/tests/unit/components/media/MediaAnnotationList.spec.js
+++ b/packages/portal/tests/unit/components/media/MediaAnnotationList.spec.js
@@ -13,7 +13,7 @@ const annotations = [
 ];
 const fetchCanvasAnnotationsSpy = sinon.spy();
 const searchAnnotationsSpy = sinon.spy();
-const selectAnnotationSpy = sinon.spy();
+const setActiveAnnotationSpy = sinon.spy();
 const routerReplaceSpy = sinon.spy();
 
 const factory = ({ data, propsData, mocks } = {}) => shallowMountNuxt(MediaAnnotationList, {
@@ -23,6 +23,9 @@ const factory = ({ data, propsData, mocks } = {}) => shallowMountNuxt(MediaAnnot
     };
   },
   propsData,
+  provide: {
+    annotationScrollToContainerSelector: '#list-container'
+  },
   mocks: {
     $fetchState: {},
     $route: {
@@ -42,7 +45,7 @@ const stubItemMediaPresentationComposable = (stubs = {}) => {
     annotations,
     fetchCanvasAnnotations: fetchCanvasAnnotationsSpy,
     searchAnnotations: searchAnnotationsSpy,
-    selectAnnotation: selectAnnotationSpy,
+    setActiveAnnotation: setActiveAnnotationSpy,
     ...stubs
   });
 };
@@ -71,14 +74,14 @@ describe('components/media/MediaAnnotationList', () => {
     });
 
     describe('when annotation is clicked', () => {
-      it('calls selectAnnotation on itemMediaPresentation composable', async() => {
+      it('calls setActiveAnnotation on itemMediaPresentation composable', async() => {
         stubItemMediaPresentationComposable();
         const wrapper = factory();
 
         const listItem = wrapper.find('b-list-group-item-stub');
         await listItem.vm.$emit('click');
 
-        expect(selectAnnotationSpy.calledWith(annotations[0])).toBe(true);
+        expect(setActiveAnnotationSpy.calledWith(annotations[0])).toBe(true);
       });
 
       it('replaces route', async() => {
@@ -121,14 +124,14 @@ describe('components/media/MediaAnnotationList', () => {
     });
 
     describe('when there is an annotation in the route query', () => {
-      it('calls selectAnnotation on itemMediaPresentation composable', async() => {
+      it('calls setActiveAnnotation on itemMediaPresentation composable', async() => {
         stubItemMediaPresentationComposable();
         const $route = { query: { anno: 'anno1' } };
         const wrapper = factory({ mocks: { $route } });
 
         await wrapper.vm.fetch();
 
-        expect(selectAnnotationSpy.calledWith('anno1')).toBe(true);
+        expect(setActiveAnnotationSpy.calledWith(annotations[0])).toBe(true);
       });
     });
   });

--- a/packages/portal/tests/unit/components/media/MediaAnnotationList.spec.js
+++ b/packages/portal/tests/unit/components/media/MediaAnnotationList.spec.js
@@ -11,8 +11,9 @@ const annotations = [
   { body: { value: 'anno 1' }, id: 'anno1' },
   { body: { value: 'anno 2' }, id: 'anno2' }
 ];
-const fetchCanvasAnnotationsStub = sinon.stub();
-const selectAnnotationStub = sinon.stub();
+const fetchCanvasAnnotationsSpy = sinon.spy();
+const searchAnnotationsSpy = sinon.spy();
+const selectAnnotationSpy = sinon.spy();
 const routerPushSpy = sinon.spy();
 
 const factory = ({ data, propsData, mocks } = {}) => shallowMountNuxt(MediaAnnotationList, {
@@ -39,8 +40,9 @@ const factory = ({ data, propsData, mocks } = {}) => shallowMountNuxt(MediaAnnot
 const stubItemMediaPresentationComposable = (stubs = {}) => {
   sinon.stub(itemMediaPresentation, 'default').returns({
     annotations,
-    fetchCanvasAnnotations: fetchCanvasAnnotationsStub,
-    selectAnnotation: selectAnnotationStub,
+    fetchCanvasAnnotations: fetchCanvasAnnotationsSpy,
+    searchAnnotations: searchAnnotationsSpy,
+    selectAnnotation: selectAnnotationSpy,
     ...stubs
   });
 };
@@ -75,18 +77,32 @@ describe('components/media/MediaAnnotationList', () => {
       const listItem = wrapper.find('b-list-group-item-stub');
       await listItem.vm.$emit('click');
 
-      expect(selectAnnotationStub.calledWith(annotations[0])).toBe(true);
+      expect(selectAnnotationSpy.calledWith(annotations[0])).toBe(true);
     });
   });
 
   describe('fetch', () => {
-    it('fetches annotation list via itemMediaPresentation composable', async() => {
-      stubItemMediaPresentationComposable();
-      const wrapper = factory();
+    describe('without a query', () => {
+      it('fetches canvas annotations via itemMediaPresentation composable', async() => {
+        stubItemMediaPresentationComposable();
+        const wrapper = factory();
 
-      await wrapper.vm.fetch();
+        await wrapper.vm.fetch();
 
-      expect(fetchCanvasAnnotationsStub.called).toBe(true);
+        expect(fetchCanvasAnnotationsSpy.called).toBe(true);
+      });
+    });
+
+    describe('with a query', () => {
+      it('searches for annotations via itemMediaPresentation composable', async() => {
+        stubItemMediaPresentationComposable();
+        const query = 'something';
+        const wrapper = factory({ propsData: { query } });
+
+        await wrapper.vm.fetch();
+
+        expect(searchAnnotationsSpy.calledWith(query)).toBe(true);
+      });
     });
   });
 });

--- a/packages/portal/tests/unit/components/media/MediaAnnotationList.spec.js
+++ b/packages/portal/tests/unit/components/media/MediaAnnotationList.spec.js
@@ -14,7 +14,7 @@ const annotations = [
 const fetchCanvasAnnotationsSpy = sinon.spy();
 const searchAnnotationsSpy = sinon.spy();
 const selectAnnotationSpy = sinon.spy();
-const routerPushSpy = sinon.spy();
+const routerReplaceSpy = sinon.spy();
 
 const factory = ({ data, propsData, mocks } = {}) => shallowMountNuxt(MediaAnnotationList, {
   data() {
@@ -29,7 +29,7 @@ const factory = ({ data, propsData, mocks } = {}) => shallowMountNuxt(MediaAnnot
       query: {}
     },
     $router: {
-      push: routerPushSpy
+      replace: routerReplaceSpy
     },
     ...mocks
   },
@@ -101,7 +101,7 @@ describe('components/media/MediaAnnotationList', () => {
 
         await wrapper.vm.fetch();
 
-        expect(searchAnnotationsSpy.calledWith(query)).toBe(true);
+        expect(searchAnnotationsSpy.calledWith('"something"')).toBe(true);
       });
     });
   });

--- a/packages/portal/tests/unit/components/media/MediaAnnotationList.spec.js
+++ b/packages/portal/tests/unit/components/media/MediaAnnotationList.spec.js
@@ -70,14 +70,29 @@ describe('components/media/MediaAnnotationList', () => {
       expect(listItems.at(1).attributes('active')).toBe('true');
     });
 
-    it('calls selectAnnotation on itemMediaPresentation composable when annotation is clicked', async() => {
-      stubItemMediaPresentationComposable();
-      const wrapper = factory();
+    describe('when annotation is clicked', () => {
+      it('calls selectAnnotation on itemMediaPresentation composable', async() => {
+        stubItemMediaPresentationComposable();
+        const wrapper = factory();
 
-      const listItem = wrapper.find('b-list-group-item-stub');
-      await listItem.vm.$emit('click');
+        const listItem = wrapper.find('b-list-group-item-stub');
+        await listItem.vm.$emit('click');
 
-      expect(selectAnnotationSpy.calledWith(annotations[0])).toBe(true);
+        expect(selectAnnotationSpy.calledWith(annotations[0])).toBe(true);
+      });
+
+      it('replaces route', async() => {
+        stubItemMediaPresentationComposable({
+          activeAnnotation: { id: 'anno2' },
+          pageForAnnotationTarget: () => 2
+        });
+        const wrapper = factory();
+
+        const listItem = wrapper.find('b-list-group-item-stub');
+        await listItem.vm.$emit('click');
+
+        expect(routerReplaceSpy.calledWith({ query: { anno: 'anno2', page: 2 } })).toBe(true);
+      });
     });
   });
 
@@ -102,6 +117,18 @@ describe('components/media/MediaAnnotationList', () => {
         await wrapper.vm.fetch();
 
         expect(searchAnnotationsSpy.calledWith('"something"')).toBe(true);
+      });
+    });
+
+    describe('when there is an annotation in the route query', () => {
+      it('calls selectAnnotation on itemMediaPresentation composable', async() => {
+        stubItemMediaPresentationComposable();
+        const $route = { query: { anno: 'anno1' } };
+        const wrapper = factory({ mocks: { $route } });
+
+        await wrapper.vm.fetch();
+
+        expect(selectAnnotationSpy.calledWith('anno1')).toBe(true);
       });
     });
   });

--- a/packages/portal/tests/unit/components/media/MediaAnnotationSearch.spec.js
+++ b/packages/portal/tests/unit/components/media/MediaAnnotationSearch.spec.js
@@ -5,7 +5,7 @@ import MediaAnnotationSearch from '@/components/media/MediaAnnotationSearch.vue'
 
 const localVue = createLocalVue();
 const routerPushSpy = sinon.spy();
-const query = 'something';
+const fulltext = 'something';
 
 const factory = ({ data, propsData, mocks } = {}) => shallowMount(MediaAnnotationSearch, {
   data() {
@@ -16,7 +16,7 @@ const factory = ({ data, propsData, mocks } = {}) => shallowMount(MediaAnnotatio
   propsData,
   mocks: {
     $route: {
-      query: { query }
+      query: { fulltext }
     },
     $router: {
       push: routerPushSpy
@@ -45,7 +45,7 @@ describe('components/media/MediaAnnotationSearch', () => {
 
       const input = wrapper.find('#media-annotation-search-query');
 
-      expect(input.attributes('value')).toBe(query);
+      expect(input.attributes('value')).toBe(fulltext);
     });
 
     it('renders MediaAnnotationList to run the search', () => {
@@ -54,7 +54,7 @@ describe('components/media/MediaAnnotationSearch', () => {
       const list = wrapper.find('MediaAnnotationList-stub');
 
       expect(list.isVisible()).toBe(true);
-      expect(list.attributes('query')).toBe(query);
+      expect(list.attributes('query')).toBe(fulltext);
     });
 
     // FIXME: submit.prevent trigger isn't working here (but does when rendered)

--- a/packages/portal/tests/unit/components/media/MediaAnnotationSearch.spec.js
+++ b/packages/portal/tests/unit/components/media/MediaAnnotationSearch.spec.js
@@ -1,0 +1,70 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import sinon from 'sinon';
+
+import MediaAnnotationSearch from '@/components/media/MediaAnnotationSearch.vue';
+
+const localVue = createLocalVue();
+const routerPushSpy = sinon.spy();
+const query = 'something';
+
+const factory = ({ data, propsData, mocks } = {}) => shallowMount(MediaAnnotationSearch, {
+  data() {
+    return {
+      ...data
+    };
+  },
+  propsData,
+  mocks: {
+    $route: {
+      query: { query }
+    },
+    $router: {
+      push: routerPushSpy
+    },
+    ...mocks
+  },
+  localVue,
+  stubs: ['b-form', 'b-form-group', 'b-form-input', 'MediaAnnotationList']
+});
+
+describe('components/media/MediaAnnotationSearch', () => {
+  afterEach(sinon.resetBehavior);
+  afterAll(sinon.restore);
+
+  describe('template', () => {
+    it('renders a form input for the query', () => {
+      const wrapper = factory();
+
+      const input = wrapper.find('#media-annotation-search-query');
+
+      expect(input.isVisible()).toBe(true);
+    });
+
+    it('initialises the form input value from the route query', () => {
+      const wrapper = factory();
+
+      const input = wrapper.find('#media-annotation-search-query');
+
+      expect(input.attributes('value')).toBe(query);
+    });
+
+    it('renders MediaAnnotationList to run the search', () => {
+      const wrapper = factory();
+
+      const list = wrapper.find('MediaAnnotationList-stub');
+
+      expect(list.isVisible()).toBe(true);
+      expect(list.attributes('query')).toBe(query);
+    });
+
+    // FIXME: submit.prevent trigger isn't working here (but does when rendered)
+    // it('updates the route when the form is submitted', async() => {
+    //   const wrapper = factory({ data: { query } });
+    //
+    //   wrapper.find('#media-annotation-search-form').trigger('submit.prevent');
+    //   await wrapper.vm.$nextTick();
+    //
+    //   expect(routerPushSpy.calledWith({ query: { query } })).toBe(true);
+    // });
+  });
+});

--- a/packages/portal/tests/unit/composables/activeTab.spec.js
+++ b/packages/portal/tests/unit/composables/activeTab.spec.js
@@ -1,0 +1,87 @@
+import sinon from 'sinon';
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import * as vueRouter from 'vue2-helpers/vue-router';
+import { reactive } from 'vue';
+
+import useActiveTab from '@/composables/activeTab.js';
+
+const routerPushSpy = sinon.spy();
+
+const route = reactive({ hash: '#links' });
+sinon.stub(vueRouter, 'useRoute').returns(route);
+sinon.stub(vueRouter, 'useRouter').returns({
+  push: routerPushSpy
+});
+
+const tabHashes = ['#annotations', '#search', '#links'];
+
+const component = {
+  template: `
+    <div>
+      <span id="activeTabHash">{{ activeTabHash }}</span>
+      <input id="activeTabIndex" v-model="activeTabIndex" />
+    </div>
+  `,
+  setup() {
+    const { activeTabHash, activeTabIndex } = useActiveTab(tabHashes);
+
+    return { activeTabHash, activeTabIndex };
+  }
+};
+
+const localVue = createLocalVue();
+
+const factory = () => shallowMount(component, {
+  propsData: {},
+  mocks: {},
+  localVue
+});
+
+describe('useActiveTab', () => {
+  beforeEach(() => {
+    route.hash = '#links';
+  });
+  afterEach(sinon.resetHistory);
+  afterAll(sinon.restore);
+
+  describe('activeTabHash', () => {
+    it('is computed from activeTabIndex', async() => {
+      const wrapper = factory();
+
+      wrapper.find('#activeTabIndex').setValue(1);
+      await wrapper.vm.$nextTick();
+
+      const span = wrapper.find('#activeTabHash');
+      expect(span.text()).toBe('#search');
+    });
+  });
+
+  describe('activeTabIndex', () => {
+    it('is initialised from route hash', () => {
+      const wrapper = factory();
+
+      const input = wrapper.find('#activeTabIndex');
+
+      expect(input.element.value).toBe('2');
+    });
+
+    it('is watched for changes to update route', async() => {
+      const wrapper = factory();
+
+      wrapper.find('#activeTabIndex').setValue(1);
+      await wrapper.vm.$nextTick();
+
+      expect(routerPushSpy.calledWith({ hash: '#search' })).toBe(true);
+    });
+
+    it('is updated on route changes', async() => {
+      const wrapper = factory();
+
+      route.hash = '#annotations';
+      await wrapper.vm.$nextTick();
+
+      const input = wrapper.find('#activeTabIndex');
+      expect(input.element.value).toBe('0');
+    });
+  });
+});

--- a/packages/portal/tests/unit/composables/itemMediaPresentation.spec.js
+++ b/packages/portal/tests/unit/composables/itemMediaPresentation.spec.js
@@ -96,26 +96,26 @@ describe('useItemMediaPresentation', () => {
     nock.enableNetConnect();
   });
 
-  describe('fetchAnnotations', () => {
+  describe('fetchCanvasAnnotations', () => {
     beforeEach(() => {
       nock(origin).get(listPath).query({ textGranularity }).reply(200, listResponseData);
       nock(origin).get(bodyPath).reply(200, bodyResponseData);
     });
 
     it('fetches annotation list w/ text granularity and embeds bodies', async() => {
-      const { presentation, fetchAnnotations } = useItemMediaPresentation();
+      const { presentation, fetchCanvasAnnotations } = useItemMediaPresentation();
       presentation.value = presentationValue;
 
-      await fetchAnnotations(listUri);
+      await fetchCanvasAnnotations(listUri);
 
       expect(nock.isDone()).toBe(true);
     });
 
     it('stores relevant annotations', async() => {
-      const { annotations, presentation, fetchAnnotations } = useItemMediaPresentation();
+      const { annotations, presentation, fetchCanvasAnnotations } = useItemMediaPresentation();
       presentation.value = presentationValue;
 
-      await fetchAnnotations(listUri);
+      await fetchCanvasAnnotations(listUri);
 
       expect(annotations.value).toEqual([
         {

--- a/packages/portal/tests/unit/composables/itemMediaPresentation.spec.js
+++ b/packages/portal/tests/unit/composables/itemMediaPresentation.spec.js
@@ -190,4 +190,15 @@ describe('useItemMediaPresentation', () => {
       });
     });
   });
+
+  describe('pageForAnnotationTarget', () => {
+    it('finds the page/canvas number for an annotation target', () => {
+      const { pageForAnnotationTarget, presentation } = useItemMediaPresentation();
+      presentation.value = presentationValue;
+
+      const page = pageForAnnotationTarget(canvasId);
+
+      expect(page).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
Composables:
* update `itemMediaPresentation`:
  * add support for searching annotations via the IIIF Search API service on the Presentation manifest, and storing results and hits in new refs
  * add a new ref for the active annotation
* create `activeTab`:
  * helper for when using Bootstrap Vue tab to pre-select the active tab based on the hash in the route, and to update the route hash when the active tab changes
    * keeps a history of the active tabs, to aid in not re-fetching data after it's been cached once but the tab becomes inactive

Components:
* update `ItemHero`:
  * stop computing the full text query and prop-drilling it down from here
* update `ItemMediaPresentation`:
  * stop handling annotation updates, which annotation components should do directly via `useItemMediaPresentation` composable
  * `provide` the HTML ID of the sidebar container for descendent components to `inject`
* update `ItemPreviewCard`:
  * add props to set route query and hash on item links
* update `ItemPreviewCardGroup`:
  * compute the full text query (from a search) and pass to `ItemPreviewCard`, plus default to the annotation search tab via the hash if one is present
* update `ItemMediaSidebar`:
  * new tab for annotation search
  * tab selection based on route hash, via `activeTab` composable
  * lazy-load the annotation list and search tabs
  * pass down to the annotation list and search tabs whether they are active, so that reactive annotation fetching/searching only occurs when the tab is active
* update `MediaAnnotationList`:
  * update active annotation directly via `useItemMediaPresentation` composable, not by emitting it
  * when active annotation changes, update the route for the relevant page and the annotation ID itself
  * on load, if there is an annotation ID in the route query, make that the active annotation
  * add a `query` prop which takes a search term, and if present searches annotations rather than fetching those for the current page/canvas
  * when searching, display hit highlights
* create `MediaAnnotationSearch`:
  * renders a form with a text input field for entering a search query
  * when the form is submitted, search the IIIF Search API service by rendering as a child component `MediaAnnotationList` with the search query passed to it

Utils:
* create `SearchHit` to model a [IIIF Search API hit](https://iiif.io/api/search/1.0/#search-api-specific-responses)
* update `AnnotationList` to include hits