### PR TITLE
test: mock nuxt fetchState in mounter

### DIFF
--- a/packages/portal/src/components/generic/AlertMessage.vue
+++ b/packages/portal/src/components/generic/AlertMessage.vue
@@ -18,7 +18,7 @@
     },
     props: {
       error: {
-        type: [String, Object],
+        type: [String, Object, Error],
         default: ''
       }
     }

--- a/packages/portal/src/pages/feature-ideas/index.vue
+++ b/packages/portal/src/pages/feature-ideas/index.vue
@@ -7,7 +7,6 @@
       <b-row class="flex-md-row py-4 text-center">
         <b-col cols="12">
           <LoadingSpinner />
-          {{ $fetchState }}
         </b-col>
       </b-row>
     </b-container>

--- a/packages/portal/src/pages/feature-ideas/index.vue
+++ b/packages/portal/src/pages/feature-ideas/index.vue
@@ -7,6 +7,7 @@
       <b-row class="flex-md-row py-4 text-center">
         <b-col cols="12">
           <LoadingSpinner />
+          {{ $fetchState }}
         </b-col>
       </b-row>
     </b-container>
@@ -82,7 +83,6 @@
         name: null,
         description: null,
         socialMediaImage: null,
-        pageFetched: false,
         text: null,
         features: []
       };

--- a/packages/portal/tests/unit/components/browse/BrowseAutomatedCardGroup.spec.js
+++ b/packages/portal/tests/unit/components/browse/BrowseAutomatedCardGroup.spec.js
@@ -37,10 +37,6 @@ const factory = (propsData = { sectionType: FEATURED_TOPICS })  => shallowMountN
     $contentful: {
       query: sinon.stub()
     },
-    $fetchState: {
-      error: false,
-      pending: false
-    },
     localePath: () => 'mocked path',
     $i18n: { locale: 'en', t: (key) => key, n: (num) => `${num}`, localeProperties: { iso: 'en-GB' } },
     $route: { query: {} },

--- a/packages/portal/tests/unit/components/embed/EmbedHTML.spec.js
+++ b/packages/portal/tests/unit/components/embed/EmbedHTML.spec.js
@@ -24,10 +24,7 @@ const fixtures = {
 
 const factory = (propsData = {}) => shallowMountNuxt(EmbedHTML, {
   propsData,
-  localVue,
-  mocks: {
-    $fetchState: {}
-  }
+  localVue
 });
 
 describe('components/embed/EmbedHTML', () => {

--- a/packages/portal/tests/unit/components/embed/EmbedOEmbed.spec.js
+++ b/packages/portal/tests/unit/components/embed/EmbedOEmbed.spec.js
@@ -31,10 +31,9 @@ const factory = ({ propsData = {}, data = {} } = {}) => shallowMountNuxt(EmbedOE
   }),
   localVue,
   mocks: {
-    $fetchState: {},
     $t: (key) => key
   },
-  stubs: ['EmbedHTML', 'client-only']
+  stubs: ['EmbedHTML', 'client-only', 'AlertMessage']
 });
 
 describe('components/embed/EmbedOEmbed', () => {
@@ -74,21 +73,17 @@ describe('components/embed/EmbedOEmbed', () => {
       expect(wrapper.vm.providerName).toBe(response['provider_name']);
     });
 
-    it('throws an error if response does not contain HTML', async() => {
+    it('displays an error if response does not contain HTML', async() => {
       const response = {
         type: 'link'
       };
       const wrapper = factory({ propsData: { url, endpoint } });
       nockRequest().reply(200, response);
 
-      let error;
-      try {
-        await wrapper.vm.fetch();
-      } catch (e) {
-        error = e;
-      }
+      await wrapper.vm.fetch();
+      const alertMessage = wrapper.find('alertmessage-stub');
 
-      expect(error.message).toBe('messages.externalContentError');
+      expect(alertMessage.attributes('error')).toContain('messages.externalContentError');
     });
   });
 

--- a/packages/portal/tests/unit/components/entity/EntityRelatedCollectionsCard.spec.js
+++ b/packages/portal/tests/unit/components/entity/EntityRelatedCollectionsCard.spec.js
@@ -15,7 +15,6 @@ const factory = ({ propsData = {}, data = {}, responses } = {}) => {
       $apis: {
         record: { search: sinon.stub().resolves(responses?.record?.search || {}) }
       },
-      $fetchState: {},
       $store: {
         state: {
           search: {

--- a/packages/portal/tests/unit/components/entity/EntityTable.spec.js
+++ b/packages/portal/tests/unit/components/entity/EntityTable.spec.js
@@ -10,11 +10,10 @@ localVue.use(BootstrapVue);
 
 const $axiosGetStub = sinon.stub();
 
-const factory = (propsData = { type: 'organisations' }, fetchState = { error: false, pending: false }) => mountNuxt(EntityTable, {
+const factory = (propsData = { type: 'organisations' }) => mountNuxt(EntityTable, {
   localVue,
   propsData,
   mocks: {
-    $fetchState: fetchState,
     $axios: {
       get: $axiosGetStub
     },

--- a/packages/portal/tests/unit/components/generic/FeatureIdeas.spec.js
+++ b/packages/portal/tests/unit/components/generic/FeatureIdeas.spec.js
@@ -30,7 +30,6 @@ const factory = ({ propsData = {}, mocks = {} } = {}) => {
       },
       $config: config,
       $error: sinon.spy(),
-      $fetchState: {},
       $nuxt: { context: {} },
       $t: (key) => key,
       $tc: (key) => key,

--- a/packages/portal/tests/unit/components/home/HomePage.spec.js
+++ b/packages/portal/tests/unit/components/home/HomePage.spec.js
@@ -62,8 +62,7 @@ const factory = ({ data = {} } = {}) => shallowMountNuxt(HomePage, {
     $t: (key) => key,
     localePath: (args) => {
       return args.params ? `${args.params.type}/${args.params.pathMatch}` : args;
-    },
-    $fetchState: {}
+    }
   },
   stubs: ['b-container']
 });

--- a/packages/portal/tests/unit/components/item/ItemMediaPresentation.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemMediaPresentation.spec.js
@@ -29,7 +29,6 @@ const factory = ({ data = {}, propsData = {}, mocks = {} } = {}) => shallowMount
   },
   mocks: {
     $apis,
-    $fetchState: { pending: false },
     $nuxt: {
       context: {
         $apis

--- a/packages/portal/tests/unit/components/item/ItemRecommendations.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemRecommendations.spec.js
@@ -33,7 +33,6 @@ const factory = ({ propsData = {}, mocks = {} } = {}) => shallowMountNuxt(ItemRe
       }
     },
     $auth: {},
-    $fetchState: {},
     $i18n: { locale: 'en' },
     $t: key => key,
     ...mocks

--- a/packages/portal/tests/unit/components/item/ItemTrendingItems.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemTrendingItems.spec.js
@@ -44,7 +44,6 @@ const factory = ({ mocks = {} } = {}) => shallowMountNuxt(ItemTrendingItems, {
       }
     },
     $features: { mockTrendingItems: false },
-    $fetchState: {},
     ...mocks
   },
   stubs: ['b-container']

--- a/packages/portal/tests/unit/components/media/MediaAnnotationList.spec.js
+++ b/packages/portal/tests/unit/components/media/MediaAnnotationList.spec.js
@@ -28,7 +28,6 @@ const factory = ({ data, propsData, mocks } = {}) => shallowMountNuxt(MediaAnnot
     annotationScrollToContainerSelector: '#list-container'
   },
   mocks: {
-    $fetchState: {},
     $route: {
       query: {}
     },
@@ -38,7 +37,7 @@ const factory = ({ data, propsData, mocks } = {}) => shallowMountNuxt(MediaAnnot
     ...mocks
   },
   localVue,
-  stubs: ['NuxtLink']
+  stubs: ['NuxtLink', 'b-col', 'b-row', 'b-container']
 });
 
 const stubItemMediaPresentationComposable = (stubs = {}) => {

--- a/packages/portal/tests/unit/components/media/MediaImageViewer.spec.js
+++ b/packages/portal/tests/unit/components/media/MediaImageViewer.spec.js
@@ -16,7 +16,6 @@ const factory = ({ propsData = {}, mocks = {} } = {}) => shallowMountNuxt(MediaI
         mediaProxyUrl: (url) => `mediaProxyUrl ${url}`
       }
     },
-    $fetchState: {},
     $t: (key) => key,
     ...mocks
   }

--- a/packages/portal/tests/unit/components/related/RelatedCollectionsCard.spec.js
+++ b/packages/portal/tests/unit/components/related/RelatedCollectionsCard.spec.js
@@ -19,7 +19,6 @@ const factory = (options = {}) => {
     propsData: options.propsData,
     mocks: {
       $apis: { entity: { suggest: sinon.stub().resolves(relatedCollections) } },
-      $fetchState: {},
       $i18n: { locale: 'en' },
       $t: key => key,
       $store: {

--- a/packages/portal/tests/unit/components/search/SearchFacetDropdown.spec.js
+++ b/packages/portal/tests/unit/components/search/SearchFacetDropdown.spec.js
@@ -89,7 +89,6 @@ const factory = (options = {}) => shallowMountNuxt(SearchFacetDropdown, {
         search: apisRecordSearchStub
       }
     },
-    $fetchState: options.fetchState || {},
     $route: {
       query: {}
     },
@@ -108,7 +107,8 @@ const factory = (options = {}) => shallowMountNuxt(SearchFacetDropdown, {
       state: {
         search: {}
       }
-    }
+    },
+    ...options.mocks || {}
   },
   stubs: {
     'b-form-tags': {
@@ -131,7 +131,6 @@ const fullFactory = (options = {}) => mountNuxt(SearchFacetDropdown, {
         search: apisRecordSearchStub
       }
     },
-    $fetchState: options.fetchState || {},
     $route: {
       query: {}
     },
@@ -150,7 +149,8 @@ const fullFactory = (options = {}) => mountNuxt(SearchFacetDropdown, {
       state: {
         search: {}
       }
-    }
+    },
+    ...options.mocks || {}
   },
   stubs: ['i18n'],
   propsData: {
@@ -857,9 +857,6 @@ describe('components/search/SearchFacetDropdown', () => {
           propsData: {
             search: true,
             name: 'PROVIDER'
-          },
-          fetchState: {
-            pending: false
           }
         });
         await wrapper.setData({ fetched: true, fields: providerFields });

--- a/packages/portal/tests/unit/components/search/SearchInterface.spec.js
+++ b/packages/portal/tests/unit/components/search/SearchInterface.spec.js
@@ -25,14 +25,13 @@ const searchResult = {
 
 const logApmTransactionSpy = sinon.spy();
 
-const factory = ({ $fetchState = {}, mocks = {}, propsData = {}, data = {} } = {}) => shallowMountNuxt(SearchInterface, {
+const factory = ({ mocks = {}, propsData = {}, data = {} } = {}) => shallowMountNuxt(SearchInterface, {
   localVue,
   attachTo: document.body,
   mocks: {
     $t: (key) => key,
     localePath: () => '/',
     $router: { push: sinon.spy() },
-    $fetchState,
     $route: { path: '/search', name: 'search', query: {} },
     $error: sinon.spy(),
     localise: (val) => val,

--- a/packages/portal/tests/unit/components/set/SetRecommendations.spec.js
+++ b/packages/portal/tests/unit/components/set/SetRecommendations.spec.js
@@ -8,7 +8,6 @@ const factory = ({ propsData = {}, features = {}, recommendations = [] }) => sha
   mocks: {
     $apis: { recommendation: { recommend: sinon.stub().resolves({ items: recommendations }) } },
     $features: features,
-    $fetchState: {},
     $store: {
       commit: sinon.spy(),
       state: { set: { activeRecommendations: recommendations } }

--- a/packages/portal/tests/unit/components/stories/StoriesInterface.spec.js
+++ b/packages/portal/tests/unit/components/stories/StoriesInterface.spec.js
@@ -140,7 +140,7 @@ const contentfulQueryStub = () => {
   return stub;
 };
 
-const factory = ({ data = {}, propsData = {}, $fetchState = {}, mocks = {} } = {}) => shallowMountNuxt(StoriesInterface, {
+const factory = ({ data = {}, propsData = {}, mocks = {} } = {}) => shallowMountNuxt(StoriesInterface, {
   localVue,
   data() {
     return data;
@@ -159,7 +159,6 @@ const factory = ({ data = {}, propsData = {}, $fetchState = {}, mocks = {} } = {
         page: '1'
       }
     },
-    $fetchState,
     $t: (key) => key,
     $tc: (key) => key,
     ...mocks
@@ -170,7 +169,7 @@ const factory = ({ data = {}, propsData = {}, $fetchState = {}, mocks = {} } = {
 describe('components/stories/StoriesInterface', () => {
   describe('while the fetch state is pending', () => {
     it('show a loading spinner', async() => {
-      const wrapper = factory({ $fetchState: { pending: true } });
+      const wrapper = factory({ mocks: { $fetchState: { pending: true } } });
 
       const spinner = wrapper.find('loadingspinner-stub');
 
@@ -180,7 +179,7 @@ describe('components/stories/StoriesInterface', () => {
 
   describe('when the fetch state is complete', () => {
     it('show a loading spinner', async() => {
-      const wrapper = factory({ $fetchState: { pending: false } });
+      const wrapper = factory({ mocks: { $fetchState: { pending: false } } });
 
       const spinner = wrapper.find('loadingspinner-stub');
 

--- a/packages/portal/tests/unit/components/user/UserSets.spec.js
+++ b/packages/portal/tests/unit/components/user/UserSets.spec.js
@@ -37,7 +37,6 @@ const factory = ({ propsData = {}, data = {}, $route = {} } = {}) => shallowMoun
   mocks: {
     $auth: { user: { sub: 'user-id' } },
     $config: { app: { internalLinkDomain: null } },
-    $fetchState: {},
     $apis: {
       set: { search: sinon.stub().resolves({ items: sets, partOf: { total: sets.length } }) },
       thumbnail: { edmPreview: (img) => img?.edmPreview?.[0] }

--- a/packages/portal/tests/unit/pages/feature-ideas/index.spec.js
+++ b/packages/portal/tests/unit/pages/feature-ideas/index.spec.js
@@ -19,16 +19,17 @@ const contentfulFullResponse = { data: { data: { featureIdeasPageCollection: { i
   ] }
 }] } } } };
 
-const factory = ({ contentfulResponse = {}, $fetchState = {} }) => shallowMountNuxt(featureIdeasPage, {
+const factory = ({ contentfulResponse = {}, mocks = {} }) => shallowMountNuxt(featureIdeasPage, {
   localVue,
   mocks: {
     $contentful: {
       query: sinon.stub().resolves(contentfulResponse)
     },
-    $fetchState,
     $i18n: { localeProperties: { iso: 'en-GB' } },
     $route: { query: {} },
-    $t: key => key
+    $t: (key) => key,
+    $tc: (key) => key,
+    ...mocks
   }
 });
 
@@ -55,11 +56,12 @@ describe('pages/feature-ideas/index', () => {
 
     describe('when fetch errors', () => {
       it('renders an alert message', () => {
-        const wrapper = factory({ $fetchState: { error: { message: 'Error message' } } });
+        const wrapper = factory({ mocks: { $fetchState: { error: { message: 'Error message' } } } });
 
         const alertMessage = wrapper.find('[data-qa="alert message container"]');
 
         expect(alertMessage.exists()).toBe(true);
+
       });
     });
   });

--- a/packages/portal/tests/unit/pages/feature-ideas/index.spec.js
+++ b/packages/portal/tests/unit/pages/feature-ideas/index.spec.js
@@ -61,7 +61,6 @@ describe('pages/feature-ideas/index', () => {
         const alertMessage = wrapper.find('[data-qa="alert message container"]');
 
         expect(alertMessage.exists()).toBe(true);
-
       });
     });
   });


### PR DESCRIPTION
so that:
* fetchState does not need to be repeatedly mocked in component/page unit tests
* it behaves like it does when running the nuxt app