### PR TITLE
refactor: prefer local params over overrides

### DIFF
--- a/packages/portal/src/components/search/SearchInterface.vue
+++ b/packages/portal/src/components/search/SearchInterface.vue
@@ -215,7 +215,7 @@
         type: Boolean,
         default: false
       },
-      overrideParams: {
+      defaultParams: {
         type: Object,
         default: () => ({})
       }
@@ -413,7 +413,7 @@
           rows: this.perPage
         }, isUndefined);
 
-        const params = merge(this.overrideParams, localParams);
+        const params = merge(this.defaultParams, localParams);
 
         if (this.advancedSearchQueryCount > 0) {
           if (this.hasFulltextQa) {

--- a/packages/portal/src/components/search/SearchInterface.vue
+++ b/packages/portal/src/components/search/SearchInterface.vue
@@ -163,6 +163,7 @@
   import isEqual from 'lodash/isEqual.js';
   import isUndefined from 'lodash/isUndefined.js';
   import omitBy from 'lodash/omitBy.js';
+  import uniq from 'lodash/uniq.js';
 
   import ItemPreviewCardGroup from '../item/ItemPreviewCardGroup'; // Sorted before InfoMessage to prevent Conflicting CSS sorting warning
   import InfoMessage from '../generic/InfoMessage';
@@ -434,6 +435,7 @@
         }
 
         params.qf = addContentTierFilter(params.qf);
+        params.qf = uniq(params.qf);
 
         this.apiParams = params;
       },

--- a/packages/portal/src/components/search/SearchInterface.vue
+++ b/packages/portal/src/components/search/SearchInterface.vue
@@ -160,7 +160,9 @@
 <script>
   import ClientOnly from 'vue-client-only';
   import merge from 'deepmerge';
-  import isEqual from 'lodash/isEqual';
+  import isEqual from 'lodash/isEqual.js';
+  import isUndefined from 'lodash/isUndefined.js';
+  import omitBy from 'lodash/omitBy.js';
 
   import ItemPreviewCardGroup from '../item/ItemPreviewCardGroup'; // Sorted before InfoMessage to prevent Conflicting CSS sorting warning
   import InfoMessage from '../generic/InfoMessage';
@@ -399,16 +401,18 @@
       //       `onClickItem`
       // TODO: reduce cognitive complexity
       deriveApiParams() {
-        const params = ['boost', 'qf', 'query', 'reusability', 'sort'].reduce((memo, field) => {
-          if (this[field] && (!Array.isArray(this[field]) || this[field].length > 0)) {
-            memo[field] = this[field];
-          }
-          return memo;
-        }, {});
+        const localParams = omitBy({
+          boost: this.boost,
+          qf: this.qf,
+          query: this.query,
+          reusability: this.reusability,
+          sort: this.sort,
+          page: this.page,
+          profile: 'minimal',
+          rows: this.perPage
+        }, isUndefined);
 
-        params.page = this.page;
-        params.profile = 'minimal';
-        params.rows = this.perPage;
+        const params = merge(this.overrideParams, localParams);
 
         if (this.advancedSearchQueryCount > 0) {
           if (this.hasFulltextQa) {
@@ -431,7 +435,7 @@
 
         params.qf = addContentTierFilter(params.qf);
 
-        this.apiParams = merge(params, this.overrideParams);
+        this.apiParams = params;
       },
 
       // NOTE: do not use computed properties here as they may change when the

--- a/packages/portal/src/pages/collections/_type/_.vue
+++ b/packages/portal/src/pages/collections/_type/_.vue
@@ -17,7 +17,7 @@
         :route="route"
         :show-content-tier-toggle="false"
         :show-pins="userIsEntitiesEditor && userIsSetsEditor"
-        :override-params="searchOverrides"
+        :default-params="searchOverrides"
       >
         <EntityHeader
           v-if="entity"
@@ -172,15 +172,15 @@
         return this.$store.state.entity.entity;
       },
       searchOverrides() {
-        const overrideParams = {};
+        const defaultParams = {};
 
         if (this.entity) {
           const entityQuery = getEntityQuery([this.entity.id].concat(this.entity.sameAs || []));
-          overrideParams.qf = [entityQuery];
-          overrideParams.query = entityQuery; // Triggering best bets.
+          defaultParams.qf = [entityQuery];
+          defaultParams.query = entityQuery; // Triggering best bets.
         }
 
-        return overrideParams;
+        return defaultParams;
       },
       entityId() {
         return normalizeEntityId(this.$route.params.pathMatch);

--- a/packages/portal/src/pages/collections/_type/_.vue
+++ b/packages/portal/src/pages/collections/_type/_.vue
@@ -177,9 +177,7 @@
         if (this.entity) {
           const entityQuery = getEntityQuery([this.entity.id].concat(this.entity.sameAs || []));
           overrideParams.qf = [entityQuery];
-          if (!this.$route.query.query) {
-            overrideParams.query = entityQuery; // Triggering best bets.
-          }
+          overrideParams.query = entityQuery; // Triggering best bets.
         }
 
         return overrideParams;

--- a/packages/portal/src/pages/search/index.vue
+++ b/packages/portal/src/pages/search/index.vue
@@ -5,7 +5,7 @@
   >
     <SearchInterface
       id="search-interface"
-      :override-params="searchOverrides"
+      :default-params="searchOverrides"
     >
       <template
         v-if="!!searchQuery"

--- a/packages/portal/src/pages/search/index.vue
+++ b/packages/portal/src/pages/search/index.vue
@@ -93,7 +93,7 @@
       },
       searchOverrides() {
         const sort = 'score desc,contentTier desc,random_europeana asc,timestamp_update desc,europeana_id asc';
-        return !this.searchQuery && !this.$route.query.sort ? { sort } : {};
+        return this.searchQuery ? {} : { sort };
       }
     },
 

--- a/packages/portal/tests/unit/components/search/SearchInterface.spec.js
+++ b/packages/portal/tests/unit/components/search/SearchInterface.spec.js
@@ -498,10 +498,10 @@ describe('components/search/SearchInterface', () => {
           profile: 'minimal',
           query: 'calais',
           qf: [
+            'edm_agent:"http://data.europeana.eu/agent/200"',
             'TYPE:"IMAGE"',
             'proxy_dc_title:dog',
-            'contentTier:(1 OR 2 OR 3 OR 4)',
-            'edm_agent:"http://data.europeana.eu/agent/200"'
+            'contentTier:(1 OR 2 OR 3 OR 4)'
           ],
           rows: 24
         };

--- a/packages/portal/tests/unit/components/search/SearchInterface.spec.js
+++ b/packages/portal/tests/unit/components/search/SearchInterface.spec.js
@@ -511,7 +511,7 @@ describe('components/search/SearchInterface', () => {
             $route
           },
           propsData: {
-            overrideParams: {
+            defaultParams: {
               qf: [overrideQf]
             }
           }

--- a/packages/portal/tests/unit/pages/search/index.spec.js
+++ b/packages/portal/tests/unit/pages/search/index.spec.js
@@ -21,7 +21,7 @@ const setShowSearchBar = sinon.spy();
 const store = new Vuex.Store({
   state: {
     search: {
-      overrideParams: {
+      defaultParams: {
         query: {}
       },
       showSidebarToggle: false

--- a/packages/portal/tests/unit/pages/search/index.spec.js
+++ b/packages/portal/tests/unit/pages/search/index.spec.js
@@ -53,8 +53,7 @@ const factory = (options = {}) => shallowMountNuxt(page, {
     $features: {},
     $route: {
       query: {
-        query: options.query,
-        sort: options.sort
+        query: options.query
       }
     },
     $fetchState: {},
@@ -117,16 +116,6 @@ describe('pages/item/_.vue', () => {
     describe('when there is an active query', () => {
       it('does NOT include random sorting', () => {
         const wrapper = factory({ query: 'something' });
-
-        const searchOverrides = wrapper.vm.searchOverrides;
-
-        expect(searchOverrides.sort).toBe(undefined);
-      });
-    });
-
-    describe('when there is a custom sort provided', () => {
-      it('does NOT include random sorting', async() => {
-        const wrapper = factory({ sort: 'score desc' });
 
         const searchOverrides = wrapper.vm.searchOverrides;
 


### PR DESCRIPTION
Simplify the handling of overrides vs local params from the user/URL-constructed query by always favouring the latter over the former.