### PR TITLE
fix: restore WR-level rights statement

### DIFF
--- a/packages/portal/src/components/item/ItemHero.vue
+++ b/packages/portal/src/components/item/ItemHero.vue
@@ -142,7 +142,7 @@
     },
     data() {
       return {
-        selectedMedia: this.media?.[0] || {}
+        selectedMedia: {}
       };
     },
     computed: {
@@ -177,6 +177,9 @@
         return this.$features.transcribathonCta && this.linkForContributingAnnotation && TRANSCRIBATHON_URL_ROOT.test(this.linkForContributingAnnotation);
       }
     },
+    created() {
+      this.selectMedia(this.media?.[0]);
+    },
     methods: {
       // Ensure we only proxy web resource media, preventing proxying of
       // arbitrary other resources such as images linked from (non-Europeana-hosted)
@@ -185,7 +188,12 @@
         return this.allMediaUris.some(uri => uri === url);
       },
       selectMedia(resource) {
-        this.selectedMedia = resource;
+        this.selectedMedia = {
+          // media prop may contain some metadata not available from iiif-derived
+          // resource emitted from ItemMediaPresentation, e.g. rights statement
+          ...this.media.find((wr) => wr.about === resource.about),
+          ...resource
+        };
       }
     }
   };

--- a/packages/portal/tests/size/.size-limit.json
+++ b/packages/portal/tests/size/.size-limit.json
@@ -2,7 +2,7 @@
   {
     "name": "portal.js client",
     "running": false,
-    "limit": "1865 KB",
+    "limit": "1875 KB",
     "path": [
       ".nuxt/dist/client/*.js",
       "!.nuxt/dist/client/*.modern.js"


### PR DESCRIPTION
ItemPage:
* keep WR-level edm:rights only if different from item-level, to save memory
* for IIIF items, keep only ID and edm:rights for WRs as other metadata derived from IIIF

ItemHero:
* when selecting media, including on component creation, combine the emitted resource (from ItemMediaPresentation), and the stored metadata from the prop, so that both IIIF and Record API metadata can be combined where needed, such as for edm:rights here