### PR TITLE
perf: selective WebResource construction

### DIFF
--- a/packages/portal/src/pages/item/_.vue
+++ b/packages/portal/src/pages/item/_.vue
@@ -231,7 +231,7 @@
 
     computed: {
       webResources() {
-        return this.media.map((webResource) => new WebResource(webResource, this.identifier));
+        return this.media.map((item) => item instanceof WebResource ? item : new WebResource(item, this.identifier));
       },
       pageMeta() {
         return {


### PR DESCRIPTION
don't create new instances of WebResource if the source is already an instance of it