### PR TITLE
fix: don't exit if previous hash unknown

### DIFF
--- a/packages/portal/src/composables/activeTab.js
+++ b/packages/portal/src/composables/activeTab.js
@@ -34,9 +34,6 @@ export default function useActiveTab(tabHashes) {
     }
 
     unwatchTabIndex = watch(activeTabIndex, () => {
-      if (route.hash && !tabHashes.includes(route.hash)) {
-        return;
-      }
       if (activeTabIndex.value !== -1) {
         activeTabHistory.value.push(activeTabHash.value);
         router.replace({ ...route, hash: activeTabHash.value });


### PR DESCRIPTION
the new hash should still be propagated to the route if known