### PR TITLE
fix: mitigate regression for fetching likes, after like

### DIFF
--- a/packages/portal/src/store/set.js
+++ b/packages/portal/src/store/set.js
@@ -48,7 +48,10 @@ export default {
             return Promise.reject(new Error('100 likes'));
           } else {
             return this.$apis.set.insertItem(state.likesId, itemId)
-              .then(commit('like', itemId));
+              .then(() => {
+                commit('like', itemId);
+                dispatch('fetchLikes');
+              });
           }
         })
         .catch((e) => {


### PR DESCRIPTION
Make sure that liking an item from for example the search page, re-fetches the likes.