### PR TITLE
refactor: loading spinner for static images only

### DIFF
--- a/packages/portal/src/components/media/MediaImageViewer.vue
+++ b/packages/portal/src/components/media/MediaImageViewer.vue
@@ -159,6 +159,14 @@
       }
     },
 
+    computed: {
+      showSpinner() {
+        // only show the loading spinner for static images as it really messes
+        // with loading tiles when panning/zooming/etc
+        return this.imageLoading && (this.source === 'ImageStatic');
+      }
+    },
+
     watch: {
       activeAnnotation: {
         deep: true,
@@ -180,14 +188,6 @@
     mounted() {
       if (!this.$fetchState.pending) {
         this.renderImage();
-      }
-    },
-
-    computed: {
-      showSpinner() {
-        // only show the loading spinner for static images as it really messes
-        // with loading tiles when panning/zooming/etc
-        return this.imageLoading && (this.source === 'ImageStatic');
       }
     },
 

--- a/packages/portal/src/components/media/MediaImageViewer.vue
+++ b/packages/portal/src/components/media/MediaImageViewer.vue
@@ -7,7 +7,7 @@
       id="media-image-viewer-keyboard-toggle"
     />
     <b-container
-      v-if="imageLoading"
+      v-if="showSpinner"
       class="h-100 d-flex align-items-center justify-content-center"
       data-qa="loading spinner container"
     >
@@ -180,6 +180,14 @@
     mounted() {
       if (!this.$fetchState.pending) {
         this.renderImage();
+      }
+    },
+
+    computed: {
+      showSpinner() {
+        // only show the loading spinner for static images as it really messes
+        // with loading tiles when panning/zooming/etc
+        return this.imageLoading && (this.source === 'ImageStatic');
       }
     },
 


### PR DESCRIPTION
temporary workaround to alleviate it messing with zooming/panning tile sources like IIIF

later could be reconsidered if there is a better option as some IIIF images can be slow to load so the loading spinner may still be of value in those scenarios