### PR TITLE
refactor: improve activeTab URL modifications

### DIFF
--- a/packages/portal/src/components/item/ItemMediaPresentation.vue
+++ b/packages/portal/src/components/item/ItemMediaPresentation.vue
@@ -26,12 +26,12 @@
         <template v-else>
           <template v-if="sidebarHasContent">
             <ItemMediaSidebar
-              v-show="showSidebar"
               ref="sidebar"
               tabindex="0"
               :annotation-list="hasAnnotations"
               :annotation-search="hasAnnotations && hasSearchService"
               :manifest-uri="uri"
+              :show="showSidebar"
               @keydown.escape.native="showSidebar = false"
             />
             <ItemMediaSidebarToggle

--- a/packages/portal/src/components/item/ItemMediaSidebar.vue
+++ b/packages/portal/src/components/item/ItemMediaSidebar.vue
@@ -3,6 +3,7 @@
     name="fade"
   >
     <div
+      v-show="show"
       class="media-viewer-sidebar"
       data-qa="item media sidebar"
     >
@@ -158,6 +159,10 @@
       query: {
         type: String,
         default: null
+      },
+      show: {
+        type: Boolean,
+        default: true
       }
     },
 
@@ -173,8 +178,8 @@
         tabHashes.push('#links');
       }
 
-      const { activeTabHash, activeTabHistory, activeTabIndex } = useActiveTab(tabHashes);
-      return { activeTabHash, activeTabHistory, activeTabIndex };
+      const { activeTabHash, activeTabHistory, activeTabIndex, watchTabIndex, unwatchTabIndex } = useActiveTab(tabHashes);
+      return { activeTabHash, activeTabHistory, activeTabIndex, watchTabIndex, unwatchTabIndex };
     },
 
     data() {
@@ -182,6 +187,22 @@
         sidebarId: 'item-media-sidebar',
         annotationsCount: null
       };
+    },
+
+    watch: {
+      show(val) {
+        if (val) {
+          this.watchTabIndex();
+        } else {
+          this.unwatchTabIndex();
+        }
+      }
+    },
+
+    mounted() {
+      if (this.show) {
+        this.watchTabIndex();
+      }
     },
 
     methods: {

--- a/packages/portal/tests/unit/composables/activeTab.spec.js
+++ b/packages/portal/tests/unit/composables/activeTab.spec.js
@@ -5,12 +5,12 @@ import { reactive } from 'vue';
 
 import useActiveTab from '@/composables/activeTab.js';
 
-const routerPushSpy = sinon.spy();
+const routerReplaceSpy = sinon.spy();
 
 const route = reactive({ hash: '#links' });
 sinon.stub(vueRouter, 'useRoute').returns(route);
 sinon.stub(vueRouter, 'useRouter').returns({
-  push: routerPushSpy
+  replace: routerReplaceSpy
 });
 
 const tabHashes = ['#annotations', '#search', '#links'];
@@ -23,9 +23,9 @@ const component = {
     </div>
   `,
   setup() {
-    const { activeTabHash, activeTabIndex } = useActiveTab(tabHashes);
+    const { activeTabHash, activeTabIndex, watchTabIndex } = useActiveTab(tabHashes);
 
-    return { activeTabHash, activeTabIndex };
+    return { activeTabHash, activeTabIndex, watchTabIndex };
   }
 };
 
@@ -65,15 +65,6 @@ describe('useActiveTab', () => {
       expect(input.element.value).toBe('2');
     });
 
-    it('is watched for changes to update route', async() => {
-      const wrapper = factory();
-
-      wrapper.find('#activeTabIndex').setValue(1);
-      await wrapper.vm.$nextTick();
-
-      expect(routerPushSpy.calledWith({ hash: '#search' })).toBe(true);
-    });
-
     it('is updated on route changes', async() => {
       const wrapper = factory();
 
@@ -82,6 +73,18 @@ describe('useActiveTab', () => {
 
       const input = wrapper.find('#activeTabIndex');
       expect(input.element.value).toBe('0');
+    });
+  });
+
+  describe('watchTabIndex', () => {
+    it('starts watching for changes to replace hash in route', async() => {
+      const wrapper = factory();
+      wrapper.vm.watchTabIndex();
+
+      wrapper.find('#activeTabIndex').setValue(1);
+      await wrapper.vm.$nextTick();
+
+      expect(routerReplaceSpy.calledWith({ hash: '#search' })).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Issues this addresses
1. when opening an item page with any sidebar content, #links is always added to the url if there is a IIIF manifest but no annotations or anno search, but this is undesirable if the sidebar is not open
2. back/forward browser navigation goes between tabs on item page before going back to e.g. search results

## Changes

activeTab composable:
* don't watch activeTabIndex by default, but return a function to start watching on-demand, plus one to [stop watching](https://vuejs.org/guide/essentials/watchers.html#stopping-a-watcher)
* switch to using router replace so that browser back/forward navigation doesn't loop through the tabs 

ItemMediaSidebar:
* add a `show` prop to control visibility
* only watch activeTabIndex changes when component is shown (according to that prop)
  * preventing immediate triggering of it on initialisation always selecting the first tab's index & hash

ItemMediaPresentation:
* pass show prop to ItemMediaSidebar based on value of showSidebar