### PR TITLE
chore: update & lock sass to v1.77.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28936,10 +28936,11 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
-      "version": "1.66.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.66.1.tgz",
-      "integrity": "sha512-50c+zTsZOJVgFfTgwwEzkjA3/QACgdNsKueWPyAR0mRINIvLAStVQBbPg14iuqEQ74NPDbXzJARJ/O4SI1zftA==",
+      "version": "1.77.6",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.6.tgz",
+      "integrity": "sha512-ByXE1oLD79GVq9Ht1PeHWCPMPB8XHpBuz1r85oByKHjZY6qV6rWnQovQzXJXuQ/XyE1Oj3iPk3lo28uzaRA2/Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -34746,7 +34747,7 @@
         "postcss": "^8.4.16",
         "postcss-html": "^1.5.0",
         "postcss-scss": "^4.0.4",
-        "sass": "^1.44.0",
+        "sass": "1.77.6",
         "sass-loader": "^10.0.0",
         "sinon": "^13.0.1",
         "style-resources-loader": "^1.4.1",

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -73,7 +73,7 @@
     "postcss": "^8.4.16",
     "postcss-html": "^1.5.0",
     "postcss-scss": "^4.0.4",
-    "sass": "^1.44.0",
+    "sass": "1.77.6",
     "sass-loader": "^10.0.0",
     "sinon": "^13.0.1",
     "style-resources-loader": "^1.4.1",


### PR DESCRIPTION
from v1.77.7 deprecation warnings are issued re https://sass-lang.com/d/mixed-decls