### PR TITLE
feat: create auth service API plugin

### DIFF
--- a/packages/portal/src/pages/account/api-keys.vue
+++ b/packages/portal/src/pages/account/api-keys.vue
@@ -17,6 +17,32 @@
                 </NuxtLink>
               </b-col>
             </b-row>
+            <b-row>
+              <b-col>
+                <LoadingSpinner
+                  v-if="$fetchState.pending"
+                  class="text-center pb-4"
+                />
+                <AlertMessage
+                  v-else-if="$fetchState.error"
+                  :error="$fetchState.error.message"
+                />
+                <template v-else>
+                  <h2>API keys</h2>
+                  <ol v-if="apiKeys.length > 0">
+                    <li
+                      v-for="apiKey in apiKeys"
+                      :key="apiKey.id"
+                    >
+                      {{ apiKey['client_id'] }}
+                    </li>
+                  </ol>
+                  <p v-else>
+                    You have no API keys.
+                  </p>
+                </template>
+              </b-col>
+            </b-row>
           </b-container>
         </b-col>
       </b-row>
@@ -25,6 +51,8 @@
 </template>
 
 <script>
+  import AlertMessage from '@/components/generic/AlertMessage';
+  import LoadingSpinner from '@/components/generic/LoadingSpinner';
   import UserHeader from '@/components/user/UserHeader';
   import pageMetaMixin from '@/mixins/pageMeta';
 
@@ -32,6 +60,8 @@
     name: 'AccountAPIKeysPage',
 
     components: {
+      AlertMessage,
+      LoadingSpinner,
       UserHeader
     },
 
@@ -40,6 +70,16 @@
     ],
 
     middleware: 'auth',
+
+    data() {
+      return {
+        apiKeys: []
+      };
+    },
+
+    async fetch() {
+      this.apiKeys = await this.$apis.auth.getUserClients();
+    },
 
     computed: {
       pageMeta() {

--- a/packages/portal/src/plugins/europeana-apis.js
+++ b/packages/portal/src/plugins/europeana-apis.js
@@ -4,6 +4,7 @@
 import EuropeanaApiEnvConfig from './europeana/apis/config/env.js';
 
 import annotation from './europeana/annotation.js';
+import auth from './europeana/auth.js';
 import entity from './europeana/entity.js';
 import entityManagement from './europeana/entity-management.js';
 import fulltext from './europeana/fulltext.js';
@@ -18,6 +19,7 @@ const MODULE_NAME = 'apis';
 
 export const APIS = {
   annotation,
+  auth,
   entity,
   entityManagement,
   fulltext,

--- a/packages/portal/src/plugins/europeana/auth.js
+++ b/packages/portal/src/plugins/europeana/auth.js
@@ -1,0 +1,15 @@
+import EuropeanaApi from './apis/base.js';
+
+export default class EuropeanaAuthApi extends EuropeanaApi {
+  static ID = 'auth';
+  static BASE_URL = 'https://auth.europeana.eu';
+  // static AUTHENTICATING = true;
+  static AUTHORISING = true;
+
+  getUserClients() {
+    return this.request({
+      method: 'get',
+      url: '/auth/realms/europeana/user/clients'
+    });
+  }
+}

--- a/packages/portal/tests/unit/pages/account/api-keys.spec.js
+++ b/packages/portal/tests/unit/pages/account/api-keys.spec.js
@@ -1,5 +1,7 @@
 import { createLocalVue } from '@vue/test-utils';
 import { shallowMountNuxt } from '../../utils';
+import sinon from 'sinon';
+
 import AccountAPIKeysPage from '@/pages/account/api-keys';
 
 const localVue = createLocalVue();
@@ -20,6 +22,9 @@ const factory = ({ mocks = {} } = {}) => shallowMountNuxt(AccountAPIKeysPage, {
 });
 
 describe('pages/account/api-keys', () => {
+  afterEach(sinon.resetHistory);
+  afterAll(sinon.restore);
+
   it('shows the user header', () => {
     const wrapper = factory();
 
@@ -35,5 +40,35 @@ describe('pages/account/api-keys', () => {
 
     expect(nuxtLink.attributes('to')).toBe('/account');
     expect(nuxtLink.text()).toBe('🡠 account.title');
+  });
+
+  describe('fetch', () => {
+    const apiKeys = [{ 'client_id': 'myKey', id: 'api-key-id', type: 'PersonalKey' }];
+    const getUserClientsStub = sinon.stub().resolves(apiKeys);
+    const mocks = { $apis: { auth: { getUserClients: getUserClientsStub } } };
+
+    it('requests the user clients from the auth service', async() => {
+      const wrapper = factory({ mocks });
+
+      await wrapper.vm.$fetch();
+
+      expect(getUserClientsStub.called).toBe(true);
+    });
+
+    it('stores the API keys in apiKeys', async() => {
+      const wrapper = factory({ mocks });
+
+      await wrapper.vm.$fetch();
+
+      expect(wrapper.vm.apiKeys).toEqual(apiKeys);
+    });
+
+    it('displays the API keys', async() => {
+      const wrapper = factory({ mocks });
+
+      await wrapper.vm.$fetch();
+
+      expect(wrapper.html()).toContain(apiKeys[0]['client_id']);
+    });
   });
 });

--- a/packages/portal/tests/unit/plugins/europeana/auth.spec.js
+++ b/packages/portal/tests/unit/plugins/europeana/auth.spec.js
@@ -1,0 +1,29 @@
+import nock from 'nock';
+
+import auth from '@/plugins/europeana/auth';
+
+describe('plugins/europeana/auth', () => {
+  beforeAll(() => {
+    nock.disableNetConnect();
+  });
+  afterEach(() => {
+    nock.cleanAll();
+  });
+  afterAll(() => {
+    nock.enableNetConnect();
+  });
+
+  describe('getUserClients', () => {
+    it('gets the user clients from the auth service', async() => {
+      const apiKeys = [{ 'client_id': 'myKey', id: 'api-key-id', type: 'PersonalKey' }];
+      nock(auth.BASE_URL)
+        .get('/auth/realms/europeana/user/clients')
+        .reply(200, apiKeys);
+
+      const response = await (new auth).getUserClients();
+
+      expect(nock.isDone()).toBe(true);
+      expect(response).toEqual(apiKeys);
+    });
+  });
+});


### PR DESCRIPTION
and implement fetching & display of user's API keys

Configure with:
```
EUROPEANA_AUTH_API_URL=https://keycloak.acceptance.eanadev.org
```

(This duplicates the OAUTH_ORIGIN setting and will need to be kept aligned for now, which should be refactored.)