### PR TITLE
chore: store version in APIs config

### DIFF
--- a/packages/portal/src/features/toggles.js
+++ b/packages/portal/src/features/toggles.js
@@ -4,7 +4,6 @@ export default [
   { name: 'eventLogging' },
   { name: 'jiraServiceDeskFeedbackForm' },
   { name: 'mockTrendingItems' },
-  { name: 'newSetApi' },
   { name: 'rejectEntityRecommendations' },
   { name: 'storiesViewCounts' },
   { name: 'transcribathonCta' },

--- a/packages/portal/src/plugins/europeana/apis/config/context.js
+++ b/packages/portal/src/plugins/europeana/apis/config/context.js
@@ -6,6 +6,7 @@ export default class EuropeanaApiContextConfig {
     this.key = this.keyFromContext(context);
     this.url = this.urlFromContext(context);
     this.urlRewrite = this.urlRewriteFromContext(context);
+    this.version = this.versionFromContext(context);
   }
 
   keyFromContext(context) {
@@ -24,6 +25,10 @@ export default class EuropeanaApiContextConfig {
     } else {
       return context.$config?.europeana?.apis?.[this.id]?.urlRewrite;
     }
+  }
+
+  versionFromContext(context) {
+    return context.$config?.europeana?.apis?.[this.id]?.version;
   }
 
   apiUrlFromRequestHeaders(headers) {

--- a/packages/portal/src/plugins/europeana/apis/config/env.js
+++ b/packages/portal/src/plugins/europeana/apis/config/env.js
@@ -8,6 +8,7 @@ export default class EuropeanaApiEnvConfig {
     this.key = this.keyFromEnv;
     this.url = this.urlFromEnv;
     this.urlRewrite = this.urlRewriteFromEnv;
+    this.version = this.versionFromEnv;
   }
 
   env(prop, { shared = false } = {}) {
@@ -36,13 +37,18 @@ export default class EuropeanaApiEnvConfig {
     return urlRewriteFromEnv;
   }
 
+  get versionFromEnv() {
+    return this.env('version', { shared: false });
+  }
+
   toJSON() {
     return JSON.stringify({
       key: this.key,
       id: this.id,
       scope: this.scope,
       url: this.url,
-      urlRewrite: this.urlRewrite
+      urlRewrite: this.urlRewrite,
+      version: this.version
     });
   }
 }

--- a/packages/portal/tests/unit/plugins/europeana/apis/config/env.spec.js
+++ b/packages/portal/tests/unit/plugins/europeana/apis/config/env.spec.js
@@ -32,8 +32,6 @@ describe('EuropeanaApiEnvConfig', () => {
         });
 
         it('is otherwise undefined', () => {
-          const id = 'record';
-
           const config = new EuropeanaApiEnvConfig(id, scope);
 
           expect(config.url).toBeUndefined();
@@ -90,8 +88,6 @@ describe('EuropeanaApiEnvConfig', () => {
         });
 
         it('is otherwise undefined', () => {
-          const id = 'record';
-
           const config = new EuropeanaApiEnvConfig(id, scope);
 
           expect(config.key).toBeUndefined();
@@ -100,16 +96,38 @@ describe('EuropeanaApiEnvConfig', () => {
     }
   });
 
+  describe('version', () => {
+    for (const scope of scopes) {
+      describe(`when scope is ${scope}`, () => {
+        it('is set from env var EUROPEANA_${ID}_API_VERSION', () => {
+          const version = '2';
+          process.env.EUROPEANA_RECORD_API_VERSION = version;
+
+          const config = new EuropeanaApiEnvConfig(id, scope);
+
+          expect(config.version).toBe(version);
+        });
+
+        it('is otherwise undefined', () => {
+          const config = new EuropeanaApiEnvConfig(id, scope);
+
+          expect(config.version).toBeUndefined();
+        });
+      });
+    }
+  });
+
   describe('toJSON', () => {
-    it('includes key, id, scope & url', () => {
+    it('includes key, id, scope, url & version', () => {
       process.env.EUROPEANA_TEST_API_KEY = 'secret';
       process.env.EUROPEANA_TEST_API_URL = 'https://test.example.org/';
       process.env.EUROPEANA_TEST_API_URL_PRIVATE = 'https://priv.example.org/';
+      process.env.EUROPEANA_TEST_API_VERSION = '2';
       const config = new EuropeanaApiEnvConfig('test', 'private');
 
       const json = config.toJSON();
 
-      expect(json).toBe('{"key":"secret","id":"test","scope":"private","url":"https://test.example.org/","urlRewrite":"https://priv.example.org/"}');
+      expect(json).toBe('{"key":"secret","id":"test","scope":"private","url":"https://test.example.org/","urlRewrite":"https://priv.example.org/","version":"2"}');
     });
   });
 });


### PR DESCRIPTION
so that code within the API client classes can check to see which version of the API they need to work with using `this.config.version`