### PR TITLE
feat: create skeleton API keys page

### DIFF
--- a/packages/portal/src/components/user/UserHeader.vue
+++ b/packages/portal/src/components/user/UserHeader.vue
@@ -42,3 +42,15 @@
     }
   };
 </script>
+
+<style lang="scss" scoped>
+  @import '@europeana/style/scss/variables';
+
+  h1 {
+    margin-bottom: 0.75rem;
+
+    @media (min-width: $bp-4k) {
+      margin-bottom: calc(1.5 * 0.75rem);
+    }
+  }
+</style>

--- a/packages/portal/src/components/user/UserHeader.vue
+++ b/packages/portal/src/components/user/UserHeader.vue
@@ -1,0 +1,44 @@
+<template>
+  <b-row>
+    <b-col class="pb-4">
+      <h1 class="text-center">
+        @{{ loggedInUser?.preferred_username }}
+      </h1>
+      <div class="text-center">
+        <b-button
+          class="mr-1 text-decoration-none d-inline-flex align-items-center"
+          :href="editProfileUrl"
+          data-qa="edit profile button"
+        >
+          <span class="icon-edit pr-1" />
+          {{ $t('account.editProfile') }}
+        </b-button>
+        <b-button
+          to="/account/logout"
+          class="text-decoration-none"
+          data-qa="logout button"
+        >
+          {{ $t('account.linkLogout') }}
+        </b-button>
+      </div>
+    </b-col>
+  </b-row>
+</template>
+
+<script>
+  export default {
+    name: 'UserHeader',
+
+    data() {
+      return {
+        loggedInUser: this.$store?.state?.auth?.user
+      };
+    },
+
+    computed: {
+      editProfileUrl() {
+        return this.$keycloak?.accountUrl();
+      }
+    }
+  };
+</script>

--- a/packages/portal/src/i18n/lang/en.js
+++ b/packages/portal/src/i18n/lang/en.js
@@ -81,6 +81,9 @@ export default {
     "viewDocument": "View document",
     "vote": "Vote"
   },
+  "apiKeys": {
+    "title": "Manage API keys"
+  },
   "attribution": {
     "country": "Country:",
     "creator": "Creator:",

--- a/packages/portal/src/pages/account/api-keys.vue
+++ b/packages/portal/src/pages/account/api-keys.vue
@@ -1,0 +1,52 @@
+<template>
+  <div
+    class="xxl-page page"
+  >
+    <b-container fluid>
+      <UserHeader />
+      <b-row>
+        <b-col class="p-0 mb-3">
+          <b-container>
+            <b-row>
+              <b-col>
+                <hr>
+                <NuxtLink
+                  :to="localePath('/account')"
+                >
+                  🡠 {{ $t('account.title') }}
+                </NuxtLink>
+              </b-col>
+            </b-row>
+          </b-container>
+        </b-col>
+      </b-row>
+    </b-container>
+  </div>
+</template>
+
+<script>
+  import UserHeader from '@/components/user/UserHeader';
+  import pageMetaMixin from '@/mixins/pageMeta';
+
+  export default {
+    name: 'AccountAPIKeysPage',
+
+    components: {
+      UserHeader
+    },
+
+    mixins: [
+      pageMetaMixin
+    ],
+
+    middleware: 'auth',
+
+    computed: {
+      pageMeta() {
+        return {
+          title: this.$t('apiKeys.title')
+        };
+      }
+    }
+  };
+</script>

--- a/packages/portal/src/pages/account/index.vue
+++ b/packages/portal/src/pages/account/index.vue
@@ -4,28 +4,7 @@
     class="xxl-page page"
   >
     <b-container fluid>
-      <b-row>
-        <b-col class="pb-4">
-          <h1 class="text-center">
-            @{{ loggedInUser && loggedInUser.preferred_username }}
-          </h1>
-          <div class="text-center">
-            <b-button
-              class="mr-1 text-decoration-none d-inline-flex align-items-center"
-              :href="editProfileUrl"
-            >
-              <span class="icon-edit pr-1" />
-              {{ $t('account.editProfile') }}
-            </b-button>
-            <b-button
-              to="/account/logout"
-              class="text-decoration-none"
-            >
-              {{ $t('account.linkLogout') }}
-            </b-button>
-          </div>
-        </b-col>
-      </b-row>
+      <UserHeader />
       <b-row>
         <b-col class="p-0 mb-3">
           <b-container>
@@ -145,6 +124,7 @@
   import pageMetaMixin from '@/mixins/pageMeta';
   import AlertMessage from '@/components/generic/AlertMessage';
   import ItemPreviewInterface from '@/components/item/ItemPreviewInterface';
+  import UserHeader from '@/components/user/UserHeader';
   import UserSets from '@/components/user/UserSets';
 
   export default {
@@ -155,6 +135,7 @@
       BNav,
       ClientOnly,
       ItemPreviewInterface,
+      UserHeader,
       UserSets
     },
 
@@ -171,7 +152,6 @@
 
     data() {
       return {
-        loggedInUser: this.$store.state.auth.user,
         tabHashes: {
           likes: '#likes',
           publicGalleries: '#public-galleries',

--- a/packages/portal/src/pages/account/index.vue
+++ b/packages/portal/src/pages/account/index.vue
@@ -204,14 +204,6 @@
   @import '@europeana/style/scss/variables';
   @import '@europeana/style/scss/tabs';
 
-  h1 {
-    margin-bottom: 0.75rem;
-
-    @media (min-width: $bp-4k) {
-      margin-bottom: calc(1.5 * 0.75rem);
-    }
-  }
-
   .nav-tabs {
     margin-bottom: 2.5rem;
 

--- a/packages/portal/tests/unit/components/user/UserHeader.spec.js
+++ b/packages/portal/tests/unit/components/user/UserHeader.spec.js
@@ -1,0 +1,48 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import UserHeader from '@/components/user/UserHeader';
+
+const localVue = createLocalVue();
+
+const accountUrl = 'https://keycloak.example.org/account';
+
+const factory = ({ mocks = {} } = {}) => shallowMount(UserHeader, {
+  localVue,
+  mocks: {
+    $keycloak: { accountUrl: () => accountUrl },
+    $store: { state: { auth: { user: {} } } },
+    $t: (key) => key,
+    ...mocks
+  },
+  stubs: [
+    'b-button',
+    'b-col',
+    'b-row'
+  ]
+});
+
+describe('components/user/UserHeader', () => {
+  it('shows the logged in username as the h1 text, prefixed with @', () => {
+    const mocks = { $store: { state: { auth: { user: { 'preferred_username': 'me' } } } } };
+    const wrapper = factory({ mocks });
+
+    const h1 = wrapper.find('h1');
+
+    expect(h1.text()).toBe('@me');
+  });
+
+  it('shows an edit profile button linking to keycloak account URL', () => {
+    const wrapper = factory();
+
+    const button = wrapper.find('[data-qa="edit profile button"]');
+
+    expect(button.attributes('href')).toBe(accountUrl);
+  });
+
+  it('shows a logout button linking to app logout URL', () => {
+    const wrapper = factory();
+
+    const button = wrapper.find('[data-qa="logout button"]');
+
+    expect(button.attributes('to')).toBe('/account/logout');
+  });
+});

--- a/packages/portal/tests/unit/pages/account/api-keys.spec.js
+++ b/packages/portal/tests/unit/pages/account/api-keys.spec.js
@@ -1,0 +1,39 @@
+import { createLocalVue } from '@vue/test-utils';
+import { shallowMountNuxt } from '../../utils';
+import AccountAPIKeysPage from '@/pages/account/api-keys';
+
+const localVue = createLocalVue();
+
+const factory = ({ mocks = {} } = {}) => shallowMountNuxt(AccountAPIKeysPage, {
+  localVue,
+  mocks: {
+    localePath: (path) => path,
+    $t: (key) => key,
+    ...mocks
+  },
+  stubs: [
+    'b-col',
+    'b-container',
+    'b-row',
+    'NuxtLink'
+  ]
+});
+
+describe('pages/account/api-keys', () => {
+  it('shows the user header', () => {
+    const wrapper = factory();
+
+    const userHeader = wrapper.find('UserHeader-stub');
+
+    expect(userHeader.isVisible()).toBe(true);
+  });
+
+  it('has a link back to the account page', () => {
+    const wrapper = factory();
+
+    const nuxtLink = wrapper.find('NuxtLink-stub');
+
+    expect(nuxtLink.attributes('to')).toBe('/account');
+    expect(nuxtLink.text()).toBe('🡠 account.title');
+  });
+});


### PR DESCRIPTION
- move top section from my account page into new UserHeader component
- create skeleton api keys page at /account/api-keys, showing UserHeader and link back to my account page