### PR TITLE
fix: nullish check on ol Map when highlighting

### DIFF
--- a/packages/portal/src/components/media/MediaImageViewer.vue
+++ b/packages/portal/src/components/media/MediaImageViewer.vue
@@ -267,7 +267,7 @@
       },
 
       highlightAnnotations(annos = this.activeAnnotation, layerId = 'active') {
-        const layer = this.olMap.getLayers().getArray().find((layer) => layer.get('id') === layerId);
+        const layer = this.olMap?.getLayers()?.getArray()?.find((layer) => layer.get('id') === layerId);
         if (!layer) {
           return;
         }


### PR DESCRIPTION
because the annotations watcher may fire before the map is initialised