### PR TITLE
feat: lazy load thumbnail list elements using IntersectionObserver

### DIFF
--- a/packages/portal/src/components/item/ItemMediaThumbnails.vue
+++ b/packages/portal/src/components/item/ItemMediaThumbnails.vue
@@ -27,8 +27,9 @@
         <li
           v-for="(resource, index) in resourcesToRender"
           :key="resource.about"
+          :aria-setsize="resources.length"
+          :aria-posinset="firstRenderedResourceIndex + index + 1"
         >
-          <!-- TODO: calc offset/page separately -->
           <ItemMediaThumbnail
             :offset="firstRenderedResourceIndex + index"
             class="d-flex-inline mr-3 mr-lg-auto"
@@ -37,8 +38,6 @@
             :edm-type="edmType"
           />
         </li>
-
-        <!-- TODO: calc condition and height separately -->
         <li
           v-if="lastRenderedResourceIndex + 1 !== resources.length"
           ref="thumbnailSkeletonAfter"

--- a/packages/portal/src/components/item/ItemMediaThumbnails.vue
+++ b/packages/portal/src/components/item/ItemMediaThumbnails.vue
@@ -77,8 +77,8 @@
 
     setup() {
       const { page, resources } = useItemMediaPresentation();
-      const { scrollElementToCentre, scrollToElement, scrolling: scrollToScrolling } = useScrollTo();
-      return {  page, resources, scrollElementToCentre, scrollToElement, scrollToScrolling };
+      const { scrollElementToCentre } = useScrollTo();
+      return {  page, resources, scrollElementToCentre };
     },
 
     data() {
@@ -138,7 +138,7 @@
     },
 
     methods: {
-      async handleWindowResize() {
+      handleWindowResize() {
         this.updateThumbnailScroll();
       },
 

--- a/packages/portal/src/components/item/ItemMediaThumbnails.vue
+++ b/packages/portal/src/components/item/ItemMediaThumbnails.vue
@@ -218,9 +218,10 @@
           return;
         }
         const skeletonWidth = skeletonResources.reduce((accumulatedWidth, resource) => {
+          const cssHeight = window.innerWidth < 768 ? 58 : 124; // CSS height bp-small 3.625rem, bp-medium 7.75rem
           let imageWidth;
           if (resource.ebucoreHeight && resource.ebucoreWidth) {
-            imageWidth = (resource.ebucoreWidth / resource.ebucoreHeight) * 58; // CSS height 3.625rem
+            imageWidth = (resource.ebucoreWidth / resource.ebucoreHeight) * cssHeight;
           } else {
             imageWidth = 48; // CSS min-width 3rem
           }

--- a/packages/portal/src/components/item/ItemMediaThumbnails.vue
+++ b/packages/portal/src/components/item/ItemMediaThumbnails.vue
@@ -37,6 +37,7 @@
             :class="{ 'selected': index === selectedIndex }"
             :resource="resource"
             :edm-type="edmType"
+            :lazy="true"
           />
         </li>
         <li
@@ -59,7 +60,7 @@
   import useScrollTo from '@/composables/scrollTo.js';
   import ItemMediaThumbnail from './ItemMediaThumbnail.vue';
 
-  const perPage = 10;
+  const perPage = 5;
 
   export default {
     name: 'ItemMediaThumbnails',
@@ -83,7 +84,7 @@
 
     data() {
       return {
-        resourcesToRender: !!this.resources && (this.page <= perPage ? this.resources.slice(0, perPage * 2) :
+        resourcesToRender: !!this.resources && (this.page <= perPage ? this.resources.slice(0, perPage) :
           this.resources.slice(Math.max(this.page - perPage, 0), Math.min(this.page + perPage, this.resources.length))),
         skeletonObserver: null
       };
@@ -181,7 +182,8 @@
               }
             });
           },
-          { root: this.$refs.mediaThumbnailsContainer });
+          { root: this.$refs.mediaThumbnailsContainer }
+        );
 
         const thumbnailSkeletonBefore = this.$refs.thumbnailSkeletonBefore;
         const thumbnailSkeletonAfter = this.$refs.thumbnailSkeletonAfter;

--- a/packages/portal/src/components/item/ItemMediaThumbnails.vue
+++ b/packages/portal/src/components/item/ItemMediaThumbnails.vue
@@ -15,7 +15,10 @@
           v-if="firstRenderedResourceIndex > 0"
           ref="thumbnailSkeletonBefore"
           class="thumbnail-skeleton-before"
-          :style="{ '--itemsbefore': firstRenderedResourceIndex + 1 }"
+          :style="{
+            '--skeletonheightbefore': calculateSkeletonHeight(resources.slice(0, firstRenderedResourceIndex)),
+            '--skeletonwidthbefore': calculateSkeletonWidth(resources.slice(0, firstRenderedResourceIndex))
+          }"
         />
 
         <!-- The ref array does not guarantee the same order as the source array. This causes issues when prepending resources.
@@ -40,7 +43,10 @@
           v-if="lastRenderedResourceIndex + 1 !== resources.length"
           ref="thumbnailSkeletonAfter"
           class="thumbnail-skeleton-after"
-          :style="{ '--itemsafter': (resources.length - (lastRenderedResourceIndex + 1 ))}"
+          :style="{
+            '--skeletonheightafter': calculateSkeletonHeight(resources.slice(lastRenderedResourceIndex, resources.length - 1)),
+            '--skeletonwidthafter': calculateSkeletonWidth(resources.slice(lastRenderedResourceIndex, resources.length - 1))
+          }"
         />
       </ol>
     </div>
@@ -177,6 +183,42 @@
             container: this.$refs.mediaThumbnailsContainer
           }
         );
+      },
+
+      calculateSkeletonHeight(skeletonResources) {
+        if (!skeletonResources.length) {
+          return;
+        }
+        const skeletonHeight = skeletonResources.reduce((accumulatedHeight, resource) => {
+          let imageHeight;
+          if (resource.ebucoreHeight && resource.ebucoreWidth) {
+            imageHeight = (resource.ebucoreHeight / resource.ebucoreWidth) * 176; // CSS width 11rem
+          } else {
+            imageHeight = 80; // CSS min-height 5rem
+          }
+          const renderedHeight = imageHeight < 480 ? imageHeight : 480;
+          return accumulatedHeight + renderedHeight + 16; // add 16px margin
+        }, 0);
+
+        return `${skeletonHeight}px`;
+      },
+
+      calculateSkeletonWidth(skeletonResources) {
+        if (!skeletonResources.length) {
+          return;
+        }
+        const skeletonWidth = skeletonResources.reduce((accumulatedWidth, resource) => {
+          let imageWidth;
+          if (resource.ebucoreHeight && resource.ebucoreWidth) {
+            imageWidth = (resource.ebucoreWidth / resource.ebucoreHeight) * 58; // CSS height 3.625rem
+          } else {
+            imageWidth = 48; // CSS min-width 3rem
+          }
+          const renderedWidth = imageWidth < 200 ? imageWidth : 200;
+          return accumulatedWidth + renderedWidth + 16; // add 16px margin
+        }, 0);
+
+        return `${skeletonWidth}px`;
       }
     }
   };
@@ -198,19 +240,20 @@
     scrollbar-width: thin;
 
     .thumbnail-skeleton-before {
-      width: calc(var(--itemsbefore) * 30px);
+      width: var(--skeletonwidthbefore);
 
       @media (min-width: $bp-large) {
         width: auto;
-        height: calc(var(--itemsbefore) * 80px);
+        height: var(--skeletonheightbefore);
       }
     }
 
     .thumbnail-skeleton-after {
-      width: calc(var(--itemsafter) * 30px);
+      width: var(--skeletonwidthafter);
 
       @media (min-width: $bp-large) {
-        height: calc(var(--itemsafter) * 80px);
+        width: auto;
+        height: var(--skeletonheightafter);
       }
     }
 

--- a/packages/portal/tests/unit/components/item/ItemMediaThumbnails.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemMediaThumbnails.spec.js
@@ -95,4 +95,173 @@ describe('components/item/ItemMediaThumbnail', () => {
       expect(removeEventListener.called).toBe(true);
     });
   });
+
+  describe('when there are more than 20 pages', () => {
+    afterEach(() => {
+      itemMediaPresentation.default.restore();
+    });
+    const manyResources = Array.from({ length: 100 }, (element, index) => {
+      return { about: `https://resource.eu/${index}` };
+    });
+    describe('and on page 1', () => {
+      it('appends a skeleton list item to the list', () => {
+        sinon.stub(itemMediaPresentation, 'default').returns({
+          page: 1,
+          resources: manyResources
+        });
+        const wrapper = factory();
+
+        const skeletonAfter = wrapper.find('[data-qa="item media thumbnail skeleton after"]');
+
+        expect(skeletonAfter.exists()).toBe(true);
+      });
+
+      describe('when intersecting the skeleton after', () => {
+        it('appends items', () => {
+          sinon.stub(itemMediaPresentation, 'default').returns({
+            page: 1,
+            resources: manyResources
+          });
+          window.IntersectionObserver = class {
+            constructor(callback) {
+              this.callback = callback;
+            }
+            observe() {}
+            unobserve() {}
+          };
+          window.IntersectionObserverEntry = class {};
+
+          const wrapper = factory();
+
+          expect(wrapper.vm.skeletonObserver).toBeInstanceOf(IntersectionObserver);
+          expect(wrapper.vm.resourcesToRender.length).toBe(20);
+
+          // Simulate the intersection
+          const entries = [{ intersectionRatio: 0.5,
+            target: wrapper.vm.$refs.thumbnailSkeletonAfter }];
+          wrapper.vm.skeletonObserver.callback(entries);
+
+          expect(wrapper.vm.resourcesToRender.length).toBe(30);
+        });
+      });
+    });
+
+    describe('and on page 11 or more', () => {
+      it('prepends a skeleton list item to the list', () => {
+        sinon.stub(itemMediaPresentation, 'default').returns({
+          page: 11,
+          resources: manyResources
+        });
+        const wrapper = factory();
+
+        const skeletonBefore = wrapper.find('[data-qa="item media thumbnail skeleton before"]');
+
+        expect(skeletonBefore.exists()).toBe(true);
+      });
+
+      describe('when intersecting the skeleton before', () => {
+        it('prepends items', () => {
+          sinon.stub(itemMediaPresentation, 'default').returns({
+            page: 30,
+            resources: manyResources
+          });
+          window.IntersectionObserver = class {
+            constructor(callback) {
+              this.callback = callback;
+            }
+            observe() {}
+            unobserve() {}
+          };
+          window.IntersectionObserverEntry = class {};
+
+          const wrapper = factory();
+
+          expect(wrapper.vm.skeletonObserver).toBeInstanceOf(IntersectionObserver);
+          expect(wrapper.vm.resourcesToRender.length).toBe(20);
+
+          // Simulate the intersection
+          const entries = [{ isIntersecting: true, target: wrapper.vm.$refs.thumbnailSkeletonBefore }];
+          wrapper.vm.skeletonObserver.callback(entries);
+
+          expect(wrapper.vm.resourcesToRender.length).toBe(30);
+        });
+      });
+    });
+  });
+
+  describe('methods', () => {
+    describe('calculateSkeletonHeight', () => {
+      it('calculates height based on ebucoreHeight and margin', () => {
+        const resources = [
+          { ebucoreHeight: 100, ebucoreWidth: 176 },
+          { ebucoreHeight: 200, ebucoreWidth: 176 }
+        ];
+        const wrapper = factory();
+
+        const result = wrapper.vm.calculateSkeletonHeight(resources);
+        expect(result).toBe('332px'); // 100 + 200 + 16 + 16
+      });
+
+      it('defaults to min-height when dimensions are not provided', () => {
+        const resources = [{}, {}];
+        const wrapper = factory();
+
+        const result = wrapper.vm.calculateSkeletonHeight(resources);
+        expect(result).toBe('192px'); // 80 + 80 + 16 + 16
+      });
+
+      it('limits height at CSS max-height 480px', () => {
+        const resources = [
+          { ebucoreHeight: 1000, ebucoreWidth: 176 }
+        ];
+        const wrapper = factory();
+
+        const result = wrapper.vm.calculateSkeletonHeight(resources);
+        expect(result).toBe('496px'); // 480 + 16
+      });
+    });
+
+    describe('calculateSkeletonWidth', () => {
+      it('calculates width based on ebucoreWidth and CSS height', () => {
+        const resources = [
+          { ebucoreHeight: 124, ebucoreWidth: 124 }
+        ];
+        const wrapper = factory();
+
+        const result = wrapper.vm.calculateSkeletonWidth(resources);
+        expect(result).toBe('140px'); // (124/124)*124 + 16
+      });
+
+      it('defaults to min-width when dimensions are not provided', () => {
+        const resources = [{}];
+        const wrapper = factory();
+
+        const result = wrapper.vm.calculateSkeletonWidth(resources);
+        expect(result).toBe('64px'); // 48 + 16
+      });
+
+      it('limits width to 200px', () => {
+        const resources = [
+          { ebucoreHeight: 124, ebucoreWidth: 2480 }
+        ];
+        const wrapper = factory();
+
+        const result = wrapper.vm.calculateSkeletonWidth(resources);
+        expect(result).toBe('216px'); // 200 + 16
+      });
+
+      describe('when viewport width small', () => {
+        it('calculates width based on ebucoreWidth and CSS height', () => {
+          window.innerWidth = 600;
+          const resources = [
+            { ebucoreHeight: 58, ebucoreWidth: 58 }
+          ];
+          const wrapper = factory();
+
+          const result = wrapper.vm.calculateSkeletonWidth(resources);
+          expect(result).toBe('74px'); // (58/58)*58 + 16
+        });
+      });
+    });
+  });
 });

--- a/packages/portal/tests/unit/components/item/ItemMediaThumbnails.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemMediaThumbnails.spec.js
@@ -134,14 +134,14 @@ describe('components/item/ItemMediaThumbnail', () => {
           const wrapper = factory();
 
           expect(wrapper.vm.skeletonObserver).toBeInstanceOf(IntersectionObserver);
-          expect(wrapper.vm.resourcesToRender.length).toBe(20);
+          expect(wrapper.vm.resourcesToRender.length).toBe(5);
 
           // Simulate the intersection
           const entries = [{ intersectionRatio: 0.5,
             target: wrapper.vm.$refs.thumbnailSkeletonAfter }];
           wrapper.vm.skeletonObserver.callback(entries);
 
-          expect(wrapper.vm.resourcesToRender.length).toBe(30);
+          expect(wrapper.vm.resourcesToRender.length).toBe(10);
         });
       });
     });
@@ -177,13 +177,13 @@ describe('components/item/ItemMediaThumbnail', () => {
           const wrapper = factory();
 
           expect(wrapper.vm.skeletonObserver).toBeInstanceOf(IntersectionObserver);
-          expect(wrapper.vm.resourcesToRender.length).toBe(20);
+          expect(wrapper.vm.resourcesToRender.length).toBe(10);
 
           // Simulate the intersection
           const entries = [{ isIntersecting: true, target: wrapper.vm.$refs.thumbnailSkeletonBefore }];
           wrapper.vm.skeletonObserver.callback(entries);
 
-          expect(wrapper.vm.resourcesToRender.length).toBe(30);
+          expect(wrapper.vm.resourcesToRender.length).toBe(15);
         });
       });
     });


### PR DESCRIPTION
- Introduces lazy loading / infinite scrolling of the item media thumnbnails
  - Renders max 5 thumbnails on initial load
  - When there are more it prepends or appends an extra `li` as skeleton for the non-rendered thumbnails
  - observes when the skeleton is intersected to load more (`perPage`, set to 5) thumbnails, using the IntersectionObserver API