### PR TITLE
fix: activeTab add/remove hash

### DIFF
--- a/packages/portal/src/components/item/ItemMediaPresentation.vue
+++ b/packages/portal/src/components/item/ItemMediaPresentation.vue
@@ -218,7 +218,7 @@
         fullscreen: false,
         mockFullscreenClass: false,
         showPages: true,
-        showSidebar: !!this.$route.hash,
+        showSidebar: false,
         thumbnailInteractedWith: false
       };
     },
@@ -246,9 +246,10 @@
 
       this.selectResource();
 
-      if (this.hasAnnotations && window?.innerWidth >= 768) {
-        this.showSidebar = true;
-      }
+      this.showSidebar = (
+        (this.hasAnnotations && (window?.innerWidth >= 768)) &&
+        (!this.$route.hash || ['#annotations', '#search', '#links'].includes(this.$route.hash))
+      ) || ['#annotations', '#search', '#links'].includes(this.$route.hash);
 
       if (error) {
         this.handleError(error, 'IIIFManifestError');

--- a/packages/portal/src/components/item/ItemMediaSidebar.vue
+++ b/packages/portal/src/components/item/ItemMediaSidebar.vue
@@ -195,6 +195,7 @@
           this.watchTabIndex();
         } else {
           this.unwatchTabIndex();
+          this.$router.replace({ ...this.$route, hash: undefined });
         }
       }
     },

--- a/packages/portal/src/composables/activeTab.js
+++ b/packages/portal/src/composables/activeTab.js
@@ -26,7 +26,17 @@ export default function useActiveTab(tabHashes) {
     // unwatch 1st to prevent duplicate watchers
     unwatchTabIndex();
 
+    if (activeTabIndex.value !== -1) {
+      activeTabHistory.value.push(activeTabHash.value);
+      if (activeTabHash.value !== route.hash) {
+        router.replace({ ...route, hash: activeTabHash.value });
+      }
+    }
+
     unwatchTabIndex = watch(activeTabIndex, () => {
+      if (route.hash && !tabHashes.includes(route.hash)) {
+        return;
+      }
       if (activeTabIndex.value !== -1) {
         activeTabHistory.value.push(activeTabHash.value);
         router.replace({ ...route, hash: activeTabHash.value });
@@ -48,7 +58,7 @@ export default function useActiveTab(tabHashes) {
     activeTabHash,
     activeTabHistory,
     activeTabIndex,
-    watchTabIndex,
-    unwatchTabIndex
+    unwatchTabIndex,
+    watchTabIndex
   };
 }


### PR DESCRIPTION
- ensure any active tab is added to hash when sidebar first opened, inc. #links
- clear hash when sidebar closed
- don't show sidebar if other non-sidebar hash is set, e.g. for API requests w/ #api-requests