### PR TITLE
refactor: use activeTab in AccountIndexPage, with router push

### DIFF
--- a/packages/portal/src/components/user/UserSets.vue
+++ b/packages/portal/src/components/user/UserSets.vue
@@ -139,6 +139,7 @@
       const searchResponse = await this.$apis.set.search(searchParams);
       this.sets = searchResponse.items || [];
       this.total = searchResponse.partOf?.total || 0;
+      this.$emit('fetched');
     },
     computed: {
       userId() {

--- a/packages/portal/src/components/user/UserSets.vue
+++ b/packages/portal/src/components/user/UserSets.vue
@@ -139,7 +139,6 @@
       const searchResponse = await this.$apis.set.search(searchParams);
       this.sets = searchResponse.items || [];
       this.total = searchResponse.partOf?.total || 0;
-      this.$emit('fetched');
     },
     computed: {
       userId() {

--- a/packages/portal/src/composables/activeTab.js
+++ b/packages/portal/src/composables/activeTab.js
@@ -3,7 +3,13 @@ import { computed, onBeforeMount, ref, watch } from 'vue';
 // vue2-helpers provides helpers that do
 import { useRoute, useRouter } from 'vue2-helpers/vue-router';
 
-export default function useActiveTab(tabHashes) {
+export default function useActiveTab(tabHashes, options = {}) {
+  const { replaceRoute } = {
+    replaceRoute: true,
+    ...options
+  };
+  const routerUpdateAction = replaceRoute ? 'replace' : 'push';
+
   const router = useRouter();
   const route = useRoute();
   const activeTabIndex = ref(-1);
@@ -29,14 +35,14 @@ export default function useActiveTab(tabHashes) {
     if (activeTabIndex.value !== -1) {
       activeTabHistory.value.push(activeTabHash.value);
       if (activeTabHash.value !== route.hash) {
-        router.replace({ ...route, hash: activeTabHash.value });
+        router[routerUpdateAction]({ ...route, hash: activeTabHash.value });
       }
     }
 
     unwatchTabIndex = watch(activeTabIndex, () => {
       if (activeTabIndex.value !== -1) {
         activeTabHistory.value.push(activeTabHash.value);
-        router.replace({ ...route, hash: activeTabHash.value });
+        router[routerUpdateAction]({ ...route, hash: activeTabHash.value });
       }
     });
   };

--- a/packages/portal/src/composables/activeTab.js
+++ b/packages/portal/src/composables/activeTab.js
@@ -16,9 +16,14 @@ export default function useActiveTab(tabHashes, options = {}) {
   const activeTabHistory = ref([]);
 
   const setActiveTabIndexFromRouteHash = () => {
-    if (tabHashes.includes(route?.hash)) {
-      activeTabIndex.value = tabHashes.indexOf(route.hash);
-      activeTabHistory.value.push(activeTabHash.value);
+    if (route) {
+      if (!route.hash) {
+        activeTabIndex.value = 0;
+        activeTabHistory.value.push(activeTabHash.value);
+      } else if (tabHashes.includes(route.hash)) {
+        activeTabIndex.value = tabHashes.indexOf(route.hash);
+        activeTabHistory.value.push(activeTabHash.value);
+      }
     }
   };
 

--- a/packages/portal/src/pages/account/index.vue
+++ b/packages/portal/src/pages/account/index.vue
@@ -247,6 +247,7 @@
         await this.$store.dispatch('set/fetchLikes');
       },
 
+      // TODO: incorporate into useActiveTab composable?
       focusActiveTab() {
         if (!this.tabFocused && this.$route.hash) {
           const element = this.$refs[this.$route.hash]?.$el;

--- a/packages/portal/src/pages/account/index.vue
+++ b/packages/portal/src/pages/account/index.vue
@@ -167,7 +167,7 @@
 
     data() {
       return {
-        activeTab: HASH_LIKES,
+        activeTab: null,
         HASH_CURATED_COLLECTIONS,
         HASH_LIKES,
         HASH_PRIVATE_GALLERIES,
@@ -221,6 +221,8 @@
     created() {
       if (this.tabHashes.includes(this.$route.hash)) {
         this.activeTab = this.$route.hash;
+      } else {
+        this.activeTab = HASH_LIKES;
       }
     },
 

--- a/packages/portal/src/pages/account/index.vue
+++ b/packages/portal/src/pages/account/index.vue
@@ -16,37 +16,37 @@
               >
                 <b-nav-item
                   data-qa="likes collection"
-                  :to="localePath({ hash: tabHashes.likes })"
-                  :active="activeTab === tabHashes.likes"
+                  :to="localePath({ hash: HASH_LIKES })"
+                  :active="activeTab === HASH_LIKES"
                 >
                   {{ $t('account.likes') }}
                 </b-nav-item>
                 <b-nav-item
                   data-qa="public collections"
-                  :to="localePath({ hash: tabHashes.publicGalleries })"
-                  :active="activeTab === tabHashes.publicGalleries"
+                  :to="localePath({ hash: HASH_PUBLIC_GALLERIES })"
+                  :active="activeTab === HASH_PUBLIC_GALLERIES"
                 >
                   {{ $t('account.publicCollections') }}
                 </b-nav-item>
                 <b-nav-item
                   data-qa="private collections"
-                  :to="localePath({ hash: tabHashes.privateGalleries })"
-                  :active="activeTab === tabHashes.privateGalleries"
+                  :to="localePath({ hash: HASH_PRIVATE_GALLERIES })"
+                  :active="activeTab === HASH_PRIVATE_GALLERIES"
                 >
                   {{ $t('account.privateCollections') }}
                 </b-nav-item>
                 <b-nav-item
                   data-qa="published collections"
-                  :to="localePath({ hash: tabHashes.publishedGalleries })"
-                  :active="activeTab === tabHashes.publishedGalleries"
+                  :to="localePath({ hash: HASH_PUBLISHED_GALLERIES })"
+                  :active="activeTab === HASH_PUBLISHED_GALLERIES"
                 >
                   {{ $t('account.publishedCollections') }}
                 </b-nav-item>
                 <b-nav-item
                   v-if="userIsEditor"
                   data-qa="curated collections"
-                  :to="localePath({ hash: tabHashes.curatedCollections })"
-                  :active="activeTab === tabHashes.curatedCollections"
+                  :to="localePath({ hash: HASH_CURATED_COLLECTIONS })"
+                  :active="activeTab === HASH_CURATED_COLLECTIONS"
                 >
                   {{ $t('account.curatedCollections') }}
                 </b-nav-item>
@@ -54,14 +54,14 @@
             </b-row>
           </b-container>
           <client-only>
-            <template v-if="activeTab === tabHashes.likes">
+            <template v-if="activeTab === HASH_LIKES">
               <AlertMessage
                 v-if="$fetchState.error"
                 :error="$fetchState.error.message"
               />
               <ItemPreviewInterface
                 v-else
-                :ref="tabHashes.likes"
+                :ref="HASH_LIKES"
                 class="tab-content"
                 data-qa="liked items"
                 :enable-item-multi-select="true"
@@ -81,8 +81,8 @@
               </ItemPreviewInterface>
             </template>
             <UserSets
-              v-else-if="activeTab === tabHashes.publicGalleries"
-              :ref="tabHashes.publicGalleries"
+              v-else-if="activeTab === HASH_PUBLIC_GALLERIES"
+              :ref="HASH_PUBLIC_GALLERIES"
               class="tab-content"
               visibility="public"
               :empty-text="$t('account.notifications.noCollections.public')"
@@ -90,8 +90,8 @@
               @fetched="focusActiveTab"
             />
             <UserSets
-              v-else-if="activeTab === tabHashes.privateGalleries"
-              :ref="tabHashes.privateGalleries"
+              v-else-if="activeTab === HASH_PRIVATE_GALLERIES"
+              :ref="HASH_PRIVATE_GALLERIES"
               class="tab-content"
               visibility="private"
               :empty-text="$t('account.notifications.noCollections.private')"
@@ -99,8 +99,8 @@
               @fetched="focusActiveTab"
             />
             <UserSets
-              v-else-if="activeTab === tabHashes.publishedGalleries"
-              :ref="tabHashes.publishedGalleries"
+              v-else-if="activeTab === HASH_PUBLISHED_GALLERIES"
+              :ref="HASH_PUBLISHED_GALLERIES"
               class="tab-content"
               visibility="published"
               :show-create-set-button="false"
@@ -109,8 +109,8 @@
               @fetched="focusActiveTab"
             />
             <UserSets
-              v-else-if="userIsEditor && activeTab === tabHashes.curatedCollections"
-              :ref="tabHashes.curatedCollections"
+              v-else-if="userIsEditor && activeTab === HASH_CURATED_COLLECTIONS"
+              :ref="HASH_CURATED_COLLECTIONS"
               class="tab-content"
               type="EntityBestItemsSet"
               :show-create-set-button="false"
@@ -135,6 +135,12 @@
   import ItemPreviewInterface from '@/components/item/ItemPreviewInterface';
   import UserHeader from '@/components/user/UserHeader';
   import UserSets from '@/components/user/UserSets';
+
+  const HASH_CURATED_COLLECTIONS = '#curated-collections';
+  const HASH_LIKES = '#likes';
+  const HASH_PRIVATE_GALLERIES = '#private-galleries';
+  const HASH_PUBLIC_GALLERIES = '#public-galleries';
+  const HASH_PUBLISHED_GALLERIES = '#published-galleries';
 
   export default {
     name: 'AccountIndexPage',
@@ -161,20 +167,26 @@
 
     data() {
       return {
+        activeTab: HASH_LIKES,
+        HASH_CURATED_COLLECTIONS,
+        HASH_LIKES,
+        HASH_PRIVATE_GALLERIES,
+        HASH_PUBLIC_GALLERIES,
+        HASH_PUBLISHED_GALLERIES,
         tabFocused: false,
-        tabHashes: {
-          likes: '#likes',
-          publicGalleries: '#public-galleries',
-          privateGalleries: '#private-galleries',
-          publishedGalleries: '#published-galleries',
-          curatedCollections: '#curated-collections'
-        }
+        tabHashes: [
+          HASH_CURATED_COLLECTIONS,
+          HASH_LIKES,
+          HASH_PRIVATE_GALLERIES,
+          HASH_PUBLIC_GALLERIES,
+          HASH_PUBLISHED_GALLERIES
+        ]
       };
     },
 
     async fetch() {
       await this.fetchLikes();
-      if (this.$route.hash === '#likes') {
+      if (this.$route.hash === HASH_LIKES) {
         this.focusActiveTab();
       }
     },
@@ -195,9 +207,20 @@
         likesId: state => state.set.likesId,
         likedItems: state => state.set.likedItems,
         curations: state => state.set.curations
-      }),
-      activeTab() {
-        return this.$route.hash || this.tabHashes.likes;
+      })
+    },
+
+    watch: {
+      '$route.hash'() {
+        if (this.tabHashes.includes(this.$route.hash)) {
+          this.activeTab = this.$route.hash;
+        }
+      }
+    },
+
+    created() {
+      if (this.tabHashes.includes(this.$route.hash)) {
+        this.activeTab = this.$route.hash;
       }
     },
 

--- a/packages/portal/src/pages/account/index.vue
+++ b/packages/portal/src/pages/account/index.vue
@@ -28,7 +28,7 @@
                     />
                     <ItemPreviewInterface
                       v-else
-                      :id="HASH_LIKES.slice(1)"
+                      :ref="HASH_LIKES"
                       class="tab-content"
                       data-qa="liked items"
                       :enable-item-multi-select="true"
@@ -58,7 +58,7 @@
                   <client-only>
                     <UserSets
                       v-if="activeTabHash === HASH_PUBLIC_GALLERIES"
-                      :id="HASH_PUBLIC_GALLERIES.slice(1)"
+                      :ref="HASH_PUBLIC_GALLERIES"
                       class="tab-content"
                       visibility="public"
                       :empty-text="$t('account.notifications.noCollections.public')"
@@ -77,7 +77,7 @@
                   <client-only>
                     <UserSets
                       v-if="activeTabHash === HASH_PRIVATE_GALLERIES"
-                      :id="HASH_PRIVATE_GALLERIES.slice(1)"
+                      :ref="HASH_PRIVATE_GALLERIES"
                       class="tab-content"
                       visibility="private"
                       :empty-text="$t('account.notifications.noCollections.private')"
@@ -96,7 +96,7 @@
                   <client-only>
                     <UserSets
                       v-if="activeTabHash === HASH_PUBLISHED_GALLERIES"
-                      :id="HASH_PUBLISHED_GALLERIES.slice(1)"
+                      :ref="HASH_PUBLISHED_GALLERIES"
                       class="tab-content"
                       visibility="published"
                       :show-create-set-button="false"
@@ -117,7 +117,7 @@
                   <client-only>
                     <UserSets
                       v-if="userIsEditor && activeTabHash === HASH_CURATED_COLLECTIONS"
-                      :id="HASH_CURATED_COLLECTIONS.slice(1)"
+                      :ref="HASH_CURATED_COLLECTIONS"
                       class="tab-content"
                       type="EntityBestItemsSet"
                       :show-create-set-button="false"
@@ -250,7 +250,7 @@
       // TODO: incorporate into useActiveTab composable?
       focusActiveTab() {
         if (!this.tabFocused && this.$route.hash) {
-          const element = document.querySelector(this.$route.hash);
+          const element = this.$refs[this.$route.hash]?.$el;
           element?.setAttribute('tabindex', '-1');
           element?.focus();
           this.tabFocused = true;

--- a/packages/portal/src/pages/account/index.vue
+++ b/packages/portal/src/pages/account/index.vue
@@ -183,7 +183,7 @@
         HASH_CURATED_COLLECTIONS
       ];
 
-      const { activeTabHash, activeTabIndex, watchTabIndex, unwatchTabIndex } = useActiveTab(tabHashes);
+      const { activeTabHash, activeTabIndex, watchTabIndex, unwatchTabIndex } = useActiveTab(tabHashes, { replaceRoute: false });
 
       return {
         activeTabHash,

--- a/packages/portal/src/pages/account/index.vue
+++ b/packages/portal/src/pages/account/index.vue
@@ -9,123 +9,107 @@
         <b-col class="p-0 mb-3">
           <b-container>
             <b-row>
-              <b-tabs
-                v-model="activeTabIndex"
+              <b-nav
+                tabs
                 align="center"
                 class="w-100"
               >
-                <b-tab
+                <b-nav-item
                   data-qa="likes collection"
-                  :title-link-attributes="{ 'aria-label': $t('account.likes'), href: HASH_LIKES }"
+                  :to="localePath({ hash: HASH_LIKES})"
+                  :active="activeTabHash === HASH_LIKES"
                 >
-                  <template #title>
-                    {{ $t('account.likes') }}
-                  </template>
-                  <client-only>
-                    <AlertMessage
-                      v-if="$fetchState.error"
-                      :error="$fetchState.error.message"
-                    />
-                    <ItemPreviewInterface
-                      v-else
-                      :ref="HASH_LIKES"
-                      class="tab-content"
-                      data-qa="liked items"
-                      :enable-item-multi-select="true"
-                      :loading="$fetchState.pending"
-                      :items="likedItems"
-                      :per-page="100"
-                      :max-results="100"
-                      :total="likedItems?.length || 0"
-                    >
-                      <template #no-items>
-                        <div
-                          class="text-center pb-4"
-                        >
-                          {{ $t('account.notifications.noLikedItems') }}
-                        </div>
-                      </template>
-                    </ItemPreviewInterface>
-                  </client-only>
-                </b-tab>
-                <b-tab
+                  {{ $t('account.likes') }}
+                </b-nav-item>
+                <b-nav-item
                   data-qa="public collections"
-                  :title-link-attributes="{ 'aria-label': $t('account.publicCollections'), href: HASH_PUBLIC_GALLERIES }"
+                  :to="localePath({ hash: HASH_PUBLIC_GALLERIES})"
+                  :active="activeTabHash === HASH_PUBLIC_GALLERIES"
                 >
-                  <template #title>
-                    {{ $t('account.publicCollections') }}
-                  </template>
-                  <client-only>
-                    <UserSets
-                      v-if="activeTabHash === HASH_PUBLIC_GALLERIES"
-                      :ref="HASH_PUBLIC_GALLERIES"
-                      class="tab-content"
-                      visibility="public"
-                      :empty-text="$t('account.notifications.noCollections.public')"
-                      data-qa="public sets"
-                    />
-                  </client-only>
-                </b-tab>
-                <b-tab
+                  {{ $t('account.publicCollections') }}
+                </b-nav-item>
+                <b-nav-item
                   data-qa="private collections"
-                  :title-link-attributes="{ 'aria-label': $t('account.privateCollections'), href: HASH_PRIVATE_GALLERIES }"
+                  :to="localePath({ hash: HASH_PRIVATE_GALLERIES})"
+                  :active="activeTabHash === HASH_PRIVATE_GALLERIES"
                 >
-                  <template #title>
-                    {{ $t('account.privateCollections') }}
-                  </template>
-                  <client-only>
-                    <UserSets
-                      v-if="activeTabHash === HASH_PRIVATE_GALLERIES"
-                      :ref="HASH_PRIVATE_GALLERIES"
-                      class="tab-content"
-                      visibility="private"
-                      :empty-text="$t('account.notifications.noCollections.private')"
-                      data-qa="private sets"
-                    />
-                  </client-only>
-                </b-tab>
-                <b-tab
+                  {{ $t('account.privateCollections') }}
+                </b-nav-item>
+                <b-nav-item
                   data-qa="published collections"
-                  :title-link-attributes="{ 'aria-label': $t('account.publishedCollections'), href: HASH_PUBLISHED_GALLERIES }"
+                  :to="localePath({ hash: HASH_PUBLISHED_GALLERIES})"
+                  :active="activeTabHash === HASH_PUBLISHED_GALLERIES"
                 >
-                  <template #title>
-                    {{ $t('account.publishedCollections') }}
-                  </template>
-                  <client-only>
-                    <UserSets
-                      v-if="activeTabHash === HASH_PUBLISHED_GALLERIES"
-                      :ref="HASH_PUBLISHED_GALLERIES"
-                      class="tab-content"
-                      visibility="published"
-                      :show-create-set-button="false"
-                      :empty-text="$t('account.notifications.noCollections.published')"
-                      data-qa="published sets"
-                    />
-                  </client-only>
-                </b-tab>
-                <b-tab
+                  {{ $t('account.publishedCollections') }}
+                </b-nav-item>
+                <b-nav-item
                   v-if="userIsEditor"
                   data-qa="curated collections"
-                  :title-link-attributes="{ 'aria-label': $t('account.curatedCollections'), href: HASH_CURATED_COLLECTIONS }"
+                  :to="localePath({ hash: HASH_CURATED_COLLECTIONS})"
+                  :active="activeTabHash === HASH_CURATED_COLLECTIONS"
                 >
-                  <template #title>
-                    {{ $t('account.curatedCollections') }}
-                  </template>
-                  <client-only>
-                    <UserSets
-                      v-if="userIsEditor && activeTabHash === HASH_CURATED_COLLECTIONS"
-                      :ref="HASH_CURATED_COLLECTIONS"
-                      class="tab-content"
-                      type="EntityBestItemsSet"
-                      :show-create-set-button="false"
-                      :empty-text="$t('account.notifications.noCollections.curated')"
-                      data-qa="curated sets"
-                    />
-                  </client-only>
-                </b-tab>
-              </b-tabs>
+                  {{ $t('account.curatedCollections') }}
+                </b-nav-item>
+              </b-nav>
             </b-row>
           </b-container>
+          <client-only>
+            <AlertMessage
+              v-if="$fetchState.error"
+              :error="$fetchState.error.message"
+            />
+            <template
+              v-else-if="activeTabHash === HASH_LIKES"
+            >
+              <ItemPreviewInterface
+                data-qa="liked items"
+                :enable-item-multi-select="true"
+                :loading="$fetchState.pending"
+                :items="likedItems"
+                :per-page="100"
+                :max-results="100"
+                :total="likedItems?.length || 0"
+              >
+                <template #no-items>
+                  <div
+                    class="text-center pb-4"
+                  >
+                    {{ $t('account.notifications.noLikedItems') }}
+                  </div>
+                </template>
+              </ItemPreviewInterface>
+            </template>
+            <template v-else-if="activeTabHash === HASH_PUBLIC_GALLERIES">
+              <UserSets
+                visibility="public"
+                :empty-text="$t('account.notifications.noCollections.public')"
+                data-qa="public sets"
+              />
+            </template>
+            <template v-else-if="activeTabHash === HASH_PRIVATE_GALLERIES">
+              <UserSets
+                visibility="private"
+                :empty-text="$t('account.notifications.noCollections.private')"
+                data-qa="private sets"
+              />
+            </template>
+            <template v-else-if="activeTabHash === HASH_PUBLISHED_GALLERIES">
+              <UserSets
+                visibility="published"
+                :show-create-set-button="false"
+                :empty-text="$t('account.notifications.noCollections.published')"
+                data-qa="published sets"
+              />
+            </template>
+            <template v-else-if="userIsEditor && activeTabHash === HASH_CURATED_COLLECTIONS">
+              <UserSets
+                type="EntityBestItemsSet"
+                :show-create-set-button="false"
+                :empty-text="$t('account.notifications.noCollections.curated')"
+                data-qa="curated sets"
+              />
+            </template>
+          </client-only>
         </b-col>
       </b-row>
     </b-container>
@@ -134,7 +118,7 @@
 
 <script>
   import ClientOnly from 'vue-client-only';
-  import { BTab, BTabs } from 'bootstrap-vue';
+  import { BNav, BNavItem } from 'bootstrap-vue';
   import { mapState } from 'vuex';
 
   import pageMetaMixin from '@/mixins/pageMeta';
@@ -155,8 +139,8 @@
 
     components: {
       AlertMessage,
-      BTab,
-      BTabs,
+      BNav,
+      BNavItem,
       ClientOnly,
       ItemPreviewInterface,
       UserHeader,
@@ -225,14 +209,6 @@
         likedItems: state => state.set.likedItems,
         curations: state => state.set.curations
       })
-    },
-
-    mounted() {
-      this.watchTabIndex();
-    },
-
-    beforeDestroy() {
-      this.unwatchTabIndex();
     },
 
     methods: {

--- a/packages/portal/src/pages/account/index.vue
+++ b/packages/portal/src/pages/account/index.vue
@@ -167,13 +167,10 @@
         HASH_CURATED_COLLECTIONS
       ];
 
-      const { activeTabHash, activeTabIndex, watchTabIndex, unwatchTabIndex } = useActiveTab(tabHashes, { replaceRoute: false });
+      const { activeTabHash } = useActiveTab(tabHashes, { replaceRoute: false });
 
       return {
-        activeTabHash,
-        activeTabIndex,
-        watchTabIndex,
-        unwatchTabIndex
+        activeTabHash
       };
     },
 
@@ -230,9 +227,5 @@
     @media (min-width: $bp-4k) {
       margin-bottom: calc(1.5 * 2.5rem);
     }
-  }
-
-  .tab-content:focus {
-    outline: none;
   }
 </style>

--- a/packages/portal/src/pages/account/index.vue
+++ b/packages/portal/src/pages/account/index.vue
@@ -28,7 +28,7 @@
                     />
                     <ItemPreviewInterface
                       v-else
-                      :ref="HASH_LIKES"
+                      :id="HASH_LIKES.slice(1)"
                       class="tab-content"
                       data-qa="liked items"
                       :enable-item-multi-select="true"
@@ -58,7 +58,7 @@
                   <client-only>
                     <UserSets
                       v-if="activeTabHash === HASH_PUBLIC_GALLERIES"
-                      :ref="HASH_PUBLIC_GALLERIES"
+                      :id="HASH_PUBLIC_GALLERIES.slice(1)"
                       class="tab-content"
                       visibility="public"
                       :empty-text="$t('account.notifications.noCollections.public')"
@@ -77,7 +77,7 @@
                   <client-only>
                     <UserSets
                       v-if="activeTabHash === HASH_PRIVATE_GALLERIES"
-                      :ref="HASH_PRIVATE_GALLERIES"
+                      :id="HASH_PRIVATE_GALLERIES.slice(1)"
                       class="tab-content"
                       visibility="private"
                       :empty-text="$t('account.notifications.noCollections.private')"
@@ -96,7 +96,7 @@
                   <client-only>
                     <UserSets
                       v-if="activeTabHash === HASH_PUBLISHED_GALLERIES"
-                      :ref="HASH_PUBLISHED_GALLERIES"
+                      :id="HASH_PUBLISHED_GALLERIES.slice(1)"
                       class="tab-content"
                       visibility="published"
                       :show-create-set-button="false"
@@ -117,7 +117,7 @@
                   <client-only>
                     <UserSets
                       v-if="userIsEditor && activeTabHash === HASH_CURATED_COLLECTIONS"
-                      :ref="HASH_CURATED_COLLECTIONS"
+                      :id="HASH_CURATED_COLLECTIONS.slice(1)"
                       class="tab-content"
                       type="EntityBestItemsSet"
                       :show-create-set-button="false"
@@ -250,7 +250,7 @@
       // TODO: incorporate into useActiveTab composable?
       focusActiveTab() {
         if (!this.tabFocused && this.$route.hash) {
-          const element = this.$refs[this.$route.hash]?.$el;
+          const element = document.querySelector(this.$route.hash);
           element?.setAttribute('tabindex', '-1');
           element?.focus();
           this.tabFocused = true;

--- a/packages/portal/src/pages/account/index.vue
+++ b/packages/portal/src/pages/account/index.vue
@@ -63,7 +63,6 @@
                       visibility="public"
                       :empty-text="$t('account.notifications.noCollections.public')"
                       data-qa="public sets"
-                      @fetched="focusActiveTab"
                     />
                   </client-only>
                 </b-tab>
@@ -82,7 +81,6 @@
                       visibility="private"
                       :empty-text="$t('account.notifications.noCollections.private')"
                       data-qa="private sets"
-                      @fetched="focusActiveTab"
                     />
                   </client-only>
                 </b-tab>
@@ -102,7 +100,6 @@
                       :show-create-set-button="false"
                       :empty-text="$t('account.notifications.noCollections.published')"
                       data-qa="published sets"
-                      @fetched="focusActiveTab"
                     />
                   </client-only>
                 </b-tab>
@@ -123,7 +120,6 @@
                       :show-create-set-button="false"
                       :empty-text="$t('account.notifications.noCollections.curated')"
                       data-qa="curated sets"
-                      @fetched="focusActiveTab"
                     />
                   </client-only>
                 </b-tab>
@@ -208,18 +204,11 @@
       };
     },
 
-    async fetch() {
-      await this.fetchLikes();
-      if (this.$route.hash === HASH_LIKES) {
-        this.focusActiveTab();
-      }
+    fetch() {
+      this.fetchLikes();
     },
 
     fetchOnServer: false,
-
-    mounted() {
-      this.watchTabIndex();
-    },
 
     computed: {
       pageMeta() {
@@ -238,23 +227,17 @@
       })
     },
 
+    mounted() {
+      this.watchTabIndex();
+    },
+
     beforeDestroy() {
       this.unwatchTabIndex();
     },
 
     methods: {
-      async fetchLikes() {
-        await this.$store.dispatch('set/fetchLikes');
-      },
-
-      // TODO: incorporate into useActiveTab composable?
-      focusActiveTab() {
-        if (!this.tabFocused && this.$route.hash) {
-          const element = this.$refs[this.$route.hash]?.$el;
-          element?.setAttribute('tabindex', '-1');
-          element?.focus();
-          this.tabFocused = true;
-        }
+      fetchLikes() {
+        this.$store.dispatch('set/fetchLikes');
       }
     }
   };

--- a/packages/portal/src/pages/account/index.vue
+++ b/packages/portal/src/pages/account/index.vue
@@ -9,116 +9,127 @@
         <b-col class="p-0 mb-3">
           <b-container>
             <b-row>
-              <b-nav
-                tabs
+              <b-tabs
+                v-model="activeTabIndex"
                 align="center"
                 class="w-100"
               >
-                <b-nav-item
+                <b-tab
                   data-qa="likes collection"
-                  :to="localePath({ hash: HASH_LIKES })"
-                  :active="activeTab === HASH_LIKES"
+                  :title-link-attributes="{ 'aria-label': $t('account.likes'), href: HASH_LIKES }"
                 >
-                  {{ $t('account.likes') }}
-                </b-nav-item>
-                <b-nav-item
+                  <template #title>
+                    {{ $t('account.likes') }}
+                  </template>
+                  <client-only>
+                    <AlertMessage
+                      v-if="$fetchState.error"
+                      :error="$fetchState.error.message"
+                    />
+                    <ItemPreviewInterface
+                      v-else
+                      :ref="HASH_LIKES"
+                      class="tab-content"
+                      data-qa="liked items"
+                      :enable-item-multi-select="true"
+                      :loading="$fetchState.pending"
+                      :items="likedItems"
+                      :per-page="100"
+                      :max-results="100"
+                      :total="likedItems?.length || 0"
+                    >
+                      <template #no-items>
+                        <div
+                          class="text-center pb-4"
+                        >
+                          {{ $t('account.notifications.noLikedItems') }}
+                        </div>
+                      </template>
+                    </ItemPreviewInterface>
+                  </client-only>
+                </b-tab>
+                <b-tab
                   data-qa="public collections"
-                  :to="localePath({ hash: HASH_PUBLIC_GALLERIES })"
-                  :active="activeTab === HASH_PUBLIC_GALLERIES"
+                  :title-link-attributes="{ 'aria-label': $t('account.publicCollections'), href: HASH_PUBLIC_GALLERIES }"
                 >
-                  {{ $t('account.publicCollections') }}
-                </b-nav-item>
-                <b-nav-item
+                  <template #title>
+                    {{ $t('account.publicCollections') }}
+                  </template>
+                  <client-only>
+                    <UserSets
+                      v-if="activeTabHash === HASH_PUBLIC_GALLERIES"
+                      :ref="HASH_PUBLIC_GALLERIES"
+                      class="tab-content"
+                      visibility="public"
+                      :empty-text="$t('account.notifications.noCollections.public')"
+                      data-qa="public sets"
+                      @fetched="focusActiveTab"
+                    />
+                  </client-only>
+                </b-tab>
+                <b-tab
                   data-qa="private collections"
-                  :to="localePath({ hash: HASH_PRIVATE_GALLERIES })"
-                  :active="activeTab === HASH_PRIVATE_GALLERIES"
+                  :title-link-attributes="{ 'aria-label': $t('account.privateCollections'), href: HASH_PRIVATE_GALLERIES }"
                 >
-                  {{ $t('account.privateCollections') }}
-                </b-nav-item>
-                <b-nav-item
+                  <template #title>
+                    {{ $t('account.privateCollections') }}
+                  </template>
+                  <client-only>
+                    <UserSets
+                      v-if="activeTabHash === HASH_PRIVATE_GALLERIES"
+                      :ref="HASH_PRIVATE_GALLERIES"
+                      class="tab-content"
+                      visibility="private"
+                      :empty-text="$t('account.notifications.noCollections.private')"
+                      data-qa="private sets"
+                      @fetched="focusActiveTab"
+                    />
+                  </client-only>
+                </b-tab>
+                <b-tab
                   data-qa="published collections"
-                  :to="localePath({ hash: HASH_PUBLISHED_GALLERIES })"
-                  :active="activeTab === HASH_PUBLISHED_GALLERIES"
+                  :title-link-attributes="{ 'aria-label': $t('account.publishedCollections'), href: HASH_PUBLISHED_GALLERIES }"
                 >
-                  {{ $t('account.publishedCollections') }}
-                </b-nav-item>
-                <b-nav-item
+                  <template #title>
+                    {{ $t('account.publishedCollections') }}
+                  </template>
+                  <client-only>
+                    <UserSets
+                      v-if="activeTabHash === HASH_PUBLISHED_GALLERIES"
+                      :ref="HASH_PUBLISHED_GALLERIES"
+                      class="tab-content"
+                      visibility="published"
+                      :show-create-set-button="false"
+                      :empty-text="$t('account.notifications.noCollections.published')"
+                      data-qa="published sets"
+                      @fetched="focusActiveTab"
+                    />
+                  </client-only>
+                </b-tab>
+                <b-tab
                   v-if="userIsEditor"
                   data-qa="curated collections"
-                  :to="localePath({ hash: HASH_CURATED_COLLECTIONS })"
-                  :active="activeTab === HASH_CURATED_COLLECTIONS"
+                  :title-link-attributes="{ 'aria-label': $t('account.curatedCollections'), href: HASH_CURATED_COLLECTIONS }"
                 >
-                  {{ $t('account.curatedCollections') }}
-                </b-nav-item>
-              </b-nav>
+                  <template #title>
+                    {{ $t('account.curatedCollections') }}
+                  </template>
+                  <client-only>
+                    <UserSets
+                      v-if="userIsEditor && activeTabHash === HASH_CURATED_COLLECTIONS"
+                      :ref="HASH_CURATED_COLLECTIONS"
+                      class="tab-content"
+                      type="EntityBestItemsSet"
+                      :show-create-set-button="false"
+                      :empty-text="$t('account.notifications.noCollections.curated')"
+                      data-qa="curated sets"
+                      @fetched="focusActiveTab"
+                    />
+                  </client-only>
+                </b-tab>
+              </b-tabs>
             </b-row>
           </b-container>
-          <client-only>
-            <template v-if="activeTab === HASH_LIKES">
-              <AlertMessage
-                v-if="$fetchState.error"
-                :error="$fetchState.error.message"
-              />
-              <ItemPreviewInterface
-                v-else
-                :ref="HASH_LIKES"
-                class="tab-content"
-                data-qa="liked items"
-                :enable-item-multi-select="true"
-                :loading="$fetchState.pending"
-                :items="likedItems"
-                :per-page="100"
-                :max-results="100"
-                :total="likedItems?.length || 0"
-              >
-                <template #no-items>
-                  <div
-                    class="text-center pb-4"
-                  >
-                    {{ $t('account.notifications.noLikedItems') }}
-                  </div>
-                </template>
-              </ItemPreviewInterface>
-            </template>
-            <UserSets
-              v-else-if="activeTab === HASH_PUBLIC_GALLERIES"
-              :ref="HASH_PUBLIC_GALLERIES"
-              class="tab-content"
-              visibility="public"
-              :empty-text="$t('account.notifications.noCollections.public')"
-              data-qa="public sets"
-              @fetched="focusActiveTab"
-            />
-            <UserSets
-              v-else-if="activeTab === HASH_PRIVATE_GALLERIES"
-              :ref="HASH_PRIVATE_GALLERIES"
-              class="tab-content"
-              visibility="private"
-              :empty-text="$t('account.notifications.noCollections.private')"
-              data-qa="private sets"
-              @fetched="focusActiveTab"
-            />
-            <UserSets
-              v-else-if="activeTab === HASH_PUBLISHED_GALLERIES"
-              :ref="HASH_PUBLISHED_GALLERIES"
-              class="tab-content"
-              visibility="published"
-              :show-create-set-button="false"
-              :empty-text="$t('account.notifications.noCollections.published')"
-              data-qa="published sets"
-              @fetched="focusActiveTab"
-            />
-            <UserSets
-              v-else-if="userIsEditor && activeTab === HASH_CURATED_COLLECTIONS"
-              :ref="HASH_CURATED_COLLECTIONS"
-              class="tab-content"
-              type="EntityBestItemsSet"
-              :show-create-set-button="false"
-              :empty-text="$t('account.notifications.noCollections.curated')"
-              data-qa="curated sets"
-              @fetched="focusActiveTab"
-            />
-          </client-only>
         </b-col>
       </b-row>
     </b-container>
@@ -127,7 +138,7 @@
 
 <script>
   import ClientOnly from 'vue-client-only';
-  import { BNav } from 'bootstrap-vue';
+  import { BTab, BTabs } from 'bootstrap-vue';
   import { mapState } from 'vuex';
 
   import pageMetaMixin from '@/mixins/pageMeta';
@@ -135,6 +146,7 @@
   import ItemPreviewInterface from '@/components/item/ItemPreviewInterface';
   import UserHeader from '@/components/user/UserHeader';
   import UserSets from '@/components/user/UserSets';
+  import useActiveTab from '@/composables/activeTab.js';
 
   const HASH_CURATED_COLLECTIONS = '#curated-collections';
   const HASH_LIKES = '#likes';
@@ -147,7 +159,8 @@
 
     components: {
       AlertMessage,
-      BNav,
+      BTab,
+      BTabs,
       ClientOnly,
       ItemPreviewInterface,
       UserHeader,
@@ -165,22 +178,33 @@
 
     middleware: 'auth',
 
+    setup() {
+      const tabHashes = [
+        HASH_LIKES,
+        HASH_PUBLIC_GALLERIES,
+        HASH_PRIVATE_GALLERIES,
+        HASH_PUBLISHED_GALLERIES,
+        HASH_CURATED_COLLECTIONS
+      ];
+
+      const { activeTabHash, activeTabIndex, watchTabIndex, unwatchTabIndex } = useActiveTab(tabHashes);
+
+      return {
+        activeTabHash,
+        activeTabIndex,
+        watchTabIndex,
+        unwatchTabIndex
+      };
+    },
+
     data() {
       return {
-        activeTab: null,
         HASH_CURATED_COLLECTIONS,
         HASH_LIKES,
         HASH_PRIVATE_GALLERIES,
         HASH_PUBLIC_GALLERIES,
         HASH_PUBLISHED_GALLERIES,
-        tabFocused: false,
-        tabHashes: [
-          HASH_CURATED_COLLECTIONS,
-          HASH_LIKES,
-          HASH_PRIVATE_GALLERIES,
-          HASH_PUBLIC_GALLERIES,
-          HASH_PUBLISHED_GALLERIES
-        ]
+        tabFocused: false
       };
     },
 
@@ -192,6 +216,10 @@
     },
 
     fetchOnServer: false,
+
+    mounted() {
+      this.watchTabIndex();
+    },
 
     computed: {
       pageMeta() {
@@ -210,20 +238,8 @@
       })
     },
 
-    watch: {
-      '$route.hash'() {
-        if (this.tabHashes.includes(this.$route.hash)) {
-          this.activeTab = this.$route.hash;
-        }
-      }
-    },
-
-    created() {
-      if (this.tabHashes.includes(this.$route.hash)) {
-        this.activeTab = this.$route.hash;
-      } else {
-        this.activeTab = HASH_LIKES;
-      }
+    beforeDestroy() {
+      this.unwatchTabIndex();
     },
 
     methods: {

--- a/packages/portal/tests/unit/pages/account/index.spec.js
+++ b/packages/portal/tests/unit/pages/account/index.spec.js
@@ -2,6 +2,8 @@ import { createLocalVue } from '@vue/test-utils';
 import { shallowMountNuxt } from '../../utils';
 import BootstrapVue from 'bootstrap-vue';
 import sinon from 'sinon';
+import { reactive } from 'vue';
+import * as vue2RouterHelpers from 'vue2-helpers/vue-router';
 
 import page from '@/pages/account/index';
 
@@ -11,52 +13,59 @@ localVue.use(BootstrapVue);
 const storeCommit = sinon.spy();
 const storeDispatch = sinon.stub().resolves({});
 
-const factory = (options = {}) => shallowMountNuxt(page, {
-  localVue,
-  stubs: ['client-only'],
-  mocks: {
-    $t: key => key,
-    $tc: key => key,
-    $auth: {
-      userHasClientRole: options.userHasClientRoleStub || sinon.stub().returns(false),
-      strategy: {
-        options: {
-          origin: 'https://auth.example.eu',
-          realm: 'europeana',
-          'client_id': 'portal.js'
+const factory = (options = {}) => {
+  sinon.stub(vue2RouterHelpers, 'useRoute').returns(reactive({ hash: options.hash || '' }));
+
+  return shallowMountNuxt(page, {
+    localVue,
+    stubs: ['b-tabs', 'b-tab', 'client-only'],
+    mocks: {
+      $t: key => key,
+      $tc: key => key,
+      $auth: {
+        userHasClientRole: options.userHasClientRoleStub || sinon.stub().returns(false),
+        strategy: {
+          options: {
+            origin: 'https://auth.example.eu',
+            realm: 'europeana',
+            'client_id': 'portal.js'
+          }
         }
-      }
-    },
-    $config: { app: { baseUrl: 'https://www.example.eu' } },
-    $features: {},
-    $fetchState: options.fetchState || {},
-    $keycloak: { accountUrl: () => '/account' },
-    localePath: (path) => path,
-    $route: {
-      hash: options.hash || '',
-      query: {}
-    },
-    $store: {
-      commit: storeCommit,
-      dispatch: storeDispatch,
-      getters: {},
-      state: {
-        auth: { loggedIn: true,
-          user: {
-            'preferred_username': 'username',
-            ...options.user
-          } },
-        set: {
-          creations: [],
-          curations: [],
-          likedItems: ['http://data.europeana.eu/set/123']
+      },
+      $config: { app: { baseUrl: 'https://www.example.eu' } },
+      $features: {},
+      $fetchState: options.fetchState || {},
+      $keycloak: { accountUrl: () => '/account' },
+      localePath: (path) => path,
+      $route: {},
+      $store: {
+        commit: storeCommit,
+        dispatch: storeDispatch,
+        getters: {},
+        state: {
+          auth: { loggedIn: true,
+            user: {
+              'preferred_username': 'username',
+              ...options.user
+            } },
+          set: {
+            creations: [],
+            curations: [],
+            likedItems: ['http://data.europeana.eu/set/123']
+          }
         }
       }
     }
-  }
-});
+  });
+};
 
 describe('pages/account/index.vue', () => {
+  afterEach(() => {
+    sinon.resetHistory();
+    vue2RouterHelpers.useRoute.restore?.();
+  });
+  afterAll(sinon.restore);
+
   describe('when visiting the account page', () => {
     it('fetches the likes of the logged in user', () => {
       const wrapper = factory();
@@ -88,47 +97,41 @@ describe('pages/account/index.vue', () => {
 
     describe('when visiting the curated collections', () => {
       it('shows the curated collections', () => {
-        const wrapper = factory({
-          hash: '#curated-collections',
-          userHasClientRoleStub
-        });
+        const wrapper = factory({ hash: '#curated-collections', userHasClientRoleStub });
 
-        const publicGalleries = wrapper.find('[data-qa="curated sets"]');
+        const curatedCollections = wrapper.find('[data-qa="curated sets"]');
 
-        expect(publicGalleries.exists()).toBe(true);
+        expect(curatedCollections.exists()).toBe(true);
       });
     });
   });
 
   describe('when visiting the likes collection', () => {
-    const wrapper = factory({
-      hash: '#likes'
-    });
-
     it('shows the liked items', () => {
+      const wrapper = factory({ hash: '#likes' });
+
       const likedItems = wrapper.find('[data-qa="liked items"]');
+
       expect(likedItems.exists()).toBe(true);
     });
   });
 
   describe('when visiting the public galleries', () => {
-    const wrapper = factory({
-      hash: '#public-galleries'
-    });
-
     it('shows the public galleries', () => {
+      const wrapper = factory({ hash: '#public-galleries' });
+
       const publicGalleries = wrapper.find('[data-qa="public sets"]');
+
       expect(publicGalleries.exists()).toBe(true);
     });
   });
 
   describe('when visiting the private galleries', () => {
-    const wrapper = factory({
-      hash: '#private-galleries'
-    });
-
     it('shows the private galleries', () => {
+      const wrapper = factory({ hash: '#private-galleries' });
+
       const privateGalleries = wrapper.find('[data-qa="private sets"]');
+
       expect(privateGalleries.exists()).toBe(true);
     });
   });

--- a/packages/portal/tests/unit/pages/account/index.spec.js
+++ b/packages/portal/tests/unit/pages/account/index.spec.js
@@ -18,7 +18,7 @@ const factory = (options = {}) => {
 
   return shallowMountNuxt(page, {
     localVue,
-    stubs: ['b-tabs', 'b-tab', 'client-only'],
+    stubs: ['b-nav', 'b-nav-item', 'client-only'],
     mocks: {
       $t: key => key,
       $tc: key => key,


### PR DESCRIPTION
- extend activeTab composable to also support router push (instead of default replace)
- refactor AccountIndexPage to use activeTab composable