### PR TITLE
refactor: compute selected item state from store

### DIFF
--- a/packages/portal/src/components/item/ItemSelectCheckbox.vue
+++ b/packages/portal/src/components/item/ItemSelectCheckbox.vue
@@ -3,7 +3,6 @@
     v-model="selected"
     class="item-select-checkbox position-absolute"
     :class="{ active: selected }"
-    @change="toggleItemSelection"
   >
     <span
       class="m-3 position-relative d-inline-block"
@@ -39,13 +38,21 @@
       }
     },
 
-    data() {
-      return {
-        selected: false
-      };
-    },
-
     computed: {
+      selected: {
+        get() {
+          return this.$store.state.set.selectedItems.includes(this.identifier);
+        },
+
+        set(value) {
+          if (value) {
+            this.$store.commit('set/selectItem', this.identifier);
+          } else {
+            this.$store.commit('set/deselectItem', this.identifier);
+          }
+        }
+      },
+
       selectCheckboxLabel() {
         if (!this.title) {
           return null;
@@ -54,16 +61,6 @@
         } else {
           const langMapValue = langMapValueForLocale(this.title, this.$i18n.locale);
           return truncate(langMapValue.values[0], 90);
-        }
-      }
-    },
-
-    methods: {
-      toggleItemSelection(value) {
-        if (value) {
-          this.$store.commit('set/selectItem', this.identifier);
-        } else {
-          this.$store.commit('set/deselectItem', this.identifier);
         }
       }
     }

--- a/packages/portal/src/store/set.js
+++ b/packages/portal/src/store/set.js
@@ -39,7 +39,9 @@ export default {
       state.active.items.push(item);
     },
     selectItem(state, itemId) {
-      state.selectedItems.push(itemId);
+      if (!state.selectedItems.includes(itemId)) {
+        state.selectedItems.push(itemId);
+      }
     },
     deselectItem(state, itemId) {
       state.selectedItems = state.selectedItems.filter((id) => id !== itemId);

--- a/packages/portal/tests/unit/components/item/ItemSelectCheckbox.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemSelectCheckbox.spec.js
@@ -6,7 +6,7 @@ const localVue = createLocalVue();
 
 const identifier = '/001/record';
 
-const factory = (propsData) => shallowMount(ItemSelectCheckbox, {
+const factory = ({ propsData, store } = {}) => shallowMount(ItemSelectCheckbox, {
   localVue,
   propsData: {
     identifier,
@@ -14,7 +14,15 @@ const factory = (propsData) => shallowMount(ItemSelectCheckbox, {
   },
   mocks: {
     $i18n: { locale: 'en' },
-    $store: { commit: sinon.spy() }
+    $store: {
+      state: {
+        set: {
+          selectedItems: []
+        }
+      },
+      commit: sinon.spy(),
+      ...store
+    }
   },
   stubs: ['b-form-checkbox']
 });
@@ -32,37 +40,62 @@ describe('ItemSelectCheckbox', () => {
 
     describe('when it\'s of type string', () => {
       it('is used for the label', () => {
-        const wrapper = factory({ title });
+        const wrapper = factory({ propsData: { title } });
 
         expect(wrapper.find('b-form-checkbox-stub').text()).toEqual(title);
       });
     });
     describe('when it\'s of type object (is a langmap)', () => {
       it('is used for the label', () => {
-        const wrapper = factory({ title: titleLangMap });
+        const wrapper = factory({ propsData: { title: titleLangMap } });
 
         expect(wrapper.find('b-form-checkbox-stub').text()).toEqual(title);
       });
     });
   });
 
-  describe('toggleItemSelection', () => {
-    describe('when value is true', () => {
-      it('commits selectItem to the set store', () => {
-        const wrapper = factory();
-
-        wrapper.vm.toggleItemSelection(true);
-
-        expect(wrapper.vm.$store.commit.calledWith('set/selectItem', identifier)).toBe(true);
+  describe('computed', () => {
+    describe('selected', () => {
+      describe('get', () => {
+        describe('when the identifier exists in the store', () => {
+          it('returns true', () => {
+            const store = {
+              state: {
+                set: {
+                  selectedItems: [identifier]
+                }
+              }
+            };
+            const wrapper = factory({ store });
+            expect(wrapper.vm.selected).toBe(true);
+          });
+        });
+        describe('when the identifier is NOT in the store', () => {
+          it('returns false', () => {
+            const wrapper = factory();
+            expect(wrapper.vm.selected).toBe(false);
+          });
+        });
       });
-    });
-    describe('when value is false', () => {
-      it('commits deselectItem to the set store', () => {
-        const wrapper = factory();
+      describe('set', () => {
+        describe('when passed value is true', () => {
+          it('commits selectItem to the set store', () => {
+            const wrapper = factory();
 
-        wrapper.vm.toggleItemSelection(false);
+            wrapper.vm.selected = true;
 
-        expect(wrapper.vm.$store.commit.calledWith('set/deselectItem', identifier)).toBe(true);
+            expect(wrapper.vm.$store.commit.calledWith('set/selectItem', identifier)).toBe(true);
+          });
+        });
+        describe('when passed value is false', () => {
+          it('commits deselectItem to the set store', () => {
+            const wrapper = factory();
+
+            wrapper.vm.selected = false;
+
+            expect(wrapper.vm.$store.commit.calledWith('set/deselectItem', identifier)).toBe(true);
+          });
+        });
       });
     });
   });

--- a/packages/portal/tests/unit/store/set.spec.js
+++ b/packages/portal/tests/unit/store/set.spec.js
@@ -82,6 +82,14 @@ describe('store/set', () => {
         store.mutations.selectItem(state, newItem);
         expect(state.selectedItems).toEqual([newItem]);
       });
+      describe('when item is already selected', () => {
+        it('does not add to the selected items state again', () => {
+          const newItem = 'item001';
+          const state = { selectedItems: ['item001'] };
+          store.mutations.selectItem(state, newItem);
+          expect(state.selectedItems).toEqual(['item001']);
+        });
+      });
     });
     describe('deselectItemToActive()', () => {
       it('removes an item from the selected items state', () => {


### PR DESCRIPTION
Always bases the selected state on the store by making it a computed property.
In order to continue using v-model on the `b-form-checkbox` add a setter to the computed property.
As a result the separate `toggleItemSelection` method isn't needed anymore.

Also added a validation to the set store to not allow the same ID be selected twice.