### PR TITLE
refactor: use klaro mixin in cookie components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,7 @@ jobs:
       -
         name: Check image size
         env:
-          DOCKER_IMAGE_SIZE_LIMIT: '365M'
+          DOCKER_IMAGE_SIZE_LIMIT: '367M'
         run: |
           docker_image_size=$(docker image inspect --format '{{.Size}}' ${{ needs.metadata.outputs.docker-full-tag }})
           if [ ${docker_image_size} -gt $(numfmt --from=si ${DOCKER_IMAGE_SIZE_LIMIT}) ]; then

--- a/packages/portal/nuxt.config.js
+++ b/packages/portal/nuxt.config.js
@@ -141,6 +141,7 @@ export default {
       siteId: process.env.MATOMO_SITE_ID,
       loadWait: {
         delay: process.env.MATOMO_LOAD_WAIT_DELAY,
+        name: 'Matomo',
         retries: process.env.MATOMO_LOAD_WAIT_RETRIES
       }
     },

--- a/packages/portal/src/components/embed/EmbedGateway.vue
+++ b/packages/portal/src/components/embed/EmbedGateway.vue
@@ -49,13 +49,12 @@
           </i18n>
           <PageCookiesWidget
             v-if="renderCookieModal"
-            :klaro-manager="klaroManager"
-            :klaro-config="klaroConfig"
             :render-toast="false"
             :modal-id="cookieModalId"
             modal-title-path="klaro.main.purposes.thirdPartyContent.title"
             :modal-description-path="null"
             :hide-purposes="hidePurposes"
+            :only-show-if-consent-required="false"
             @consentsApplied="checkConsentAndOpenEmbed"
           />
           <i18n
@@ -114,12 +113,6 @@
     },
 
     watch: {
-      // klaroManager is not available in mounted so watch it to be ready instead
-      klaroManager(newVal) {
-        if (newVal) {
-          this.checkConsentAndOpenEmbed();
-        }
-      },
       cookieConsentRequired(newVal) {
         if (!newVal) {
           this.checkConsentAndOpenEmbed();
@@ -136,6 +129,10 @@
     },
 
     methods: {
+      onKlaroRendered() {
+        this.checkConsentAndOpenEmbed();
+      },
+
       openCookieModal() {
         if (this.cookieConsentRequired) {
           this.$bvModal.show('cookie-modal');

--- a/packages/portal/src/components/embed/EmbedGateway.vue
+++ b/packages/portal/src/components/embed/EmbedGateway.vue
@@ -117,6 +117,12 @@
         if (!newVal) {
           this.checkConsentAndOpenEmbed();
         }
+      },
+      // klaroManager is not available in mounted so watch it to be ready instead
+      klaroManager(newVal) {
+        if (newVal) {
+          this.checkConsentAndOpenEmbed();
+        }
       }
     },
 
@@ -129,10 +135,6 @@
     },
 
     methods: {
-      onKlaroRendered() {
-        this.checkConsentAndOpenEmbed();
-      },
-
       openCookieModal() {
         if (this.cookieConsentRequired) {
           this.$bvModal.show('cookie-modal');

--- a/packages/portal/src/components/page/PageCookieConsent.vue
+++ b/packages/portal/src/components/page/PageCookieConsent.vue
@@ -1,14 +1,25 @@
 <!--
-  This is a dummy component for Klaro which serves only to load the CSS when
+  This is a dummy component for Klaro which serves only to load the JS & CSS when
   needed.
 -->
 <template>
-  <div />
+  <div>
+    <script
+      :src="klaroHeadScript.src"
+      :defer="klaroHeadScript.defer"
+    /></script>
+  </div>
 </template>
 
 <script>
+  import klaroMixin from '@/mixins/klaro.js';
+
   export default {
-    name: 'PageCookieConsent'
+    name: 'PageCookieConsent',
+
+    mixins: [
+      klaroMixin
+    ]
   };
 </script>
 

--- a/packages/portal/src/components/page/PageCookieConsent.vue
+++ b/packages/portal/src/components/page/PageCookieConsent.vue
@@ -3,7 +3,7 @@
   needed.
 -->
 <template>
-  <div></div>
+  <div />
 </template>
 
 <script>

--- a/packages/portal/src/components/page/PageCookieConsent.vue
+++ b/packages/portal/src/components/page/PageCookieConsent.vue
@@ -3,12 +3,7 @@
   needed.
 -->
 <template>
-  <div>
-    <script
-      :src="klaroHeadScript.src"
-      :defer="klaroHeadScript.defer"
-    /></script>
-  </div>
+  <div></div>
 </template>
 
 <script>
@@ -19,7 +14,14 @@
 
     mixins: [
       klaroMixin
-    ]
+    ],
+
+    props: {
+      klaroServices: {
+        type: Array,
+        default: null
+      }
+    }
   };
 </script>
 

--- a/packages/portal/src/components/page/PageCookiesWidget.vue
+++ b/packages/portal/src/components/page/PageCookiesWidget.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="cookieConsentRequired"
+    v-if="!onlyShowIfConsentRequired || cookieConsentRequired"
   >
     <b-toast
       v-if="renderToast"
@@ -243,6 +243,10 @@
       klaroServices: {
         type: Array,
         default: null
+      },
+      onlyShowIfConsentRequired: {
+        type: Boolean,
+        default: true
       }
     },
 

--- a/packages/portal/src/components/page/PageCookiesWidget.vue
+++ b/packages/portal/src/components/page/PageCookiesWidget.vue
@@ -201,6 +201,7 @@
 
 <script>
   import PageCookiesCheckbox from './PageCookiesCheckbox';
+  import klaroMixin from '@/mixins/klaro.js';
 
   export default {
     // TODO: rename as this is more generally about services than solely cookies
@@ -211,20 +212,11 @@
       SmartLink: () => import('@/components/generic/SmartLink')
     },
 
-    // Do not use the klaro mixin in this component as it will cause side effects for the mixin is already imported in the layout
+    mixins: [
+      klaroMixin
+    ],
+
     props: {
-      klaroManager: {
-        type: Object,
-        required: true
-      },
-      klaroConfig: {
-        type: Object,
-        required: true
-      },
-      cookieConsentRequired: {
-        type: Boolean,
-        default: true
-      },
       modalId: {
         type: String,
         default: 'cookie-modal'
@@ -245,6 +237,10 @@
       hidePurposes: {
         type: Array,
         default: () => []
+      },
+      klaroServices: {
+        type: Array,
+        default: null
       }
     },
 
@@ -318,11 +314,11 @@
       }
     },
 
-    mounted() {
-      this.setCheckedServices();
-    },
-
     methods: {
+      onKlaroScriptLoad() {
+        this.setCheckedServices();
+      },
+      
       updateConsentPerService(service, value) {
         if (service && !service.required) {
           this.klaroManager.updateConsent(service.name, value);

--- a/packages/portal/src/components/page/PageCookiesWidget.vue
+++ b/packages/portal/src/components/page/PageCookiesWidget.vue
@@ -320,11 +320,20 @@
       }
     },
 
-    methods: {
-      onKlaroRendered() {
-        this.setCheckedServices();
-      },
+    watch: {
+      // klaroManager is likely not available in mounted so watch it to be ready instead
+      klaroManager(newVal) {
+        if (newVal) {
+          this.setCheckedServices();
+        }
+      }
+    },
 
+    mounted() {
+      this.klaroManager && this.setCheckedServices();
+    },
+
+    methods: {
       updateConsentPerService(service, value) {
         if (service && !service.required) {
           this.klaroManager.updateConsent(service.name, value);

--- a/packages/portal/src/components/page/PageCookiesWidget.vue
+++ b/packages/portal/src/components/page/PageCookiesWidget.vue
@@ -1,5 +1,7 @@
 <template>
-  <div>
+  <div
+    v-if="cookieConsentRequired"
+  >
     <b-toast
       v-if="renderToast"
       :id="toastId"
@@ -315,7 +317,7 @@
     },
 
     methods: {
-      onKlaroScriptLoad() {
+      onKlaroRendered() {
         this.setCheckedServices();
       },
 

--- a/packages/portal/src/components/page/PageCookiesWidget.vue
+++ b/packages/portal/src/components/page/PageCookiesWidget.vue
@@ -318,7 +318,7 @@
       onKlaroScriptLoad() {
         this.setCheckedServices();
       },
-      
+
       updateConsentPerService(service, value) {
         if (service && !service.required) {
           this.klaroManager.updateConsent(service.name, value);

--- a/packages/portal/src/layouts/default.vue
+++ b/packages/portal/src/layouts/default.vue
@@ -52,13 +52,10 @@
     <ErrorModal />
     <client-only>
       <PageCookiesWidget
-        v-if="$features.embeddedMediaNotification && cookieConsentRequired"
-        :klaro-manager="klaroManager"
-        :klaro-config="klaroConfig"
-        :cookie-consent-required="cookieConsentRequired"
+        v-if="$features.embeddedMediaNotification"
       />
       <PageCookieConsent
-        v-else-if="cookieConsentRequired"
+        v-else
       />
     </client-only>
   </div>
@@ -71,7 +68,6 @@
   import canonicalUrlMixin from '@/mixins/canonicalUrl';
   import makeToastMixin from '@/mixins/makeToast';
   import hotjarMixin from '@/mixins/hotjar.js';
-  import klaroMixin from '@/mixins/klaro.js';
   import versions from '../../pkg-versions';
   import { activeFeatureNotification } from '@/features/notifications';
 
@@ -93,7 +89,6 @@
     mixins: [
       canonicalUrlMixin,
       hotjarMixin,
-      klaroMixin,
       makeToastMixin
     ],
 
@@ -124,9 +119,6 @@
           { rel: 'stylesheet', href: `https://cdn.jsdelivr.net/npm/bootstrap-vue@${versions['bootstrap-vue']}/dist/bootstrap-vue.min.css` },
           { hreflang: 'x-default', rel: 'alternate', href: this.canonicalUrl({ fullPath: true, locale: false }) },
           ...i18nHead.link
-        ],
-        script: [
-          this.klaroHeadScript
         ],
         meta: [
           ...i18nHead.meta,

--- a/packages/portal/src/layouts/ds4ch.vue
+++ b/packages/portal/src/layouts/ds4ch.vue
@@ -21,13 +21,10 @@
     <DS4CHPageFooter />
     <client-only>
       <PageCookiesWidget
-        v-if="$features.embeddedMediaNotification && cookieConsentRequired"
-        :klaro-manager="klaroManager"
-        :klaro-config="klaroConfig"
-        :cookie-consent-required="cookieConsentRequired"
+        v-if="$features.embeddedMediaNotification"
       />
       <PageCookieConsent
-        v-else-if="cookieConsentRequired"
+        v-else
       />
     </client-only>
   </div>
@@ -39,7 +36,6 @@
   import DS4CHPageHeader from '@/components/DS4CH/DS4CHPageHeader';
   import DS4CHPageFooter from '@/components/DS4CH/DS4CHPageFooter';
   import canonicalUrlMixin from '@/mixins/canonicalUrl';
-  import klaroMixin from '@/mixins/klaro.js';
   import versions from '../../pkg-versions';
 
   export default {
@@ -54,13 +50,13 @@
     },
 
     mixins: [
-      canonicalUrlMixin,
-      klaroMixin
+      canonicalUrlMixin
     ],
 
     data() {
       return {
-        klaroServices: ['auth-strategy', 'i18n', 'matomo']
+        // FIXME: restore service override for this layout
+        // klaroServices: ['auth-strategy', 'i18n', 'matomo']
       };
     },
 
@@ -75,9 +71,6 @@
         ],
         meta: [
           { hid: 'og:url', property: 'og:url', content: this.canonicalUrl({ fullPath: true, locale: true }) }
-        ],
-        script: [
-          this.klaroHeadScript
         ]
       };
     }

--- a/packages/portal/src/layouts/ds4ch.vue
+++ b/packages/portal/src/layouts/ds4ch.vue
@@ -22,9 +22,11 @@
     <client-only>
       <PageCookiesWidget
         v-if="$features.embeddedMediaNotification"
+        :klaro-services="['auth-strategy', 'i18n', 'matomo']"
       />
       <PageCookieConsent
         v-else
+        :klaro-services="['auth-strategy', 'i18n', 'matomo']"
       />
     </client-only>
   </div>
@@ -52,13 +54,6 @@
     mixins: [
       canonicalUrlMixin
     ],
-
-    data() {
-      return {
-        // FIXME: restore service override for this layout
-        // klaroServices: ['auth-strategy', 'i18n', 'matomo']
-      };
-    },
 
     head() {
       return {

--- a/packages/portal/src/layouts/landing.vue
+++ b/packages/portal/src/layouts/landing.vue
@@ -20,13 +20,10 @@
     <LandingPageFooter />
     <client-only>
       <PageCookiesWidget
-        v-if="$features.embeddedMediaNotification && cookieConsentRequired"
-        :klaro-manager="klaroManager"
-        :klaro-config="klaroConfig"
-        :cookie-consent-required="cookieConsentRequired"
+        v-if="$features.embeddedMediaNotification"
       />
       <PageCookieConsent
-        v-else-if="cookieConsentRequired"
+        v-else
       />
     </client-only>
   </div>
@@ -36,7 +33,6 @@
   import LandingPageHeader from '@/components/landing/LandingPageHeader';
   import LandingPageFooter from '@/components/landing/LandingPageFooter';
   import canonicalUrlMixin from '@/mixins/canonicalUrl';
-  import klaroMixin from '@/mixins/klaro.js';
   import versions from '../../pkg-versions';
 
   export default {
@@ -50,13 +46,13 @@
     },
 
     mixins: [
-      canonicalUrlMixin,
-      klaroMixin
+      canonicalUrlMixin
     ],
 
     data() {
       return {
-        klaroServices: ['auth-strategy', 'i18n', 'matomo']
+        // FIXME: restore service override for this layout
+        // klaroServices: ['auth-strategy', 'i18n', 'matomo']
       };
     },
 
@@ -71,9 +67,6 @@
         ],
         meta: [
           { hid: 'og:url', property: 'og:url', content: this.canonicalUrl({ fullPath: true }) }
-        ],
-        script: [
-          this.klaroHeadScript
         ]
       };
     }

--- a/packages/portal/src/layouts/landing.vue
+++ b/packages/portal/src/layouts/landing.vue
@@ -21,9 +21,11 @@
     <client-only>
       <PageCookiesWidget
         v-if="$features.embeddedMediaNotification"
+        :klaro-services="['auth-strategy', 'i18n', 'matomo']"
       />
       <PageCookieConsent
         v-else
+        :klaro-services="['auth-strategy', 'i18n', 'matomo']"
       />
     </client-only>
   </div>
@@ -48,13 +50,6 @@
     mixins: [
       canonicalUrlMixin
     ],
-
-    data() {
-      return {
-        // FIXME: restore service override for this layout
-        // klaroServices: ['auth-strategy', 'i18n', 'matomo']
-      };
-    },
 
     head() {
       return {

--- a/packages/portal/src/mixins/klaro.js
+++ b/packages/portal/src/mixins/klaro.js
@@ -27,17 +27,7 @@ export default {
     script.setAttribute('src', `https://cdn.jsdelivr.net/npm/klaro@${version}/dist/klaro-no-css.js`);
     script.setAttribute('defer', true);
 
-    script.addEventListener('load', () => {
-      if (!this.klaro) {
-        this.klaro = window.klaro;
-      }
-
-      // If Matomo plugin is installed, wait for Matomo to load, but still render
-      // Klaro if it fails to.
-      const renderKlaroAfter = this.$waitForMatomo ? this.$waitForMatomo() : Promise.resolve();
-
-      renderKlaroAfter.catch(() => {}).finally(this.renderKlaro);
-    });
+    script.addEventListener('load', this.onKlaroScriptLoad);
 
     document.head.appendChild(script);
   },
@@ -81,6 +71,18 @@ export default {
 
   methods: {
     onKlaroScriptLoad() {
+      if (!this.klaro) {
+        this.klaro = window.klaro;
+      }
+
+      // If Matomo plugin is installed, wait for Matomo to load, but still render
+      // Klaro if it fails to.
+      const renderKlaroAfter = this.$waitForMatomo ? this.$waitForMatomo() : Promise.resolve();
+
+      renderKlaroAfter.catch(() => {}).finally(this.renderKlaro);
+    },
+
+    onKlaroRendered() {
       // may be overriden by components including the mixin
     },
 
@@ -91,7 +93,7 @@ export default {
         this.klaro.render(this.klaroConfig, true);
         !this.$features.embeddedMediaNotification && this.klaroManager.watch({ update: this.watchKlaroManagerUpdate });
 
-        this.onKlaroScriptLoad();
+        this.onKlaroRendered();
       }
     },
 

--- a/packages/portal/src/mixins/klaro.js
+++ b/packages/portal/src/mixins/klaro.js
@@ -27,7 +27,7 @@ export default {
     script.setAttribute('src', `https://cdn.jsdelivr.net/npm/klaro@${version}/dist/klaro-no-css.js`);
     script.setAttribute('defer', true);
 
-    script.addEventListener('load', function() {
+    script.addEventListener('load', () => {
       if (!this.klaro) {
         this.klaro = window.klaro;
       }
@@ -37,7 +37,7 @@ export default {
       const renderKlaroAfter = this.$waitForMatomo ? this.$waitForMatomo() : Promise.resolve();
 
       renderKlaroAfter.catch(() => {}).finally(this.renderKlaro);
-    }.bind(this));
+    });
 
     document.head.appendChild(script);
   },

--- a/packages/portal/src/mixins/klaro.js
+++ b/packages/portal/src/mixins/klaro.js
@@ -23,13 +23,17 @@ export default {
   },
 
   mounted() {
-    const script = document.createElement('script');
-    script.setAttribute('src', `https://cdn.jsdelivr.net/npm/klaro@${version}/dist/klaro-no-css.js`);
-    script.setAttribute('defer', true);
+    if (window.klaro) {
+      this.onKlaroScriptLoad();
+    } else {
+      const script = document.createElement('script');
+      script.setAttribute('src', `https://cdn.jsdelivr.net/npm/klaro@${version}/dist/klaro-no-css.js`);
+      script.setAttribute('defer', true);
 
-    script.addEventListener('load', this.onKlaroScriptLoad);
+      script.addEventListener('load', this.onKlaroScriptLoad);
 
-    document.head.appendChild(script);
+      document.head.appendChild(script);
+    }
   },
 
   computed: {

--- a/packages/portal/src/pages/item/_.vue
+++ b/packages/portal/src/pages/item/_.vue
@@ -142,6 +142,8 @@
   import pageMetaMixin from '@/mixins/pageMeta';
   import redirectToMixin from '@/mixins/redirectTo';
 
+  import waitFor from '@/utils/waitFor.js';
+
   export default {
     name: 'ItemPage',
     components: {
@@ -335,11 +337,7 @@
 
     methods: {
       trackCustomDimensions() {
-        if (!this.$waitForMatomo) {
-          return;
-        }
-
-        this.$waitForMatomo()
+        waitFor(() => this.$matomo, this.$config.matomo.loadWait)
           .then(() => this.$matomo.trackPageView('item page custom dimensions', this.matomoOptions))
           .catch(() => {});
       },

--- a/packages/portal/src/plugins/vue-matomo.client.js
+++ b/packages/portal/src/plugins/vue-matomo.client.js
@@ -30,24 +30,7 @@ export const trackSiteSearch = (store) => (to) => {
   return siteSearch;
 };
 
-const waitForMatomo = ({ delay = 100, retries = 20 }) => function() {
-  const that = this;
-
-  return new Promise((resolve, reject) => {
-    const attempt = (counter = 0) => {
-      if (that.$matomo) {
-        return resolve();
-      } else if (counter >= retries) {
-        return reject(new Error('No Matomo'));
-      } else {
-        return setTimeout(() => attempt(counter + 1), delay);
-      }
-    };
-    return attempt();
-  });
-};
-
-export default ({ app, $config: { matomo: { host, siteId, loadWait = {} } }, store }, inject) => {
+export default ({ app, $config: { matomo: { host, siteId } }, store }) => {
   if (!host || !siteId) {
     return;
   }
@@ -60,6 +43,4 @@ export default ({ app, $config: { matomo: { host, siteId, loadWait = {} } }, sto
     trackSiteSearch: trackSiteSearch(store),
     requireCookieConsent: true
   });
-
-  inject('waitForMatomo', waitForMatomo(loadWait));
 };

--- a/packages/portal/src/utils/waitFor.js
+++ b/packages/portal/src/utils/waitFor.js
@@ -1,0 +1,17 @@
+// waits for the callback to return a truthy value
+const waitFor = (callback, { name = 'unknown', delay = 100, retries = 20 } = {}) => {
+  return new Promise((resolve, reject) => {
+    const attempt = (counter = 0) => {
+      if (callback()) {
+        return resolve();
+      } else if (counter >= retries) {
+        return reject(new Error(`Gave up waiting for ${name}`));
+      } else {
+        return setTimeout(() => attempt(counter + 1), delay);
+      }
+    };
+    return attempt();
+  });
+};
+
+export default waitFor;

--- a/packages/portal/tests/size/.size-limit.json
+++ b/packages/portal/tests/size/.size-limit.json
@@ -11,7 +11,7 @@
   {
     "name": "portal.js modern",
     "running": false,
-    "limit": "1300 KB",
+    "limit": "1350 KB",
     "path": [
       ".nuxt/dist/client/*.modern.js"
     ]

--- a/packages/portal/tests/unit/components/page/PageCookiesWidget.spec.js
+++ b/packages/portal/tests/unit/components/page/PageCookiesWidget.spec.js
@@ -6,35 +6,29 @@ import sinon from 'sinon';
 const localVue = createLocalVue();
 localVue.use(BootstrapVue);
 
-const factory = (propsData = {}) => {
-  const wrapper = shallowMount(PageCookiesWidget, {
-    localVue,
-    propsData: {
-      ...propsData
+const factory = (propsData = {}) => shallowMount(PageCookiesWidget, {
+  localVue,
+  propsData: {
+    ...propsData
+  },
+  data: () => {
+    return {
+      klaroManager
+    };
+  },
+  mocks: {
+    localePath: () => {},
+    $features: { embeddedMediaNotification: true },
+    $i18n: { locale: 'en ' },
+    $matomo: {
+      trackEvent: sinon.spy()
     },
-    data: () => {
-      return {
-        klaroManager
-      };
-    },
-    mocks: {
-      localePath: () => {},
-      $features: { embeddedMediaNotification: true },
-      $i18n: { locale: 'en ' },
-      $matomo: {
-        trackEvent: sinon.spy()
-      },
-      $n: (num) => num,
-      $t: (key) => key,
-      $tc: (key) => key
-    },
-    stubs: ['i18n']
-  });
-
-  wrapper.vm.onKlaroRendered();
-
-  return wrapper;
-};
+    $n: (num) => num,
+    $t: (key) => key,
+    $tc: (key) => key
+  },
+  stubs: ['i18n']
+});
 
 const klaroManager = {
   changeAll: sinon.spy(),

--- a/packages/portal/tests/unit/mixins/klaro.spec.js
+++ b/packages/portal/tests/unit/mixins/klaro.spec.js
@@ -8,29 +8,35 @@ const component = {
   mixins: [mixin]
 };
 
-const factory = ({ data = {}, mocks = {} } = {}) => shallowMount(component, {
-  localVue: createLocalVue(),
-  data() {
-    return {
-      ...data
-    };
-  },
-  mocks: {
-    $i18n: {
-      locale: 'en'
+const factory = ({ data = {}, mocks = {} } = {}) => {
+  const wrapper = shallowMount(component, {
+    localVue: createLocalVue(),
+    data() {
+      return {
+        ...data
+      };
     },
-    initHotjar: sinon.spy(),
-    $matomo: {
-      forgetCookieConsentGiven: sinon.spy(),
-      rememberCookieConsentGiven: sinon.spy(),
-      trackEvent: () => {}
-    },
-    $route: { params: {} },
-    $t: (key) => key,
-    $features: {},
-    ...mocks
-  }
-});
+    mocks: {
+      $i18n: {
+        locale: 'en'
+      },
+      initHotjar: sinon.spy(),
+      $matomo: {
+        forgetCookieConsentGiven: sinon.spy(),
+        rememberCookieConsentGiven: sinon.spy(),
+        trackEvent: () => {}
+      },
+      $route: { params: {} },
+      $t: (key) => key,
+      $features: {},
+      ...mocks
+    }
+  });
+
+  wrapper.vm.onKlaroScriptLoad();
+
+  return wrapper;
+};
 
 const klaroManagerStub = {
   watch: sinon.spy()

--- a/packages/portal/tests/unit/mixins/klaro.spec.js
+++ b/packages/portal/tests/unit/mixins/klaro.spec.js
@@ -8,35 +8,32 @@ const component = {
   mixins: [mixin]
 };
 
-const factory = ({ data = {}, mocks = {} } = {}) => {
-  const wrapper = shallowMount(component, {
-    localVue: createLocalVue(),
-    data() {
-      return {
-        ...data
-      };
+const factory = ({ data = {}, mocks = {} } = {}) => shallowMount(component, {
+  localVue: createLocalVue(),
+  data() {
+    return {
+      ...data
+    };
+  },
+  mocks: {
+    $config: {
+      matomo: { loadWait: { delay: 0, retries: 1 } }
     },
-    mocks: {
-      $i18n: {
-        locale: 'en'
-      },
-      initHotjar: sinon.spy(),
-      $matomo: {
-        forgetCookieConsentGiven: sinon.spy(),
-        rememberCookieConsentGiven: sinon.spy(),
-        trackEvent: () => {}
-      },
-      $route: { params: {} },
-      $t: (key) => key,
-      $features: {},
-      ...mocks
-    }
-  });
-
-  wrapper.vm.onKlaroScriptLoad();
-
-  return wrapper;
-};
+    $i18n: {
+      locale: 'en'
+    },
+    initHotjar: sinon.spy(),
+    $matomo: {
+      forgetCookieConsentGiven: sinon.spy(),
+      rememberCookieConsentGiven: sinon.spy(),
+      trackEvent: () => {}
+    },
+    $route: { params: {} },
+    $t: (key) => key,
+    $features: {},
+    ...mocks
+  }
+});
 
 const klaroManagerStub = {
   watch: sinon.spy()
@@ -47,6 +44,12 @@ const klaroMock = {
 };
 
 describe('mixins/klaro', () => {
+  beforeAll(() => {
+    window.klaro = klaroMock;
+  });
+  afterAll(() => {
+    delete window.klaro;
+  });
   afterEach(sinon.resetHistory);
 
   describe('mounted', () => {
@@ -60,38 +63,10 @@ describe('mixins/klaro', () => {
     });
   });
 
-  describe('when Matomo plugin is installed', () => {
-    it('waits for Matomo to be ready first', () => {
-      const $waitForMatomo = sinon.stub().resolves();
-
-      factory({ mocks: { $waitForMatomo } });
-
-      expect($waitForMatomo.called).toBe(true);
-    });
-
-    it('renders Klaro if Matomo becomes ready', async() => {
-      const $waitForMatomo = sinon.stub().resolves();
-
-      factory({ data: { klaro: klaroMock }, mocks: { $waitForMatomo } });
-      await new Promise(process.nextTick);
-
-      expect(klaroMock.render.called).toBe(true);
-    });
-
-    it('renders Klaro if Matomo does not become ready', async() => {
-      const $waitForMatomo = sinon.stub().rejects();
-
-      factory({ data: { klaro: klaroMock }, mocks: { $waitForMatomo } });
-      await new Promise(process.nextTick);
-
-      expect(klaroMock.render.called).toBe(true);
-    });
-  });
-
   describe('renderKlaro', () => {
     it('renders Klaro', async() => {
       const wrapper = factory();
-      await wrapper.setData({ klaro: klaroMock });
+      await new Promise(process.nextTick);
 
       await wrapper.vm.renderKlaro();
 
@@ -100,7 +75,7 @@ describe('mixins/klaro', () => {
 
     it('registers Klaro manager update watcher', async() => {
       const wrapper = factory();
-      await wrapper.setData({ klaro: klaroMock });
+      await new Promise(process.nextTick);
 
       await wrapper.vm.renderKlaro();
 

--- a/packages/portal/tests/unit/pages/item/_.spec.js
+++ b/packages/portal/tests/unit/pages/item/_.spec.js
@@ -165,7 +165,8 @@ const factory = ({ data = {}, mocks = {} } = {}) => shallowMountNuxt(page, {
     $config: {
       app: {
         baseUrl: 'https://www.example.org'
-      }
+      },
+      matomo: {}
     },
     $features: { translatedItems: true },
     $t: (key) => key,
@@ -609,14 +610,6 @@ describe('pages/item/_.vue', () => {
         await wrapper.vm.trackCustomDimensions();
 
         expect(wrapper.vm.$matomo.trackPageView.called).toBe(true);
-      });
-
-      it('bails if NO Matomo plugin is installed', async() => {
-        const wrapper = factory({ mocks: { $waitForMatomo: undefined } });
-
-        await wrapper.vm.trackCustomDimensions();
-
-        expect(wrapper.vm.$matomo.trackPageView.called).toBe(false);
       });
     });
 

--- a/packages/portal/tests/unit/plugins/vue-matomo.client.spec.js
+++ b/packages/portal/tests/unit/plugins/vue-matomo.client.spec.js
@@ -1,4 +1,3 @@
-import sinon from 'sinon';
 import * as plugin from '@/plugins/vue-matomo.client';
 
 describe('plugins/vue-matomo.client', () => {
@@ -103,60 +102,6 @@ describe('plugins/vue-matomo.client', () => {
         const resultsCount = plugin.trackSiteSearch(store)(route).resultsCount;
 
         expect(resultsCount).toBe(9890);
-      });
-    });
-  });
-
-  describe('waitForMatomo', () => {
-    const context = { app: {}, $config: { matomo: { host: 'stats.example.org', siteId: 1 } } };
-
-    it('is injected into context', () => {
-      const inject = sinon.spy();
-
-      plugin.default(context, inject);
-
-      expect(inject.calledWith('waitForMatomo', sinon.match.func)).toBe(true);
-    });
-
-    describe('promise', () => {
-      let waitForMatomo;
-      const inject = (name, fn) => waitForMatomo = fn;
-
-      it('resolves if $matomo already set', async() => {
-        plugin.default(context, inject);
-        const vm = {
-          $matomo: true,
-          waitForMatomo
-        };
-
-        const promise = vm.waitForMatomo();
-
-        await expect(promise).resolves.not.toThrow();
-      });
-
-      it('resolves if $matomo set later', async() => {
-        const quickFailContext = { ...context, $config: { matomo: { ...context.$config.matomo, loadWait: { delay: 10, retries: 10 } } } };
-        plugin.default(quickFailContext, inject);
-        const vm = {
-          waitForMatomo
-        };
-
-        const promise = vm.waitForMatomo();
-        setTimeout(() => vm.$matomo = true, 5);
-
-        await expect(promise).resolves.not.toThrow();
-      });
-
-      it('rejects if $matomo never set', async() => {
-        const instantFailContext = { ...context, $config: { matomo: { ...context.$config.matomo, loadWait: { delay: 0, retries: 1 } } } };
-        plugin.default(instantFailContext, inject);
-        const vm = {
-          waitForMatomo
-        };
-
-        const promise = vm.waitForMatomo();
-
-        await expect(promise).rejects.toEqual(Error('No Matomo'));
       });
     });
   });

--- a/packages/portal/tests/unit/utils/waitFor.spec.js
+++ b/packages/portal/tests/unit/utils/waitFor.spec.js
@@ -1,0 +1,34 @@
+import waitFor from '@/utils/waitFor.js';
+
+describe('@/utils/waitFor.js', () => {
+  describe('waitFor', () => {
+    describe('promise', () => {
+      it('resolves if callback already truthy', async() => {
+        const callback = () => ({});
+
+        const promise = waitFor(callback);
+
+        await expect(promise).resolves.not.toThrow();
+      });
+
+      it('resolves if callback becomes truthy later', async() => {
+        let target = false;
+        const callback = () => target;
+
+        const promise = waitFor(callback, { delay: 10, retries: 10 });
+        setTimeout(() => target = true, 5);
+
+        await expect(promise).resolves.not.toThrow();
+      });
+
+      it('rejects if callback never truthy in time', async() => {
+        let target = false;
+        const callback = () => target;
+
+        const promise = waitFor(callback, { name: 'something', delay: 0, retries: 1 });
+
+        await expect(promise).rejects.toEqual(Error('Gave up waiting for something'));
+      });
+    });
+  });
+});


### PR DESCRIPTION
instead of in layouts, to prevent passing klaro manager/config down to components, and isolate use of the mixin methods to fewer locations

abstract waitForMatomo function to be a utility function for waiting for arbitrary callbacks to return truthy values, and also use it to have klaro-dependent components wait for it to become available before attempting to work with it