### PR TITLE
refactor: only render SetAddItemModal when needed

### DIFF
--- a/packages/portal/src/components/item/ItemAddButton.vue
+++ b/packages/portal/src/components/item/ItemAddButton.vue
@@ -28,12 +28,13 @@
       v-if="$auth.loggedIn"
     >
       <SetAddItemModal
+        v-if="showAddItemModal"
+        v-model="showAddItemModal"
         data-qa="add item to set modal"
-        :modal-id="addItemToSetModalId"
         :item-ids="identifiers"
         :new-set-created="newSetCreated"
         @clickCreateSet="clickCreateSet"
-        @hideModal="handleHideModal"
+        @input="handleModalInput"
       />
       <SetFormModal
         :modal-id="setFormModalId"
@@ -90,12 +91,12 @@
       const idSuffix = Array.isArray(this.identifiers) ? 'multi-select' : this.identifiers;
 
       return {
-        addItemToSetModalId: `add-item-to-set-modal-${idSuffix}`,
-        setFormModalId: `set-form-modal-${idSuffix}`,
-        showFormModal: false,
+        idSuffix,
         newSetCreated: false,
-        showTooltip: false,
-        idSuffix
+        setFormModalId: `set-form-modal-${idSuffix}`,
+        showAddItemModal: false,
+        showFormModal: false,
+        showTooltip: false
       };
     },
 
@@ -113,14 +114,14 @@
         if (this.showFormModal === false) {
           this.showFormModal = true;
           this.newSetCreated = false;
-          this.$bvModal.hide(this.addItemToSetModalId);
+          this.showAddItemModal = false;
           this.$bvModal.show(this.setFormModalId);
         }
       },
       setCreatedOrUpdated() {
         this.showFormModal = false;
         this.newSetCreated = true;
-        this.$bvModal.show(this.addItemToSetModalId);
+        this.showAddItemModal = true;
       },
       refreshSet() {
         if (!this.showFormModal) {
@@ -130,7 +131,7 @@
       addToSet() {
         if (this.$auth.loggedIn) {
           this.showTooltip = false; // Fix for touch devices that keep the tooltip open, overlaying the modal
-          this.$bvModal.show(this.addItemToSetModalId);
+          this.showAddItemModal = true;
           // TODO: how to track multi-select?
           if (!Array.isArray(this.identifiers)) {
             this.$matomo?.trackEvent('Item_add', 'Click add item button', this.identifiers);
@@ -139,12 +140,15 @@
           this.$keycloak.login();
         }
       },
-      async handleHideModal() {
-        this.refreshSet();
-        // Sets focus back to the toggle button, as this functionality is lost when opening the SetFormModal.
-        this.$refs.itemAddButton.focus();
-        // Do not show the tooltip when focus returns to button.
-        this.showTooltip = false;
+      handleModalInput(value) {
+        this.showAddItemModal = value;
+        if (!value) {
+          this.refreshSet();
+          // Sets focus back to the toggle button, as this functionality is lost when opening the SetFormModal.
+          this.$refs.itemAddButton.focus();
+          // Do not show the tooltip when focus returns to button.
+          this.showTooltip = false;
+        }
       }
     }
   };

--- a/packages/portal/src/components/set/SetAddItemModal.vue
+++ b/packages/portal/src/components/set/SetAddItemModal.vue
@@ -1,10 +1,10 @@
 <template>
   <b-modal
-    :id="modalId"
+    v-model="show"
+    :static="modalStatic"
     :title="modalTitle"
     hide-footer
     hide-header-close
-    :static="modalStatic"
     @show="fetchCollections"
     @hide="hideModal"
   >
@@ -35,7 +35,7 @@
       <b-button
         variant="outline-primary"
         data-qa="close button"
-        @click="$bvModal.hide(modalId)"
+        @click="hideModal"
       >
         {{ $t('actions.close') }}
       </b-button>
@@ -67,15 +67,15 @@
         type: [String, Array],
         required: true
       },
-      modalId: {
-        type: String,
-        default: 'add-item-to-set-modal'
-      },
       modalStatic: {
         type: Boolean,
         default: false
       },
       newSetCreated: {
+        type: Boolean,
+        default: false
+      },
+      value: {
         type: Boolean,
         default: false
       }
@@ -89,10 +89,11 @@
 
     data() {
       return {
+        added: [],
         collections: [],
         collectionsWithItem: [],
         fetched: false,
-        added: []
+        show: this.value
       };
     },
 
@@ -110,6 +111,9 @@
         if (newVal) {
           this.added.push(this.collectionsWithItem[0]);
         }
+      },
+      value() {
+        this.show = this.value;
       }
     },
 
@@ -148,7 +152,7 @@
         this.$nextTick(() => {
           this.fetched = false;
           this.added = [];
-          this.$emit('hideModal');
+          this.$emit('input', false);
         });
       },
 

--- a/packages/portal/tests/unit/components/set/SetAddItemModal.spec.js
+++ b/packages/portal/tests/unit/components/set/SetAddItemModal.spec.js
@@ -54,7 +54,7 @@ describe('components/set/SetAddItemModal', () => {
   describe('template', () => {
     describe('create set button', () => {
       it('emits "clickCreateSet" event', () => {
-        const propsData = { itemIds: '/123/abc', modalId: 'add-item-to-set-modal-/123/abc' };
+        const propsData = { itemIds: '/123/abc' };
         const wrapper = factory({ propsData });
         wrapper.find('[data-qa="create new gallery button"]').trigger('click');
 
@@ -63,20 +63,19 @@ describe('components/set/SetAddItemModal', () => {
     });
 
     describe('close button', () => {
-      it('hides the modal', () => {
-        const propsData = { itemIds: '/123/abc', modalId: 'add-item-to-set-modal-/123/abc' };
+      it('emits input event with value false', async() => {
+        const propsData = { itemIds: '/123/abc' };
         const wrapper = factory({ propsData });
-        const bvModalHide = sinon.spy(wrapper.vm.$bvModal, 'hide');
 
-        wrapper.find('[data-qa="close button"]').trigger('click');
+        await wrapper.find('[data-qa="close button"]').trigger('click');
 
-        expect(bvModalHide.calledWith('add-item-to-set-modal-/123/abc')).toBe(true);
+        expect(wrapper.emitted('input')[0]).toEqual([false]);
       });
     });
 
     describe('toggle item button', () => {
       it('adds item to gallery when item is not yet added', async() => {
-        const propsData = { itemIds: '/123/abc', modalId: 'add-item-to-set-modal-/123/abc' };
+        const propsData = { itemIds: '/123/abc' };
         const data = { fetched: true, collections: sets };
         const wrapper = factory({ propsData, data });
 
@@ -87,7 +86,7 @@ describe('components/set/SetAddItemModal', () => {
       });
 
       it('removes item from gallery when item already added', async() => {
-        const propsData = { itemIds: '/000/aaa', modalId: 'add-item-to-set-modal-/000/aaa' };
+        const propsData = { itemIds: '/000/aaa' };
         const data = { fetched: true, collections: sets, collectionsWithItem: ['001'] };
         const wrapper = factory({ propsData, data });
 


### PR DESCRIPTION
to prevent numerous hidden instances, e.g. on gallery pages