### PR TITLE
feat: disable item action buttons if no identifiers

### DIFF
--- a/packages/portal/src/components/item/ItemAddButton.vue
+++ b/packages/portal/src/components/item/ItemAddButton.vue
@@ -6,6 +6,7 @@
       class="add-button text-uppercase d-inline-flex align-items-center"
       :class="{ 'button-icon-only': !buttonText }"
       data-qa="add button"
+      :disabled="disabled"
       :variant="buttonVariant"
       :aria-label="tooltipTitle"
       @click="addToSet"
@@ -100,8 +101,11 @@
     },
 
     computed: {
+      disabled() {
+        return this.selectionCount === 0;
+      },
       selectionCount() {
-        return Array.isArray(this.identifiers) ? this.identifiers.length : false;
+        return Array.isArray(this.identifiers) ? this.identifiers.length : 1;
       },
       tooltipTitle() {
         return this.$tc(`set.actions.addItems.${this.cardinality}`, this.selectionCount, { count: this.selectionCount });

--- a/packages/portal/src/components/item/ItemLikeButton.vue
+++ b/packages/portal/src/components/item/ItemLikeButton.vue
@@ -5,6 +5,7 @@
       class="like-button text-uppercase d-inline-flex align-items-center"
       :class="{ 'button-icon-only': !buttonText }"
       :pressed="liked"
+      :disabled="disabled"
       :variant="buttonVariant"
       data-qa="like button"
       :aria-label="liked ? $t('actions.unlike') : $t('actions.like')"
@@ -79,6 +80,9 @@
     },
 
     computed: {
+      disabled() {
+        return this.selectionCount === 0;
+      },
       liked() {
         if (Array.isArray(this.identifiers)) {
           return this.identifiers.every((id) => this.$store.state.set.likedItemIds.includes(id));
@@ -99,7 +103,7 @@
         return this.$tc(`set.notifications.itemsLiked.${this.cardinality}`, this.selectionCount, { count: this.selectionCount });
       },
       selectionCount() {
-        return Array.isArray(this.identifiers) ? this.identifiers.length : false;
+        return Array.isArray(this.identifiers) ? this.identifiers.length : 1;
       },
       tooltipTitle() {
         if (this.liked) {

--- a/packages/portal/src/components/item/ItemRemoveButton.vue
+++ b/packages/portal/src/components/item/ItemRemoveButton.vue
@@ -4,6 +4,7 @@
       v-b-tooltip.bottom
       class="remove-button text-uppercase d-inline-flex align-items-center"
       :class="{ 'button-icon-only': !buttonText }"
+      :disabled="disabled"
       :variant="buttonVariant"
       data-qa="item remove button"
       :aria-label="$t('actions.remove')"
@@ -55,11 +56,14 @@
     },
 
     computed: {
+      disabled() {
+        return this.selectionCount === 0;
+      },
       activeSet() {
         return this.$store.state.set.active;
       },
       selectionCount() {
-        return Array.isArray(this.identifiers) ? this.identifiers.length : false;
+        return Array.isArray(this.identifiers) ? this.identifiers.length : 1;
       },
       tooltipTitle() {
         return this.$tc(`set.actions.removeItems.${this.cardinality}`, this.selectionCount, { count: this.selectionCount });

--- a/packages/portal/tests/unit/components/item/ItemAddButton.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemAddButton.spec.js
@@ -109,6 +109,14 @@ describe('components/item/ItemAddButton', () => {
         });
       });
     });
+
+    it('is disabled if there are no item identifiers', () => {
+      const wrapper = factory({ propsData: { identifiers: [] } });
+
+      const addButton = wrapper.find('[data-qa="add button"]');
+
+      expect(addButton.attributes('disabled')).toBe('disabled');
+    });
   });
 
   describe('data()', () => {

--- a/packages/portal/tests/unit/components/item/ItemLikeButton.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemLikeButton.spec.js
@@ -181,47 +181,53 @@ describe('components/item/ItemLikeButton', () => {
           });
         });
       });
+    });
 
-      describe('data()', () => {
-        describe('likeLimitModalId', () => {
-          describe('when there are multiple items selected', () => {
-            it('ends with "multi-select"', () => {
-              const wrapper = factory({
-                propsData: { identifiers: ['001', '002', '003'] }
-              });
+    it('is disabled if there are no item identifiers', () => {
+      const wrapper = factory({ propsData: { identifiers: [] } });
 
-              expect(wrapper.vm.likeLimitModalId).toEqual('like-limit-modal-multi-select');
-            });
+      const likeButton = wrapper.find('[data-qa="like button"]');
+
+      expect(likeButton.attributes('disabled')).toBe('true');
+    });
+  });
+
+  describe('data()', () => {
+    describe('likeLimitModalId', () => {
+      describe('when there are multiple items selected', () => {
+        it('ends with "multi-select"', () => {
+          const wrapper = factory({
+            propsData: { identifiers: ['001', '002', '003'] }
           });
+
+          expect(wrapper.vm.likeLimitModalId).toEqual('like-limit-modal-multi-select');
         });
       });
+    });
+  });
 
-      describe('computed', () => {
-        describe('liked()', () => {
-          describe('when there are multiple items selected', () => {
-            describe('and all are already liked', () => {
-              it('returns true', () => {
-                const ids = ['001', '002'];
-                const wrapper = factory({
-                  propsData: { identifiers: ids },
-                  storeState: { likedItemIds: ids },
-                  $auth
-                });
-
-                expect(wrapper.vm.liked).toBe(true);
-              });
+  describe('computed', () => {
+    describe('liked()', () => {
+      describe('when there are multiple items selected', () => {
+        describe('and all are already liked', () => {
+          it('returns true', () => {
+            const ids = ['001', '002'];
+            const wrapper = factory({
+              propsData: { identifiers: ids },
+              storeState: { likedItemIds: ids }
             });
-            describe('and only some are already liked', () => {
-              it('returns false', () => {
-                const wrapper = factory({
-                  propsData: { identifiers: ['001', '002', '003'] },
-                  storeState: { likedItemIds: ['001', '003'] },
-                  $auth
-                });
 
-                expect(wrapper.vm.liked).toBe(false);
-              });
+            expect(wrapper.vm.liked).toBe(true);
+          });
+        });
+        describe('and only some are already liked', () => {
+          it('returns false', () => {
+            const wrapper = factory({
+              propsData: { identifiers: ['001', '002', '003'] },
+              storeState: { likedItemIds: ['001', '003'] }
             });
+
+            expect(wrapper.vm.liked).toBe(false);
           });
         });
       });

--- a/packages/portal/tests/unit/components/item/ItemRemoveButton.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemRemoveButton.spec.js
@@ -59,4 +59,12 @@ describe('ItemRemoveButton', () => {
     expect(wrapper.vm.$store.dispatch.calledWith('set/refreshSet')).toBe(true);
     expect(wrapper.vm.makeToast.calledWith('set.notifications.itemsRemoved.one')).toBe(true);
   });
+
+  it('is disabled if there are no item identifiers', () => {
+    const wrapper = factory({ identifiers: [] });
+
+    const button = wrapper.find('[data-qa="item remove button"]');
+
+    expect(button.attributes('disabled')).toBe('true');
+  });
 });


### PR DESCRIPTION
because there is nothing to do