### PR TITLE
refactor: mv media viewer wrapper to ItemHero

### DIFF
--- a/packages/portal/src/components/item/ItemHero.vue
+++ b/packages/portal/src/components/item/ItemHero.vue
@@ -1,19 +1,22 @@
 <template>
   <div class="item-hero">
-    <!--
-      TODO: render the media presentation container here, both SSR and CSR,
-            to reduce UI jumpiness
-    -->
-    <client-only>
-      <ItemMediaPresentation
-        :uri="iiifPresentationManifest"
-        :item-id="identifier"
-        :provider-url="providerUrl"
-        :web-resources="media"
-        :edm-type="edmType"
-        @select="selectMedia"
-      />
-    </client-only>
+    <div
+      class="media-viewer-wrapper overflow-hidden"
+    >
+      <!--
+        NOTE: rendering this server-side increases node memory usage significantly
+      -->
+      <client-only>
+        <ItemMediaPresentation
+          :uri="iiifPresentationManifest"
+          :item-id="identifier"
+          :provider-url="providerUrl"
+          :web-resources="media"
+          :edm-type="edmType"
+          @select="selectMedia"
+        />
+      </client-only>
+    </div>
     <b-container>
       <b-row>
         <b-col
@@ -202,6 +205,7 @@
 
 <style lang="scss">
   @import '@europeana/style/scss/variables';
+  @import '@europeana/style/scss/mixins';
 
   .item-hero {
     padding-bottom: 1.625rem;
@@ -232,6 +236,17 @@
         &:hover:not(.active) {
           color: $mediumgrey;
         }
+      }
+    }
+
+    .media-viewer-wrapper {
+      position: relative;
+      background-color: $black;
+      @include media-viewer-height;
+
+      @media (max-width: ($bp-large - 1px)) {
+        max-height: none;
+        height: auto
       }
     }
 

--- a/packages/portal/tests/unit/components/item/ItemMediaPresentation.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemMediaPresentation.spec.js
@@ -68,7 +68,7 @@ describe('components/item/ItemMediaPresentation', () => {
       stubItemMediaPresentationComposable();
       const wrapper = factory();
 
-      const viewerWrapper = wrapper.find('.media-viewer-wrapper');
+      const viewerWrapper = wrapper.find('.media-viewer-inner-wrapper');
 
       expect(viewerWrapper.isVisible()).toBe(true);
     });

--- a/tests/e2e/features/ZZ-finally/memory-usage.feature
+++ b/tests/e2e/features/ZZ-finally/memory-usage.feature
@@ -1,6 +1,6 @@
 Feature: Memory budget
-  Scenario: 115 MB
+  Scenario: Node.js heap does not exceed 90 MB
     Given I am on the `home page`
     # Wait a bit to allow garbage collection, to prevent false positives for memory leaks
     And I wait 5 seconds
-    Then the memory used is less than 115 MB
+    Then the memory used is less than 90 MB


### PR DESCRIPTION
- so that client-side rendering of media viewer does not result in such big layout shifts
- but keeping the media viewer rendered only client-side due to significant increase in node memory usage otherwise