### PR TITLE
feat: De-Bias composable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -301,9 +301,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
+      "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -1189,13 +1189,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-logical-assignment-operators": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.22.11.tgz",
-      "integrity": "sha512-qQwRTP4+6xFCDV5k7gZBF3C31K34ut0tbEcTKxlX/0KXxm9GLcO14p570aWxFvVzx6QAfPgq7gaeIHXJC8LswQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.25.9.tgz",
+      "integrity": "sha512-wI4wRAzGko551Y8eVf6iOY9EouIDTtPb0ByZx+ktDGHwv6bHFimrgJM/2T021txPZ2s4c7bqvHbd+vXG6K948Q==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.22.5",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -34484,6 +34483,7 @@
         "vuex": "^3.6.2"
       },
       "devDependencies": {
+        "@babel/plugin-transform-logical-assignment-operators": "^7.25.9",
         "@europeana/style": "^2.0.0",
         "@lokalise/node-api": "^8.0.0",
         "@vue-a11y/announcer": "^2.1.0",

--- a/packages/portal/babel.config.cjs
+++ b/packages/portal/babel.config.cjs
@@ -1,5 +1,9 @@
 // Babel config used by Jest, e.g. for unit tests
 module.exports = {
+  plugins: [
+    '@babel/plugin-transform-logical-assignment-operators'
+  ],
+
   presets: [
     [
       '@babel/preset-env',

--- a/packages/portal/nuxt.config.js
+++ b/packages/portal/nuxt.config.js
@@ -448,6 +448,12 @@ export default {
   ** Build configuration
   */
   build: {
+    babel: {
+      plugins: [
+        '@babel/plugin-transform-logical-assignment-operators'
+      ]
+    },
+
     // Do not enable extractCSS as it is unreliable.
     // See: https://github.com/nuxt/nuxt.js/issues/4219
     extractCSS: false,

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -61,6 +61,7 @@
     "vuex": "^3.6.2"
   },
   "devDependencies": {
+    "@babel/plugin-transform-logical-assignment-operators": "^7.25.9",
     "@europeana/style": "^2.0.0",
     "@lokalise/node-api": "^8.0.0",
     "@vue-a11y/announcer": "^2.1.0",

--- a/packages/portal/src/composables/deBias.js
+++ b/packages/portal/src/composables/deBias.js
@@ -16,26 +16,6 @@ const termsToHighlight = computed(() => {
 
 const definitionOfTerm = (term) => definitions.value[term];
 
-const init = (annotations) => {
-  terms.value = [];
-  definitions.value = {};
-  highlighted.value = [];
-
-  const debiasAnnotations = annotations
-    .filter((anno) => (anno.motivation === 'highlighting') && (anno.body?.id.includes('/debias/')));
-
-  for (const anno of debiasAnnotations) {
-    const target = [].concat(anno.target)[0];
-    const term = target?.selector.refinedBy.exact['@value'];
-    const lang = target?.selector.refinedBy.exact['@language'];
-    const definition = anno.body?.definition?.[lang];
-    if (term && definition) {
-      terms.value.push(term);
-      definitions.value[term] = definition;
-    }
-  }
-};
-
 const parseAnnotations = (annotations) => {
   terms.value = [];
   definitions.value = {};

--- a/packages/portal/src/composables/deBias.js
+++ b/packages/portal/src/composables/deBias.js
@@ -1,0 +1,47 @@
+import { computed, ref } from 'vue';
+
+const terms = ref([]);
+const definitions = {};
+const highlighted = ref([]);
+
+const highlight = ((term) => {
+  if (!highlighted.value.includes(term)) {
+    highlighted.value.push(term);
+  }
+});
+
+const termsToHighlight = computed(() => {
+  return terms.value.filter((term) => !highlighted.value.includes(term));
+});
+
+const definitionOfTerm = (term) => definitions.value[term];
+
+const init = (annotations) => {
+  terms.value = [];
+  definitions.value = {};
+  highlighted.value = [];
+
+  const debiasAnnotations = annotations
+    .filter((anno) => (anno.motivation === 'highlighting') && (anno.body?.id.includes('/debias/')));
+
+  for (const anno of debiasAnnotations) {
+    const target = [].concat(anno.target)[0];
+    const term = target?.selector.refinedBy.exact['@value'];
+    const lang = target?.selector.refinedBy.exact['@language'];
+    const definition = anno.body?.definition?.[lang];
+    if (term && definition) {
+      terms.value.push(term);
+      definitions.value[term] = definition;
+    }
+  }
+};
+
+export default function useDeBias(annotations) {
+  annotations && init(annotations);
+
+  return {
+    definitionOfTerm,
+    highlight,
+    termsToHighlight
+  };
+}

--- a/packages/portal/src/composables/deBias.js
+++ b/packages/portal/src/composables/deBias.js
@@ -36,12 +36,33 @@ const init = (annotations) => {
   }
 };
 
+const parseAnnotations = (annotations) => {
+  terms.value = [];
+  definitions.value = {};
+  highlighted.value = [];
+
+  const debiasAnnotations = (annotations || [])
+    .filter((anno) => (anno.motivation === 'highlighting') && (anno.body?.id.includes('/debias/')));
+
+  for (const anno of debiasAnnotations) {
+    const target = [].concat(anno.target)[0];
+    const term = target?.selector.refinedBy.exact['@value'];
+    const lang = target?.selector.refinedBy.exact['@language'];
+    const definition = anno.body?.definition?.[lang];
+    if (term && definition) {
+      terms.value.push(term);
+      definitions.value[term] = definition;
+    }
+  }
+};
+
 export default function useDeBias(annotations) {
-  annotations && init(annotations);
+  annotations && parseAnnotations(annotations);
 
   return {
     definitionOfTerm,
     highlight,
+    parseAnnotations,
     termsToHighlight
   };
 }

--- a/packages/portal/src/composables/deBias.js
+++ b/packages/portal/src/composables/deBias.js
@@ -9,29 +9,35 @@ const termsToHighlight = (field) => {
 
 const definitionOfTerm = (term) => definitions.value[term];
 
-const findTargetForField = (targets, field) => {
-  return targets.find((target) => target?.selector.hasPredicate === field);
+const findAnnotationTarget = (targets, options = {}) => {
+  const { field, lang } = options;
+
+  return targets.find((target) => {
+    const fieldMatch = (!field || (target?.selector.hasPredicate === field));
+    const langMatch = (!lang || (target?.selector.refinedBy.exact['@language'] === lang));
+    return fieldMatch && langMatch;
+  });
 };
 
-const parseAnnotation = (anno) => {
+const parseAnnotation = (anno, options = {}) => {
+  const { lang } = options;
   const targets = [].concat(anno.target);
 
-  const target = findTargetForField(targets, 'dcTitle') ||
-      findTargetForField(targets, 'dcDescription') ||
-      findTargetForField(targets, 'dcSubject') ||
+  const target = findAnnotationTarget(targets, { field: 'dc:title', lang }) ||
+      findAnnotationTarget(targets, { field: 'dc:description', lang }) ||
+      findAnnotationTarget(targets, { field: 'dc:subject', lang }) ||
       // TODO: this won't necessarily be the first displayed; make order
       //       configurable by consumer?
-      targets[0];
+      findAnnotationTarget(targets, { lang });
 
   const term = target?.selector.refinedBy.exact['@value'];
-  const lang = target?.selector.refinedBy.exact['@language'];
   const field = target?.selector.hasPredicate;
   const definition = anno.body?.definition?.[lang];
 
   return { definition, field, term };
 };
 
-const parseAnnotations = (annotations) => {
+const parseAnnotations = (annotations, options = {}) => {
   terms.value = {};
   definitions.value = {};
 
@@ -39,7 +45,7 @@ const parseAnnotations = (annotations) => {
     .filter((anno) => (anno.motivation === 'highlighting') && (anno.body?.id.includes('/debias/')));
 
   for (const anno of debiasAnnotations) {
-    const { term, field, definition } = parseAnnotation(anno);
+    const { field, definition, term } = parseAnnotation(anno, options);
 
     if (term && field && definition) {
       terms.value[field] ||= [];
@@ -49,8 +55,8 @@ const parseAnnotations = (annotations) => {
   }
 };
 
-export default function useDeBias(annotations) {
-  annotations && parseAnnotations(annotations);
+export default function useDeBias(options = {}) {
+  options.annotations && parseAnnotations(options.annotations, { lang: options.lang });
 
   return {
     definitionOfTerm,

--- a/packages/portal/src/pages/item/_.vue
+++ b/packages/portal/src/pages/item/_.vue
@@ -595,7 +595,7 @@
           qf: 'motivation:(highlighting OR linkForContributing OR tagging)',
           profile: 'dereference'
         });
-        this.parseDeBiasAnnotations(annotations);
+        this.parseDeBiasAnnotations(annotations, { lang: this.$i18n.locale });
         this.annotations = (annotations || []).filter((anno) => ['linkForContributing', 'tagging'].includes(anno.motivation));
       },
 

--- a/packages/portal/src/pages/item/_.vue
+++ b/packages/portal/src/pages/item/_.vue
@@ -169,6 +169,12 @@
       logEventMixin
     ],
 
+    setup() {
+      const { parseAnnotations: parseDeBiasAnnotations } = useDeBias();
+
+      return { parseDeBiasAnnotations };
+    },
+
     data() {
       return {
         MAX_VALUES_PER_METADATA_FIELD: 10,
@@ -190,12 +196,6 @@
         type: null,
         useProxy: true
       };
-    },
-
-    setup() {
-      const { parseAnnotations: parseDeBiasAnnotations } = useDeBias();
-
-      return { parseDeBiasAnnotations };
     },
 
     async fetch() {

--- a/packages/portal/src/pages/item/_.vue
+++ b/packages/portal/src/pages/item/_.vue
@@ -584,7 +584,7 @@
       async fetchAnnotations() {
         this.annotations = await this.$apis.annotation.search({
           query: `target_record_id:"${this.identifier}"`,
-          qf: 'motivation:(linkForContributing OR tagging)',
+          qf: 'motivation:(highlighting OR linkForContributing OR tagging)',
           profile: 'dereference'
         });
       },

--- a/packages/portal/tests/unit/composables/deBias.spec.js
+++ b/packages/portal/tests/unit/composables/deBias.spec.js
@@ -1,0 +1,67 @@
+import useDeBias from '@/composables/deBias.js';
+
+const annotations = [
+  {
+    id: 'http://example.org/annotation/tagging/1',
+    motivation: 'tagging'
+  },
+  {
+    id: 'http://example.org/annotation/highlighting/1',
+    motivation: 'highlighting'
+  },
+  {
+    id: 'http://example.org/annotation/highlighting/2',
+    motivation: 'highlighting',
+    body: {
+      id: 'http://example.org/vocabulary/debias/1',
+      definition: {
+        en: 'May cause offense'
+      }
+    },
+    target: {
+      selector: { refinedBy: { exact: { '@language': 'en', '@value': 'offensive' } } }
+    }
+  },
+  {
+    id: 'http://example.org/annotation/highlighting/3',
+    motivation: 'highlighting',
+    body: {
+      id: 'http://example.org/vocabulary/debias/2',
+      definition: {
+        en: 'May cause harm'
+      }
+    },
+    target: [
+      { selector: { refinedBy: { exact: { '@language': 'en', '@value': 'harmful' } } } },
+      { selector: { refinedBy: { exact: { '@language': 'en', '@value': 'harmful' } } } }
+    ]
+  }
+];
+
+describe('useDeBias', () => {
+  it('extracts terms to highlight from DeBias annotations', () => {
+    const { termsToHighlight } = useDeBias(annotations);
+
+    expect(termsToHighlight.value).toEqual(['offensive', 'harmful']);
+  });
+
+  describe('highlight', () => {
+    it('removes highlighted term from those to highlight', () => {
+      const { highlight, termsToHighlight } = useDeBias(annotations);
+
+      highlight('offensive');
+
+      expect(termsToHighlight.value).toEqual(['harmful']);
+    });
+  });
+
+  describe('definitionOfTerm', () => {
+    it('gets the term definition', () => {
+      const { definitionOfTerm } = useDeBias(annotations);
+
+      const definition = definitionOfTerm('offensive');
+
+      expect(definition).toBe('May cause offense');
+    });
+  });
+});

--- a/packages/portal/tests/unit/composables/deBias.spec.js
+++ b/packages/portal/tests/unit/composables/deBias.spec.js
@@ -19,7 +19,7 @@ const annotations = [
       }
     },
     target: {
-      selector: { hasPredicate: 'dcTitle', refinedBy: { exact: { '@language': 'en', '@value': 'offensive' } } }
+      selector: { hasPredicate: 'dc:title', refinedBy: { exact: { '@language': 'en', '@value': 'offensive' } } }
     }
   },
   {
@@ -32,8 +32,8 @@ const annotations = [
       }
     },
     target: [
-      { selector: { hasPredicate: 'dcTitle', refinedBy: { exact: { '@language': 'en', '@value': 'harmful' } } } },
-      { selector: { hasPredicate: 'dcDescription', refinedBy: { exact: { '@language': 'en', '@value': 'harmful' } } } }
+      { selector: { hasPredicate: 'dc:title', refinedBy: { exact: { '@language': 'en', '@value': 'harmful' } } } },
+      { selector: { hasPredicate: 'dc:description', refinedBy: { exact: { '@language': 'en', '@value': 'harmful' } } } }
     ]
   },
   {
@@ -46,7 +46,20 @@ const annotations = [
       }
     },
     target: {
-      selector: { hasPredicate: 'dcDescription', refinedBy: { exact: { '@language': 'en', '@value': 'contentious' } } }
+      selector: { hasPredicate: 'dc:description', refinedBy: { exact: { '@language': 'en', '@value': 'contentious' } } }
+    }
+  },
+  {
+    id: 'http://example.org/annotation/highlighting/2',
+    motivation: 'highlighting',
+    body: {
+      id: 'http://example.org/vocabulary/debias/1',
+      definition: {
+        de: 'nein'
+      }
+    },
+    target: {
+      selector: { hasPredicate: 'dc:description', refinedBy: { exact: { '@language': 'de', '@value': 'nein' } } }
     }
   }
 ];
@@ -56,17 +69,17 @@ describe('useDeBias', () => {
     it('extracts terms to highlight from DeBias annotations', () => {
       const { parseAnnotations, terms } = useDeBias();
 
-      parseAnnotations(annotations);
+      parseAnnotations(annotations, { lang: 'en' });
 
       expect(terms.value).toEqual(
-        { dcDescription: ['contentious'], dcTitle: ['offensive', 'harmful'] }
+        { 'dc:description': ['contentious'], 'dc:title': ['offensive', 'harmful'] }
       );
     });
   });
 
   describe('definitionOfTerm', () => {
     it('gets the term definition', () => {
-      const { definitionOfTerm } = useDeBias(annotations);
+      const { definitionOfTerm } = useDeBias({ annotations, lang: 'en' });
 
       const definition = definitionOfTerm('offensive');
 
@@ -76,10 +89,10 @@ describe('useDeBias', () => {
 
   describe('termsToHighlight', () => {
     it('gets field-specific terms to highlight, avoiding duplicates', () => {
-      const { termsToHighlight } = useDeBias(annotations);
+      const { termsToHighlight } = useDeBias({ annotations, lang: 'en' });
 
-      const titleTerms = termsToHighlight('dcTitle');
-      const descriptionTerms = termsToHighlight('dcDescription');
+      const titleTerms = termsToHighlight('dc:title');
+      const descriptionTerms = termsToHighlight('dc:description');
 
       expect(titleTerms).toEqual(['offensive', 'harmful']);
       expect(descriptionTerms).toEqual(['contentious']);

--- a/packages/portal/tests/unit/pages/item/_.spec.js
+++ b/packages/portal/tests/unit/pages/item/_.spec.js
@@ -127,7 +127,7 @@ const fixtures = {
         }
       },
       target: {
-        selector: { refinedBy: { exact: { '@language': 'en', '@value': 'offensive' } } }
+        selector: { hasPredicate: 'dc:title', refinedBy: { exact: { '@language': 'en', '@value': 'offensive' } } }
       }
     }
   ],
@@ -592,7 +592,7 @@ describe('pages/item/_.vue', () => {
 
         factory({ mocks: { $fetchState } });
 
-        expect(termsToHighlight.value).toEqual(['offensive']);
+        expect(termsToHighlight('dcTitle').value).toEqual(['offensive']);
       });
 
       it('fetches entities', () => {

--- a/packages/portal/tests/unit/pages/item/_.spec.js
+++ b/packages/portal/tests/unit/pages/item/_.spec.js
@@ -592,7 +592,7 @@ describe('pages/item/_.vue', () => {
 
         factory({ mocks: { $fetchState } });
 
-        expect(termsToHighlight('dcTitle').value).toEqual(['offensive']);
+        expect(termsToHighlight('dc:title')).toEqual(['offensive']);
       });
 
       it('fetches entities', () => {

--- a/packages/portal/tests/unit/pages/item/_.spec.js
+++ b/packages/portal/tests/unit/pages/item/_.spec.js
@@ -590,7 +590,7 @@ describe('pages/item/_.vue', () => {
       it('parses DeBias annotations via composable', () => {
         const { termsToHighlight } = useDeBias();
 
-        const wrapper = factory({ mocks: { $fetchState } });
+        factory({ mocks: { $fetchState } });
 
         expect(termsToHighlight.value).toEqual(['offensive']);
       });

--- a/packages/portal/tests/unit/pages/item/_.spec.js
+++ b/packages/portal/tests/unit/pages/item/_.spec.js
@@ -566,7 +566,7 @@ describe('pages/item/_.vue', () => {
 
         expect(wrapper.vm.$apis.annotation.search.calledWith({
           query: 'target_record_id:"/123/abc"',
-          qf: 'motivation:(linkForContributing OR tagging)',
+          qf: 'motivation:(highlighting OR linkForContributing OR tagging)',
           profile: 'dereference'
         })).toBe(true);
       });


### PR DESCRIPTION
- create a De-Bias composable for filtering and parsing relevant annotations into highlighted terms and their definition, limiting each term to a single field, and limiting to those with definitions in the supplied language
- initialise this on the item page with the item's annotations and the UI locale
- other child components will then be able to use the composable and detect which terms to highlight for a given field with the method `termsToHighlight('dc:title') // => ['offensive']`, and get their definition with the method `definitionOfTerm('offensive')`