### PR TITLE
perf: render item media presentation server-side

### DIFF
--- a/packages/portal/src/components/item/ItemHero.vue
+++ b/packages/portal/src/components/item/ItemHero.vue
@@ -1,19 +1,13 @@
 <template>
   <div class="item-hero">
-    <!--
-      TODO: render the media presentation container here, both SSR and CSR,
-            to reduce UI jumpiness
-    -->
-    <client-only>
-      <ItemMediaPresentation
-        :uri="iiifPresentationManifest"
-        :item-id="identifier"
-        :provider-url="providerUrl"
-        :web-resources="media"
-        :edm-type="edmType"
-        @select="selectMedia"
-      />
-    </client-only>
+    <ItemMediaPresentation
+      :uri="iiifPresentationManifest"
+      :item-id="identifier"
+      :provider-url="providerUrl"
+      :web-resources="media"
+      :edm-type="edmType"
+      @select="selectMedia"
+    />
     <b-container>
       <b-row>
         <b-col

--- a/packages/portal/src/components/item/ItemMediaPresentation.vue
+++ b/packages/portal/src/components/item/ItemMediaPresentation.vue
@@ -262,6 +262,8 @@
       }
     },
 
+    fetchOnServer: false,
+
     computed: {
       displayThumbnail() {
         if (this.hasAnnotations) {


### PR DESCRIPTION
- to prevent large layout shifts client-side
- but don't _fetch_ server-side due to slow/large manifests