### PR TITLE
chore: rm redundant item order preservation

### DIFF
--- a/packages/portal/src/store/set.js
+++ b/packages/portal/src/store/set.js
@@ -115,12 +115,7 @@ export default {
 
       // Check if updated set is active set
       if (state.active && (state.active.id === id)) {
-        // Respect reordering of items in update
-        let items = state.active.items;
-        if (response.items) {
-          items = response.items.map(itemId => state.active.items.find(item => itemId.endsWith(item.id)));
-        }
-        commit('setActive', { ...response, items });
+        commit('setActive', { ...state.active, ...response });
       }
     },
     async publish({ state, commit }, id) {

--- a/packages/portal/tests/unit/store/set.spec.js
+++ b/packages/portal/tests/unit/store/set.spec.js
@@ -253,53 +253,24 @@ describe('store/set', () => {
       });
 
       describe('when set is active', () => {
-        describe('and items are in API response', () => {
-          it('commits with "setActive", reordering items', async() => {
-            const activeWas = {
-              ...set,
-              items: [{ id: '1' }, { id: '2' }]
-            };
-            const activeUpdates = {
-              title: { en: 'My set' },
-              items: ['2', '1']
-            };
-            const activeResponse = { id: setId, title: { en: 'My set' }, items: ['2', '1'] };
-            const activeWillBe = {
-              id: setId,
-              items: [{ id: '2' }, { id: '1' }],
-              title: { en: 'My set' }
-            };
-            store.actions.$apis.set.update = sinon.stub().resolves(activeResponse);
-            const state = { active: activeWas };
+        it('commits with "setActive", preserving what has not been updated', async() => {
+          const activeWas = {
+            ...set
+          };
+          const activeUpdates = {
+            title: { en: 'My set' }
+          };
+          const activeResponse = { id: setId, title: { en: 'My set' } };
+          const activeWillBe = {
+            ...set,
+            title: { en: 'My set' }
+          };
+          store.actions.$apis.set.update = sinon.stub().resolves(activeResponse);
+          const state = { active: activeWas };
 
-            await store.actions.update({ commit, state }, { id: setId, activeUpdates });
+          await store.actions.update({ commit, state }, { id: setId, activeUpdates });
 
-            expect(commit.calledWith('setActive', activeWillBe)).toBe(true);
-          });
-        });
-
-        describe('and items are not API response', () => {
-          it('commits with "setActive", preserving items', async() => {
-            const activeWas = {
-              ...set,
-              items: [{ id: '1' }, { id: '2' }]
-            };
-            const activeUpdates = {
-              title: { en: 'My set' }
-            };
-            const activeResponse = { id: setId, title: { en: 'My set' } };
-            const activeWillBe = {
-              id: setId,
-              items: [{ id: '1' }, { id: '2' }],
-              title: { en: 'My set' }
-            };
-            store.actions.$apis.set.update = sinon.stub().resolves(activeResponse);
-            const state = { active: activeWas };
-
-            await store.actions.update({ commit, state }, { id: setId, activeUpdates });
-
-            expect(commit.calledWith('setActive', activeWillBe)).toBe(true);
-          });
+          expect(commit.calledWith('setActive', activeWillBe)).toBe(true);
         });
       });
     });


### PR DESCRIPTION
because items are re-ordered differently now (see #2600)