### PR TITLE
fix: do not override query on collection pages when fulltext search is applied

### DIFF
--- a/packages/portal/src/components/search/SearchInterface.vue
+++ b/packages/portal/src/components/search/SearchInterface.vue
@@ -412,6 +412,12 @@
 
         if (this.advancedSearchQueryCount > 0) {
           if (this.hasFulltextQa) {
+            // override query overrides already here to prevent full-text search breaking
+            if (this.overrideParams.query) {
+              params.query = this.overrideParams.query;
+              delete this.overrideParams.query;
+            }
+
             // If there are any advanced search full-text rules, then
             // these are promoted to the primary query, and any other query
             // (from the simple search bar) is demoted to a qf, fielded to

--- a/packages/portal/src/pages/collections/_type/_.vue
+++ b/packages/portal/src/pages/collections/_type/_.vue
@@ -178,17 +178,12 @@
           const entityQuery = getEntityQuery([this.entity.id].concat(this.entity.sameAs || []));
           overrideParams.qf = [entityQuery];
 
-          if (!this.$route.query.query && !this.fulltextQas?.length) {
+          if (!this.$route.query.query) {
             overrideParams.query = entityQuery; // Triggering best bets.
           }
         }
 
         return overrideParams;
-      },
-      fulltextQas() {
-        const qaAsArray = this.$route.query.qa ? [].concat(this.$route.query.qa) : null;
-
-        return qaAsArray?.filter?.((rule) => rule.startsWith('fulltext:') || rule.startsWith('NOT fulltext:'));
       },
       entityId() {
         return normalizeEntityId(this.$route.params.pathMatch);
@@ -310,10 +305,6 @@
       }
     },
 
-    mounted() {
-      console.log(this.$route);
-      console.log(this.fulltextQas);
-    },
     methods: {
       handleEntityRelatedCollectionsFetched(relatedCollections) {
         this.relatedCollections = relatedCollections;

--- a/packages/portal/src/pages/collections/_type/_.vue
+++ b/packages/portal/src/pages/collections/_type/_.vue
@@ -177,12 +177,18 @@
         if (this.entity) {
           const entityQuery = getEntityQuery([this.entity.id].concat(this.entity.sameAs || []));
           overrideParams.qf = [entityQuery];
-          if (!this.$route.query.query) {
+
+          if (!this.$route.query.query && !this.fulltextQas?.length) {
             overrideParams.query = entityQuery; // Triggering best bets.
           }
         }
 
         return overrideParams;
+      },
+      fulltextQas() {
+        const qaAsArray = this.$route.query.qa ? [].concat(this.$route.query.qa) : null;
+
+        return qaAsArray?.filter?.((rule) => rule.startsWith('fulltext:') || rule.startsWith('NOT fulltext:'));
       },
       entityId() {
         return normalizeEntityId(this.$route.params.pathMatch);
@@ -302,6 +308,11 @@
 
         return labelledMoreInfo;
       }
+    },
+
+    mounted() {
+      console.log(this.$route);
+      console.log(this.fulltextQas);
     },
     methods: {
       handleEntityRelatedCollectionsFetched(relatedCollections) {

--- a/packages/portal/tests/unit/components/search/SearchInterface.spec.js
+++ b/packages/portal/tests/unit/components/search/SearchInterface.spec.js
@@ -549,6 +549,41 @@ describe('components/search/SearchInterface', () => {
 
           expect(wrapper.vm.apiParams).toEqual(expected);
         });
+
+        describe('and a query override', () => {
+          it('is promoted into query, moving the query override to qf', () => {
+            const queryOverride = 'skos_concept:"http://data.europeana.eu/concept/001"';
+            const $route = {
+              query: {
+                qa: [
+                  'fulltext:europe',
+                  'NOT fulltext:united'
+                ]
+              }
+            };
+            const expected = {
+              page: 1,
+              profile: 'minimal,hits',
+              query: 'fulltext:europe AND NOT fulltext:united',
+              qf: [queryOverride, 'contentTier:(1 OR 2 OR 3 OR 4)'],
+              rows: 24
+            };
+
+            const wrapper = factory({
+              propsData: {
+                overrideParams: {
+                  query: queryOverride
+                }
+              },
+              mocks: {
+                $route
+              }
+            });
+            wrapper.vm.deriveApiParams();
+
+            expect(wrapper.vm.apiParams).toEqual(expected);
+          });
+        });
       });
     });
 

--- a/tests/e2e/docker/nightwatch/support/pages.js
+++ b/tests/e2e/docker/nightwatch/support/pages.js
@@ -21,6 +21,7 @@ const pages = {
   'gallery foyer page': `${url}/en/galleries`,
   'home page': `${url}/en`,
   'Newspapers theme search page': `${url}/en/search?qf=collection%3Anewspaper`,
+  'newspaper entity page': `${url}/en/collections/topic/18-newspaper`,
   'immersive story page': `${url}/en/stories/melitta-bentz-the-woman-who-invented-the-coffee-filter`,
   'item page with a IIIF Image': `${url}/en/item/9200357/BibliographicResource_3000095247457`,
   'item page with a IIIF Presentation': `${url}/en/item/9200301/BibliographicResource_3000126341277`,

--- a/tests/e2e/features/search/advanced.feature
+++ b/tests/e2e/features/search/advanced.feature
@@ -14,14 +14,14 @@ Feature: Advanced search
     And I am on an accessible page
 
   Scenario: Full-text search on a collection page shows hit highlights
-    When I open an `entity page`
+    When I open the `newspaper entity page`
     And I click the `search list view toggle icon`
     When I click the `toggle advanced search button`
-    And I enter "paris" in the `advanced search query builder: term control`
+    And I enter "berlin" in the `advanced search query builder: term control`
     And I click the `advanced search query builder: field control`
     And I click the `advanced search query builder: fulltext field option`
     And I click the `advanced search query builder: modifier control`
     And I click the `advanced search query builder: exact modifier option`
     And I wait for an `item preview`
-    Then I see a `highlighted search term` with the text "paris"
+    Then I see a `highlighted search term` with the text "Berlin"
     And I am on an accessible page

--- a/tests/e2e/features/search/advanced.feature
+++ b/tests/e2e/features/search/advanced.feature
@@ -12,3 +12,16 @@ Feature: Advanced search
     And I wait for an `item preview`
     Then I see a `highlighted search term` with the text "First World War"
     And I am on an accessible page
+
+  Scenario: Full-text search on a collection page shows hit highlights
+    When I open an `entity page`
+    And I click the `search list view toggle icon`
+    When I click the `toggle advanced search button`
+    And I enter "paris" in the `advanced search query builder: term control`
+    And I click the `advanced search query builder: field control`
+    And I click the `advanced search query builder: fulltext field option`
+    And I click the `advanced search query builder: modifier control`
+    And I click the `advanced search query builder: exact modifier option`
+    And I wait for an `item preview`
+    Then I see a `highlighted search term` with the text "paris"
+    And I am on an accessible page


### PR DESCRIPTION
Handles the `overrideParams.query` when there is a full text search. Because the full-text search query uses the `query` param, pushing the main query to `qf`. Overrides should be handled the same.