### PR TITLE
fix: fullscreen on ipad

### DIFF
--- a/packages/portal/src/components/item/ItemMediaPaginationToolbar.vue
+++ b/packages/portal/src/components/item/ItemMediaPaginationToolbar.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="media-viewer-toolbar-pagination d-inline-flex align-items-center"
+    class="media-viewer-toolbar-pagination align-items-center"
     :class="{ closed: !showPages }"
   >
     <PaginationNavInput

--- a/packages/portal/src/components/item/ItemMediaPresentation.vue
+++ b/packages/portal/src/components/item/ItemMediaPresentation.vue
@@ -114,12 +114,13 @@
           v-if="multiplePages"
           :show-pages="showPages"
           :total-results="resourceCount"
+          :class="fullscreen ? 'd-none' : 'd-inline-flex'"
           @togglePages="togglePages"
         />
       </div>
       <ItemMediaThumbnails
         v-if="multiplePages"
-        v-show="showPages"
+        v-show="showPages && !fullscreen"
         id="item-media-thumbnails"
         ref="itemPages"
         tabindex="0"
@@ -488,13 +489,10 @@
   .media-viewer-wrapper:fullscreen,
   .media-viewer-wrapper.fullscreen-mock {
     max-height: 100%;
+
     .media-viewer-inner-wrapper {
       max-height: 100%;
       height: 100%;
-    }
-    ::v-deep #item-media-thumbnails,
-    ::v-deep .media-viewer-toolbar-pagination {
-      display: none !important;
     }
   }
 
@@ -506,6 +504,12 @@
     bottom: 0;
     height: 100%;
     z-index: 1051; // Feedback widget z-index + 1
+  }
+
+  // Fix for older Chrome (v70 and iOS)
+  .media-viewer-wrapper.fullscreen-mock .media-viewer-inner-wrapper {
+    max-height: 100%;
+    height: 100%;
   }
 
   ::v-deep .divider {

--- a/packages/portal/src/components/item/ItemMediaPresentation.vue
+++ b/packages/portal/src/components/item/ItemMediaPresentation.vue
@@ -487,8 +487,7 @@
     }
   }
 
-  .media-viewer-wrapper:fullscreen,
-  .media-viewer-wrapper.fullscreen-mock {
+  .media-viewer-wrapper:fullscreen {
     max-height: 100%;
 
     .media-viewer-inner-wrapper {
@@ -503,6 +502,7 @@
     }
   }
 
+  // Defining this together with .media-viewer-wrapper:fullscreen does not compile well in older Chrome and iOS browsers
   .media-viewer-wrapper.fullscreen-mock {
     position: fixed;
     top: 0;
@@ -510,17 +510,17 @@
     right: 0;
     bottom: 0;
     height: 100%;
-    z-index: 1051; // Feedback widget z-index + 1
-  }
-
-  // Fix for older Chrome (v70 and iOS)
-  .media-viewer-wrapper.fullscreen-mock .media-viewer-inner-wrapper {
     max-height: 100%;
-    height: 100%;
+    z-index: 1051; // Feedback widget z-index + 1
 
-    &.fullscreen-include-sidebar {
-      @media (max-width: ($bp-large - 1px)) {
-        height: calc(100% - 3.5rem);
+    .media-viewer-inner-wrapper {
+      max-height: 100%;
+      height: 100%;
+
+      &.fullscreen-include-sidebar {
+        @media (max-width: ($bp-large - 1px)) {
+          height: calc(100% - 3.5rem);
+        }
       }
     }
   }

--- a/packages/portal/src/components/item/ItemMediaPresentation.vue
+++ b/packages/portal/src/components/item/ItemMediaPresentation.vue
@@ -519,10 +519,10 @@
     height: 100%;
 
     &.fullscreen-include-sidebar {
-        @media (max-width: ($bp-large - 1px)) {
-          height: calc(100% - 3.5rem);
-        }
+      @media (max-width: ($bp-large - 1px)) {
+        height: calc(100% - 3.5rem);
       }
+    }
   }
 
   ::v-deep .divider {

--- a/packages/portal/src/components/item/ItemMediaPresentation.vue
+++ b/packages/portal/src/components/item/ItemMediaPresentation.vue
@@ -10,7 +10,8 @@
         class="media-viewer-inner-wrapper w-100 overflow-auto"
         :class="{
           'pagination-toolbar-max-width': addPaginationToolbarMaxWidth,
-          'sidebar-toggle-max-width': addSidebarToggleMaxWidth
+          'sidebar-toggle-max-width': addSidebarToggleMaxWidth,
+          'fullscreen-include-sidebar': fullscreen && sidebarHasContent
         }"
       >
         <b-container
@@ -493,6 +494,12 @@
     .media-viewer-inner-wrapper {
       max-height: 100%;
       height: 100%;
+
+      &.fullscreen-include-sidebar {
+        @media (max-width: ($bp-large - 1px)) {
+          height: calc(100% - 3.5rem);
+        }
+      }
     }
   }
 
@@ -510,6 +517,12 @@
   .media-viewer-wrapper.fullscreen-mock .media-viewer-inner-wrapper {
     max-height: 100%;
     height: 100%;
+
+    &.fullscreen-include-sidebar {
+        @media (max-width: ($bp-large - 1px)) {
+          height: calc(100% - 3.5rem);
+        }
+      }
   }
 
   ::v-deep .divider {


### PR DESCRIPTION
- Fixes style bug on older Chrome (v70) and iOS where the mock fullscreen styles were not applied as expected
- Includes the sidebar toggle in fullscreen mode, when there is sidebar content, on mobile and tablet size screens