### PR TITLE
refactor: add resource and service media classes

### DIFF
--- a/packages/portal/src/components/item/ItemMediaPresentation.vue
+++ b/packages/portal/src/components/item/ItemMediaPresentation.vue
@@ -21,35 +21,35 @@
           />
           <MediaImageViewer
             v-if="imageTypeResource"
-            :url="resource.about"
+            :url="resource.id"
             :item-id="itemId"
-            :width="resource.ebucoreWidth"
-            :height="resource.ebucoreHeight"
-            :format="resource.ebucoreHasMimeType"
-            :service="resource.svcsHasService"
+            :width="resource.width"
+            :height="resource.height"
+            :format="resource.format"
+            :service="resource.service"
             :annotation="activeAnnotation"
           />
           <MediaPDFViewer
-            v-else-if="resource?.ebucoreHasMimeType === 'application/pdf'"
-            :url="resource.about"
+            v-else-if="resource?.format === 'application/pdf'"
+            :url="resource.id"
             :item-id="itemId"
           />
           <MediaAudioVisualPlayer
-            v-else-if="resource?.isPlayableMedia"
-            :url="resource.about"
-            :format="resource.ebucoreHasMimeType"
+            v-else-if="resource?.edm.isPlayableMedia"
+            :url="resource.id"
+            :format="resource.format"
             :item-id="itemId"
           />
           <EmbedOEmbed
-            v-else-if="resource?.isOEmbed"
-            :url="resource.about"
+            v-else-if="resource?.edm.isOEmbed"
+            :url="resource.id"
           />
           <code
             v-else
             class="h-50 w-100 p-5"
           >
             <pre
-              :style="{ color: 'white' }"
+              :style="{ color: 'white', 'overflow-wrap': 'break-word' }"
             ><!--
               -->{{ JSON.stringify(resource, null, 2) }}
             </pre>
@@ -128,8 +128,8 @@
 </template>
 
 <script>
-  import hideTooltips from '@/mixins/hideTooltips';
   import useItemMediaPresentation from '@/composables/itemMediaPresentation.js';
+  import hideTooltips from '@/mixins/hideTooltips';
 
   export default {
     name: 'ItemMediaPresentation',
@@ -239,7 +239,7 @@
       },
 
       imageTypeResource() {
-        return this.resource?.ebucoreHasMimeType?.startsWith('image/');
+        return this.resource?.format?.startsWith('image/');
       }
     },
 

--- a/packages/portal/src/components/media/MediaCardImage.vue
+++ b/packages/portal/src/components/media/MediaCardImage.vue
@@ -4,7 +4,7 @@
     class="media-card-image"
   >
     <b-link
-      v-if="linkable && imageLink && thumbnails.large && !media.forEdmIsShownAt"
+      v-if="linkable && imageLink && thumbnails.large && !webResource.forEdmIsShownAt"
       :href="imageLink"
       target="_blank"
     >
@@ -54,7 +54,8 @@
 </template>
 
 <script>
-  import WebResource from '@/plugins/europeana/edm/WebResource';
+  import EuropeanaMediaResource from '@/utils/europeana/media/Resource.js';
+  import WebResource from '@/plugins/europeana/edm/WebResource.js';
 
   export default {
     name: 'MediaCardImage',
@@ -65,7 +66,9 @@
 
     props: {
       media: {
-        type: WebResource,
+        // TODO: refactor to only receive EuropeanaMediaResource, once legacy
+        //       media presentation is gone
+        type: [EuropeanaMediaResource, WebResource],
         default: null
       },
       lazy: {
@@ -96,38 +99,39 @@
 
     data() {
       return {
+        webResource: (this.media instanceof WebResource) ? this.media : this.media.edm,
         showDefaultThumbnail: false
       };
     },
 
     computed: {
       imageLink() {
-        return this.$apis.record.mediaProxyUrl(this.media.about, this.europeanaIdentifier, { disposition: 'inline' });
+        return this.$apis.record.mediaProxyUrl(this.webResource.about, this.europeanaIdentifier, { disposition: 'inline' });
       },
       thumbnails() {
-        return this.media.thumbnails(this.$nuxt.context);
+        return this.webResource.thumbnails(this.$nuxt.context);
       },
       thumbnailSrc() {
         return this.thumbnails[this.thumbnailSize];
       },
       thumbnailWidth() {
-        if (!this.media.ebucoreWidth) {
+        if (!this.webResource.ebucoreWidth) {
           return null;
         }
         const thumbnailMaxSize = this.thumbnailSize === 'large' ? 400 : 200;
-        if (this.media.ebucoreWidth < thumbnailMaxSize) {
-          return this.media.ebucoreWidth;
+        if (this.webResource.ebucoreWidth < thumbnailMaxSize) {
+          return this.webResource.ebucoreWidth;
         }
         return thumbnailMaxSize;
       },
       thumbnailHeight() {
-        if (!this.media.ebucoreHeight || !this.thumbnailWidth) {
+        if (!this.webResource.ebucoreHeight || !this.thumbnailWidth) {
           return null;
         }
-        return (this.media.ebucoreHeight / this.media.ebucoreWidth) * this.thumbnailWidth;
+        return (this.webResource.ebucoreHeight / this.webResource.ebucoreWidth) * this.thumbnailWidth;
       },
       edmTypeWithFallback() {
-        return this.media.edmType || this.edmType;
+        return this.webResource.edmType || this.edmType;
       }
     },
 

--- a/packages/portal/src/components/media/MediaImageViewer.vue
+++ b/packages/portal/src/components/media/MediaImageViewer.vue
@@ -8,7 +8,6 @@
 </template>
 
 <script>
-  import axios from 'axios';
   // NOTE: each of the imported OpenLayers modules needs to be added to
   //       build.transpile in nuxt.config.js
   import IIIFSource from 'ol/source/IIIF.js';
@@ -29,6 +28,7 @@
 
   import useZoom from '@/composables/zoom.js';
   import EuropeanaMediaAnnotation from '@/utils/europeana/media/Annotation.js';
+  import EuropeanaMediaService from '@/utils/europeana/media/Service.js';
 
   import MediaImageViewerKeyboardToggle from './MediaImageViewerKeyboardToggle.vue';
 
@@ -58,7 +58,7 @@
         default: null
       },
       service: {
-        type: Object,
+        type: EuropeanaMediaService,
         default: null
       },
       url: {
@@ -98,8 +98,7 @@
 
     async fetch() {
       if (this.service?.id) {
-        const infoUri = `${this.service.id}/info.json`;
-        const infoResponse = await axios.get(infoUri);
+        const infoResponse = await this.service.fetchInfo();
         this.info = infoResponse.data;
         this.source = 'IIIF';
         // this.fullsize = true;

--- a/packages/portal/src/composables/itemMediaPresentation.js
+++ b/packages/portal/src/composables/itemMediaPresentation.js
@@ -2,6 +2,7 @@ import { computed, ref } from 'vue';
 
 import EuropeanaMediaAnnotationList from '@/utils/europeana/media/AnnotationList.js';
 import EuropeanaMediaPresentation from '@/utils/europeana/media/Presentation.js';
+import EuropeanaMediaResource from '@/utils/europeana/media/Resource.js';
 
 const annotations = ref([]);
 const annotationSearchHits = ref([]);
@@ -81,7 +82,7 @@ const fetchPresentation = async(uri) => {
 const setPresentationFromWebResources = (webResources) => {
   presentation.value = new EuropeanaMediaPresentation({
     canvases: webResources.map((resource) => ({
-      resource
+      resource: EuropeanaMediaResource.fromEDM(resource)
     }))
   });
 };

--- a/packages/portal/src/utils/europeana/media/Base.js
+++ b/packages/portal/src/utils/europeana/media/Base.js
@@ -54,8 +54,13 @@ export default class EuropeanaMediaBase {
   // factory method to create an instance and parse some data to initialise its
   // properties
   static parse(data) {
+    if (!data) {
+      return undefined;
+    }
+
     const resource = new this;
     resource.parse(data);
+
     return resource;
   }
 
@@ -65,6 +70,10 @@ export default class EuropeanaMediaBase {
       ...options,
       url: this.axiosUrl(options.url)
     });
+  }
+
+  static omitIsUndefined(data) {
+    return omitBy(data, isUndefined);
   }
 
   static getHashParam(hash, key) {
@@ -94,7 +103,7 @@ export default class EuropeanaMediaBase {
   }
 
   postParseData(data) {
-    return omitBy(data, isUndefined);
+    return this.constructor.omitIsUndefined(data);
   }
 
   parse(data) {

--- a/packages/portal/src/utils/europeana/media/Presentation.js
+++ b/packages/portal/src/utils/europeana/media/Presentation.js
@@ -1,5 +1,5 @@
-import WebResource from '@/plugins/europeana/edm/WebResource.js';
 import Base from './Base.js';
+import Resource from './Resource.js';
 import {
   IIIF_PRESENTATION_V2_CONTEXT,
   IIIF_PRESENTATION_V3_CONTEXT
@@ -38,32 +38,18 @@ export default class EuropeanaMediaPresentation extends Base {
   }
 
   static extractV2Canvases(manifest) {
-    // TODO: limit to images w/ motivation "painting"?
     return (manifest.sequences || []).map((sequence) => sequence.canvases.map((canvas) => ({
       id: canvas.id,
       annotations: canvas.otherContent,
-      resource: EuropeanaMediaPresentation.webResource(canvas.images[0].resource)
+      resource: Resource.parse(canvas.images[0].resource)
     }))).flat();
   }
 
   static extractV3Canvases(manifest) {
-    // TODO: limit to "annotations" w/ motivation "painting"?
     return (manifest.items || []).map((canvas) => ({
       id: canvas.id,
       annotations: canvas.annotations,
-      resource: EuropeanaMediaPresentation.webResource(canvas.items[0].items[0].body)
+      resource: Resource.parse(canvas.items[0].items[0].body)
     }));
-  }
-
-  static webResource(data) {
-    return new WebResource({
-      // TODO: rename this `id`, but do so throughout the app too
-      about: data.id,
-      ebucoreHasMimeType: data.format,
-      ebucoreHeight: data.height,
-      ebucoreWidth: data.width,
-      // TODO: filter for IIIF Image service
-      svcsHasService: [].concat(data.service || [])[0]
-    });
   }
 }

--- a/packages/portal/src/utils/europeana/media/Resource.js
+++ b/packages/portal/src/utils/europeana/media/Resource.js
@@ -1,0 +1,57 @@
+import Base from './Base.js';
+import Service from './Service.js';
+import EDMWebResource from '@/plugins/europeana/edm/WebResource.js';
+
+export default class EuropeanaMediaResource extends Base {
+  $edm;
+
+  static fromEDM(edm) {
+    if (!edm) {
+      return undefined;
+    }
+
+    const data = this.omitIsUndefined({
+      edm,
+      id: edm.about,
+      format: edm.ebucoreHasMimeType,
+      height: edm.ebucoreHeight,
+      width: edm.ebucoreWidth,
+      service: Service.fromEDM([].concat(edm.svcsHasService)[0])
+    });
+
+    return new this(data);
+  }
+
+  parseData(data) {
+    data = super.parseData(data);
+
+    const parsed = {
+      id: data.id,
+      format: data.format,
+      height: data.height,
+      service: Service.parse([].concat(data.service)[0]),
+      width: data.width
+    };
+
+    return parsed;
+  }
+
+  get edm() {
+    if (!this.$edm) {
+      const data = this.constructor.omitIsUndefined({
+        about: this.id,
+        ebucoreHasMimeType: this.format,
+        ebucoreHeight: this.height,
+        ebucoreWidth: this.width,
+        svcsHasService: [].concat(this.service || [])[0]?.edm
+      });
+
+      this.$edm = new EDMWebResource(data);
+    }
+    return this.$edm;
+  }
+
+  set edm(value) {
+    this.$edm = value;
+  }
+}

--- a/packages/portal/src/utils/europeana/media/Resource.js
+++ b/packages/portal/src/utils/europeana/media/Resource.js
@@ -10,14 +10,19 @@ export default class EuropeanaMediaResource extends Base {
       return undefined;
     }
 
-    const data = this.omitIsUndefined({
-      edm,
-      id: edm.about,
-      format: edm.ebucoreHasMimeType,
-      height: edm.ebucoreHeight,
-      width: edm.ebucoreWidth,
-      service: Service.fromEDM([].concat(edm.svcsHasService)[0])
-    });
+    let data = {};
+    if (typeof edm === 'string') {
+      data.id = edm;
+    } else {
+      data = this.omitIsUndefined({
+        edm,
+        id: edm.about,
+        format: edm.ebucoreHasMimeType,
+        height: edm.ebucoreHeight,
+        width: edm.ebucoreWidth,
+        service: Service.fromEDM([].concat(edm.svcsHasService)[0])
+      });
+    }
 
     return new this(data);
   }

--- a/packages/portal/src/utils/europeana/media/Service.js
+++ b/packages/portal/src/utils/europeana/media/Service.js
@@ -9,12 +9,17 @@ export default class EuropeanaMediaService extends Base {
       return undefined;
     }
 
-    const data = this.omitIsUndefined({
-      edm,
-      context: 'http://iiif.io/api/image/2/context.json',
-      id: edm.about,
-      profile: edm.doapImplements
-    });
+    let data = {};
+    if (typeof edm === 'string') {
+      data.id = edm;
+    } else {
+      data = this.omitIsUndefined({
+        edm,
+        context: 'http://iiif.io/api/image/2/context.json',
+        id: edm.about,
+        profile: edm.doapImplements
+      });
+    }
 
     return new this(data);
   }

--- a/packages/portal/src/utils/europeana/media/Service.js
+++ b/packages/portal/src/utils/europeana/media/Service.js
@@ -1,0 +1,48 @@
+import Base from './Base.js';
+import EDMService from '@/plugins/europeana/edm/Service.js';
+
+export default class EuropeanaMediaService extends Base {
+  $edm;
+
+  static fromEDM(edm) {
+    if (!edm) {
+      return undefined;
+    }
+
+    const data = this.omitIsUndefined({
+      edm,
+      context: 'http://iiif.io/api/image/2/context.json',
+      id: edm.about,
+      profile: edm.doapImplements
+    });
+
+    return new this(data);
+  }
+
+  get infoUrl() {
+    return `${this.id}/info.json`;
+  }
+
+  fetchInfo() {
+    return this.constructor.fetch({
+      url: this.infoUrl
+    });
+  }
+
+  get edm() {
+    if (!this.$edm) {
+      const data = this.constructor.omitIsUndefined({
+        about: this.id,
+        doapImplements: this.profile,
+        dctermsConformsTo: ['http://iiif.io/api/image']
+      });
+
+      this.$edm = new EDMService(data);
+    }
+    return this.$edm;
+  }
+
+  set edm(value) {
+    this.$edm = value;
+  }
+}

--- a/packages/portal/tests/unit/composables/itemMediaPresentation.spec.js
+++ b/packages/portal/tests/unit/composables/itemMediaPresentation.spec.js
@@ -160,9 +160,9 @@ describe('useItemMediaPresentation', () => {
           {
             id: 'https://iiif.example.org/presentation/123/abc/canvas/1',
             resource: {
-              about: 'https://iiif.example.org/presentation/123/abc/image1.jpg',
-              ebucoreHasMimeType: 'image/jpeg',
-              svcsHasService: {
+              id: 'https://iiif.example.org/presentation/123/abc/image1.jpg',
+              format: 'image/jpeg',
+              service: {
                 id: 'https://iiif.example.org/image/123/abc/image1.jpg'
               }
             }
@@ -176,7 +176,7 @@ describe('useItemMediaPresentation', () => {
     it('initialises presentation value from web resources', () => {
       const { presentation, setPresentationFromWebResources } = useItemMediaPresentation();
       const webResources = [
-        { about: 'https://example.org/video.mp4', ebucoreMimeType: 'video/mp4' }
+        { about: 'https://example.org/video.mp4', ebucoreHasMimeType: 'video/mp4' }
       ];
 
       setPresentationFromWebResources(webResources);
@@ -184,7 +184,10 @@ describe('useItemMediaPresentation', () => {
       expect(presentation.value).toEqual({
         canvases: [
           {
-            resource: webResources[0]
+            resource: {
+              id: webResources[0].about,
+              format: webResources[0].ebucoreHasMimeType
+            }
           }
         ]
       });

--- a/packages/portal/tests/unit/utils/europeana/media/Presentation.spec.js
+++ b/packages/portal/tests/unit/utils/europeana/media/Presentation.spec.js
@@ -66,8 +66,8 @@ describe('@/utils/europeana/media/Presentation', () => {
             {
               id: 'https://iiif.europeana.eu/presentation/123/abc/canvas/1',
               resource: {
-                about: 'https://iiif.europeana.eu/presentation/123/abc/image1.jpg',
-                ebucoreHasMimeType: 'image/jpeg'
+                id: 'https://iiif.europeana.eu/presentation/123/abc/image1.jpg',
+                format: 'image/jpeg'
               }
             }
           ]
@@ -125,8 +125,8 @@ describe('@/utils/europeana/media/Presentation', () => {
             {
               id: 'https://iiif.europeana.eu/presentation/123/abc/canvas/1',
               resource: {
-                about: 'https://iiif.europeana.eu/presentation/123/abc/image1.jpg',
-                ebucoreHasMimeType: 'image/jpeg'
+                id: 'https://iiif.europeana.eu/presentation/123/abc/image1.jpg',
+                format: 'image/jpeg'
               }
             }
           ]

--- a/packages/portal/tests/unit/utils/europeana/media/Resource.spec.js
+++ b/packages/portal/tests/unit/utils/europeana/media/Resource.spec.js
@@ -1,0 +1,93 @@
+import EuropeanaMediaResource from '@/utils/europeana/media/Resource.js';
+
+describe('EuropeanaMediaResource', () => {
+  describe('Static methods', () => {
+    describe('EuropeanaMediaResource.fromEDM()', () => {
+      it('creates an instance from EDM', () => {
+        const edm = {
+          about: 'https://example.org/image.jpeg',
+          ebucoreHasMimeType: 'image/jpeg',
+          ebucoreHeight: 1000,
+          ebucoreWidth: 500,
+          svcsHasService: [
+            'https://iiif.example.org/image.jpeg'
+          ]
+        };
+
+        const resource = EuropeanaMediaResource.fromEDM(edm);
+
+        expect(resource).toEqual({
+          id: edm.about,
+          format: edm.ebucoreHasMimeType,
+          height: edm.ebucoreHeight,
+          width: edm.ebucoreWidth,
+          service: {
+            id: edm.svcsHasService[0]
+          }
+        });
+      });
+    });
+  });
+
+  describe('Instance methods', () => {
+    describe('EuropeanaMediaResource.prototype.parseData()', () => {
+      it('picks relevant properties', () => {
+        const data = {
+          id: 'https://example.org/image.jpeg',
+          format: 'image/jpeg',
+          height: 1000,
+          language: 'de',
+          service: [
+            {
+              id: 'https://iiif.example.org/image.jpeg'
+            }
+          ],
+          type: 'dctypes:Image',
+          width: 500
+        };
+        const resource = new EuropeanaMediaResource();
+
+        const parsed = resource.parseData(data);
+
+        expect(parsed).toEqual({
+          id: 'https://example.org/image.jpeg',
+          format: 'image/jpeg',
+          height: 1000,
+          service: {
+            id: 'https://iiif.example.org/image.jpeg'
+          },
+          width: 500
+        });
+      });
+    });
+  });
+
+  describe('Instance properties', () => {
+    describe('EuropeanaMediaResource.prototype.edm', () => {
+      it('converts properties to EDM equivalent', () => {
+        const data = {
+          id: 'https://example.org/image.jpeg',
+          format: 'image/jpeg',
+          height: 1000,
+          width: 500,
+          service: {
+            edm: {
+              about: 'https://iiif.example.org/image.jpeg'
+            }
+          }
+        };
+        const resource = new EuropeanaMediaResource(data);
+
+        const edm = resource.edm;
+
+        expect(edm).toEqual({
+          about: data.id,
+          ebucoreHasMimeType: data.format,
+          ebucoreHeight: data.height,
+          ebucoreWidth: data.width,
+          svcsHasService: data.service.edm
+        });
+      });
+    });
+  });
+});

--- a/packages/portal/tests/unit/utils/europeana/media/Service.spec.js
+++ b/packages/portal/tests/unit/utils/europeana/media/Service.spec.js
@@ -1,0 +1,94 @@
+import nock from 'nock';
+
+import EuropeanaMediaService from '@/utils/europeana/media/Service.js';
+
+describe('EuropeanaMediaService', () => {
+  beforeAll(() => {
+    nock.disableNetConnect();
+  });
+  afterEach(() => {
+    nock.cleanAll();
+  });
+  afterAll(() => {
+    nock.enableNetConnect();
+  });
+
+  describe('Static methods', () => {
+    describe('EuropeanaMediaService.fromEDM()', () => {
+      it('creates an instance from EDM', () => {
+        const edm = {
+          about: 'https://example.org/image.jpeg',
+          doapImplements: 'http://iiif.io/api/image/2/level1.json'
+        };
+
+        const service = EuropeanaMediaService.fromEDM(edm);
+
+        expect(service).toEqual({
+          context: 'http://iiif.io/api/image/2/context.json',
+          id: edm.about,
+          profile: edm.doapImplements
+        });
+      });
+    });
+  });
+
+  describe('Instance methods', () => {
+    describe('EuropeanaMediaService.prototype.fetchInfo()', () => {
+      const origin = 'http://example.org';
+      const path = '/image.jpeg';
+      const id = `${origin}${path}`;
+      const responseData = {
+        '@context': 'http://iiif.io/api/image/2/context.json',
+        '@id': id,
+        height: 500,
+        protocol: 'http://iiif.io/api/image',
+        sizes: [
+          { height: 500, width: 1000 }
+        ],
+        width: 1000
+      };
+
+      beforeEach(() => {
+        nock(origin).get(`${path}/info.json`).reply(200, responseData);
+      });
+
+      it('retrieves info.json resource', async() => {
+        const service = new EuropeanaMediaService({ id });
+
+        await service.fetchInfo();
+
+        expect(nock.isDone()).toBe(true);
+      });
+    });
+  });
+
+  describe('Instance properties', () => {
+    describe('EuropeanaMediaService.prototype.infoUrl', () => {
+      it('appends /info.json to id property', () => {
+        const service = new EuropeanaMediaService({ id: 'https://example.org/image.jpeg' });
+
+        const infoUrl = service.infoUrl;
+
+        expect(infoUrl).toBe('https://example.org/image.jpeg/info.json');
+      });
+    });
+
+    describe('EuropeanaMediaService.prototype.edm', () => {
+      it('converts properties to EDM equivalent', () => {
+        const data = {
+          id: 'https://example.org/image.jpeg',
+          profile: 'http://iiif.io/api/image/2/level1.json'
+        };
+        const service = new EuropeanaMediaService(data);
+
+        const edm = service.edm;
+
+        expect(edm).toEqual({
+          about: data.id,
+          doapImplements: data.profile,
+          dctermsConformsTo: ['http://iiif.io/api/image']
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
* add new europeana/media utils classes to represent resources (e.g. image/audio/etc) and services (e.g. IIIF Image service)
  * both include conversion to/from EDM equivalents
* move retrieval of IIIF Image info.json out of MediaImageViewer component and into new service class
* make MediaCardImage aware of both WebResource and EuropeanaMediaResource classes for its media prop