### PR TITLE
fix: multilingual search and item select tooltip handling

### DIFF
--- a/packages/portal/src/components/item/ItemSelectButton.vue
+++ b/packages/portal/src/components/item/ItemSelectButton.vue
@@ -39,6 +39,7 @@
       return {
         buttonId: 'item-select-button',
         selected: false,
+        // Use custom showTooltip instead of hideTooltips composable for touch devices that keep the tooltip open when selected state is changed
         showTooltip: false,
         tooltipId: 'item-select-button-tooltip'
       };
@@ -71,7 +72,7 @@
         }
       },
       toggle() {
-        this.showTooltip = false; // Fix for touch devices that keep the tooltip open, overlaying the modal
+        this.showTooltip = false;
         if (this.$auth.loggedIn) {
           this.selected = !this.selected;
           this.$emit('select', this.selected);

--- a/packages/portal/src/components/item/ItemSelectButton.vue
+++ b/packages/portal/src/components/item/ItemSelectButton.vue
@@ -7,8 +7,10 @@
       variant="light-flat"
       :aria-label="ariaLabelText"
       @click="toggle"
-      @mouseleave="$root.$emit('bv::hide::tooltip', tooltipId);"
-      @focusout="hideTooltips"
+      @mouseleave="showTooltip = false"
+      @focusout="showTooltip = false"
+      @focus="showTooltip = true"
+      @mouseover="showTooltip = true"
     >
       <span
         :class="{
@@ -20,7 +22,9 @@
     <b-tooltip
       :id="tooltipId"
       placement="bottom"
+      :show.sync="showTooltip"
       :target="buttonId"
+      @show="(e) => { if (!showTooltip) { e.preventDefault() } } "
     >
       {{ tooltipText }}
     </b-tooltip>
@@ -28,22 +32,14 @@
 </template>
 
 <script>
-  import useHideTooltips from '@/composables/hideTooltips.js';
-
   export default {
     name: 'ItemSelectButton',
 
-    setup() {
-      const buttonId = 'item-select-button';
-
-      const { hideTooltips } = useHideTooltips(buttonId);
-
-      return { buttonId, hideTooltips };
-    },
-
     data() {
       return {
+        buttonId: 'item-select-button',
         selected: false,
+        showTooltip: false,
         tooltipId: 'item-select-button-tooltip'
       };
     },
@@ -75,7 +71,7 @@
         }
       },
       toggle() {
-        this.hideTooltips();
+        this.showTooltip = false; // Fix for touch devices that keep the tooltip open, overlaying the modal
         if (this.$auth.loggedIn) {
           this.selected = !this.selected;
           this.$emit('select', this.selected);

--- a/packages/portal/src/components/search/SearchMultilingualButton.vue
+++ b/packages/portal/src/components/search/SearchMultilingualButton.vue
@@ -57,6 +57,7 @@
         buttonId: 'search-multilingual-button',
         // TODO: clean up when new feature tooltip expires
         newFeatureTooltipEnabled: false,
+        // Use custom showTooltip instead of hideTooltips composable for touch devices that keep the tooltip open when value is changed
         showTooltip: false,
         touchTapCount: 0,
         touchTap: false
@@ -87,7 +88,7 @@
         if (this.$auth.loggedIn) {
           this.$emit('input', !this.value);
           this.$cookies?.set('multilingualSearch', !this.value);
-          this.showTooltip = false; // Fix for touch devices that keep the tooltip open, overlaying the modal
+          this.showTooltip = false;
         } else if (this.touchTap && this.touchTapCount === 0) {
           this.touchTapCount = 1;
           this.touchTap = false;

--- a/packages/portal/src/components/search/SearchMultilingualButton.vue
+++ b/packages/portal/src/components/search/SearchMultilingualButton.vue
@@ -79,25 +79,21 @@
       }
     },
 
-    watch: {
-      value(newVal) {
-        this.$matomo.trackEvent('Multilingual search', `${newVal ? 'Enabled' : 'Disabled'} multilingual search`, `${this.$i18n.locales.find((locale) => locale.code === this.$i18n.locale)?.name} multilingual search toggle`);
-      }
-    },
-
     methods: {
       detectTouchTap() {
         this.touchTap = true;
       },
       toggle() {
         if (this.$auth.loggedIn) {
-          this.$emit('input', !this.value);
           this.$cookies?.set('multilingualSearch', !this.value);
+          this.$matomo.trackEvent('Multilingual search', `${this.value ? 'Disabled' : 'Enabled'} multilingual search`, `${this.$i18n.locales.find((locale) => locale.code === this.$i18n.locale)?.name} multilingual search toggle`);
+          this.$emit('input', !this.value);
           this.showTooltip = false;
         } else if (this.touchTap && this.touchTapCount === 0) {
           this.touchTapCount = 1;
           this.touchTap = false;
         } else {
+          this.$matomo.trackEvent('Multilingual search', `${this.value ? 'Disabled' : 'Enabled'} multilingual search`, `${this.$i18n.locales.find((locale) => locale.code === this.$i18n.locale)?.name} multilingual search toggle`);
           this.$keycloak.login();
           this.touchTapCount = 0;
         }

--- a/packages/portal/src/components/search/SearchMultilingualButton.vue
+++ b/packages/portal/src/components/search/SearchMultilingualButton.vue
@@ -7,8 +7,11 @@
       variant="light-flat"
       :aria-label="ariaLabelText"
       @click="toggle"
-      @mouseleave="hideTooltips()"
+      @mouseleave="showTooltip = false"
+      @focusout="showTooltip = false"
       @touchstart="detectTouchTap()"
+      @focus="showTooltip = true"
+      @mouseover="showTooltip = true"
     >
       <span
         :class="{
@@ -25,7 +28,9 @@
     <b-tooltip
       v-if="!newFeatureTooltipEnabled"
       placement="bottom"
+      :show.sync="showTooltip"
       :target="buttonId"
+      @show="(e) => { if (!showTooltip) { e.preventDefault() } } "
     >
       {{ tooltipText }}
     </b-tooltip>
@@ -33,8 +38,6 @@
 </template>
 
 <script>
-  import useHideTooltips from '@/composables/hideTooltips.js';
-
   export default {
     name: 'SearchMultilingualButton',
 
@@ -49,18 +52,12 @@
       }
     },
 
-    setup() {
-      const buttonId = 'search-multilingual-button';
-
-      const { hideTooltips } = useHideTooltips(buttonId);
-
-      return { buttonId, hideTooltips };
-    },
-
     data() {
       return {
+        buttonId: 'search-multilingual-button',
         // TODO: clean up when new feature tooltip expires
         newFeatureTooltipEnabled: false,
+        showTooltip: false,
         touchTapCount: 0,
         touchTap: false
       };
@@ -90,7 +87,7 @@
         if (this.$auth.loggedIn) {
           this.$emit('input', !this.value);
           this.$cookies?.set('multilingualSearch', !this.value);
-          this.hideTooltips();
+          this.showTooltip = false; // Fix for touch devices that keep the tooltip open, overlaying the modal
         } else if (this.touchTap && this.touchTapCount === 0) {
           this.touchTapCount = 1;
           this.touchTap = false;

--- a/packages/portal/src/components/search/SearchMultilingualButton.vue
+++ b/packages/portal/src/components/search/SearchMultilingualButton.vue
@@ -79,12 +79,17 @@
       }
     },
 
+    watch: {
+      value(newVal) {
+        this.$matomo.trackEvent('Multilingual search', `${newVal ? 'Enabled' : 'Disabled'} multilingual search`, `${this.$i18n.locales.find((locale) => locale.code === this.$i18n.locale)?.name} multilingual search toggle`);
+      }
+    },
+
     methods: {
       detectTouchTap() {
         this.touchTap = true;
       },
       toggle() {
-        this.$matomo.trackEvent('Multilingual search', `${this.value ? 'Disabled' : 'Enabled'} multilingual search`, `${this.$i18n.locales.find((locale) => locale.code === this.$i18n.locale)?.name} multilingual search toggle`);
         if (this.$auth.loggedIn) {
           this.$emit('input', !this.value);
           this.$cookies?.set('multilingualSearch', !this.value);

--- a/packages/portal/tests/unit/components/item/ItemSelectButton.spec.js
+++ b/packages/portal/tests/unit/components/item/ItemSelectButton.spec.js
@@ -34,6 +34,15 @@ describe('components/item/ItemSelectButton', () => {
     });
 
     describe('when clicked', () => {
+      it('hides the tooltip', () => {
+        const wrapper = factory();
+
+        const selectButton = wrapper.find('.item-select-button');
+        selectButton.trigger('click');
+
+        expect(wrapper.vm.showTooltip).toEqual(false);
+      });
+
       describe('and user is not logged in', () => {
         it('redirects to login', () => {
           const wrapper = factory();

--- a/packages/portal/tests/unit/components/search/SearchMultilingualButton.spec.js
+++ b/packages/portal/tests/unit/components/search/SearchMultilingualButton.spec.js
@@ -108,7 +108,6 @@ describe('components/search/SearchMultilingualButton', () => {
             button.trigger('click');
             await wrapper.vm.$nextTick();
 
-            expect(wrapper.vm.$matomo.trackEvent.calledWith('Multilingual search', 'Disabled multilingual search', 'Español multilingual search toggle')).toBe(true);
             expect(wrapper.emitted('input')).toEqual([[false]]);
             expect(wrapper.vm.showTooltip).toEqual(false);
           });
@@ -139,11 +138,24 @@ describe('components/search/SearchMultilingualButton', () => {
           const button = wrapper.find('.search-multilingual-button');
           button.trigger('click');
 
-          expect(wrapper.vm.$matomo.trackEvent.calledWith('Multilingual search', 'Enabled multilingual search', 'Español multilingual search toggle')).toBe(true);
           expect(wrapper.vm.$cookies.set.calledWith('multilingualSearch', true)).toBe(true);
           expect(wrapper.emitted('input')).toEqual([[true]]);
         });
       });
+    });
+  });
+
+  describe('when value changes', () => {
+    it('tracks the change in matomo', async() => {
+      const wrapper = factory();
+
+      await wrapper.setProps({ value: true });
+
+      expect(wrapper.vm.$matomo.trackEvent.calledWith('Multilingual search', 'Enabled multilingual search', 'Español multilingual search toggle')).toBe(true);
+
+      await wrapper.setProps({ value: false });
+
+      expect(wrapper.vm.$matomo.trackEvent.calledWith('Multilingual search', 'Disabled multilingual search', 'Español multilingual search toggle')).toBe(true);
     });
   });
 });

--- a/packages/portal/tests/unit/components/search/SearchMultilingualButton.spec.js
+++ b/packages/portal/tests/unit/components/search/SearchMultilingualButton.spec.js
@@ -64,7 +64,7 @@ describe('components/search/SearchMultilingualButton', () => {
       });
 
       describe('and click is from a touch interaction', () => {
-        it('does not login and increases the touchTap count by 1', () => {
+        it('does not login and increases the touchTap count by 1; does not matomo track', () => {
           const wrapper = factory();
 
           const button = wrapper.find('.search-multilingual-button');
@@ -73,6 +73,7 @@ describe('components/search/SearchMultilingualButton', () => {
 
           expect(wrapper.vm.$keycloak.login.called).toBe(false);
           expect(wrapper.vm.touchTapCount).toEqual(1);
+          expect(wrapper.vm.$matomo.trackEvent.called).toBe(false);
         });
 
         describe('on a second click', () => {
@@ -108,6 +109,7 @@ describe('components/search/SearchMultilingualButton', () => {
             button.trigger('click');
             await wrapper.vm.$nextTick();
 
+            expect(wrapper.vm.$matomo.trackEvent.calledWith('Multilingual search', 'Disabled multilingual search', 'Español multilingual search toggle')).toBe(true);
             expect(wrapper.emitted('input')).toEqual([[false]]);
             expect(wrapper.vm.showTooltip).toEqual(false);
           });
@@ -138,24 +140,11 @@ describe('components/search/SearchMultilingualButton', () => {
           const button = wrapper.find('.search-multilingual-button');
           button.trigger('click');
 
+          expect(wrapper.vm.$matomo.trackEvent.calledWith('Multilingual search', 'Enabled multilingual search', 'Español multilingual search toggle')).toBe(true);
           expect(wrapper.vm.$cookies.set.calledWith('multilingualSearch', true)).toBe(true);
           expect(wrapper.emitted('input')).toEqual([[true]]);
         });
       });
-    });
-  });
-
-  describe('when value changes', () => {
-    it('tracks the change in matomo', async() => {
-      const wrapper = factory();
-
-      await wrapper.setProps({ value: true });
-
-      expect(wrapper.vm.$matomo.trackEvent.calledWith('Multilingual search', 'Enabled multilingual search', 'Español multilingual search toggle')).toBe(true);
-
-      await wrapper.setProps({ value: false });
-
-      expect(wrapper.vm.$matomo.trackEvent.calledWith('Multilingual search', 'Disabled multilingual search', 'Español multilingual search toggle')).toBe(true);
     });
   });
 });

--- a/packages/portal/tests/unit/components/search/SearchMultilingualButton.spec.js
+++ b/packages/portal/tests/unit/components/search/SearchMultilingualButton.spec.js
@@ -53,7 +53,7 @@ describe('components/search/SearchMultilingualButton', () => {
   describe('when clicked', () => {
     describe('and user is not logged in', () => {
       describe('and click is not a touch tap', () => {
-        it('redirects to login and hides the tooltip', () => {
+        it('redirects to login', () => {
           const wrapper = factory();
 
           const button = wrapper.find('.search-multilingual-button');
@@ -103,7 +103,6 @@ describe('components/search/SearchMultilingualButton', () => {
         describe('and click is not a touch tap', () => {
           it('emits the input event to toggle the selected state and hides the tooltip', async() => {
             const wrapper = factory({ mocks: { $auth: { loggedIn: true } }, propsData });
-            wrapper.vm.hideTooltips = sinon.spy();
 
             const button = wrapper.find('.search-multilingual-button');
             button.trigger('click');
@@ -111,14 +110,13 @@ describe('components/search/SearchMultilingualButton', () => {
 
             expect(wrapper.vm.$matomo.trackEvent.calledWith('Multilingual search', 'Disabled multilingual search', 'Español multilingual search toggle')).toBe(true);
             expect(wrapper.emitted('input')).toEqual([[false]]);
-            expect(wrapper.vm.hideTooltips.called).toBe(true);
+            expect(wrapper.vm.showTooltip).toEqual(false);
           });
         });
 
         describe('and click is from a touch interaction', () => {
           it('emits the input event to toggle the selected state and hides the tooltip', async() => {
             const wrapper = factory({ mocks: { $auth: { loggedIn: true } }, propsData });
-            wrapper.vm.hideTooltips = sinon.spy();
 
             const button = wrapper.find('.search-multilingual-button');
             button.trigger('touchstart');
@@ -127,7 +125,7 @@ describe('components/search/SearchMultilingualButton', () => {
 
             expect(button.attributes('aria-label')).toBe('search.multilingual.disable');
             expect(wrapper.emitted('input')).toEqual([[false]]);
-            expect(wrapper.vm.hideTooltips.called).toBe(true);
+            expect(wrapper.vm.showTooltip).toEqual(false);
           });
         });
       });


### PR DESCRIPTION
Show tooltip on:
- mouse over
- focus

Hide tooltip on:
- click
- touch tab
  - exception: multilingual search when not logged in, then do show tooltip on first tab.
- tab beyond button (focusout)

Do not track 'click' on first touch tap.