### PR TITLE
feat: prefer gltf format to oEmbed

### DIFF
--- a/packages/portal/src/plugins/europeana/edm/Aggregation.js
+++ b/packages/portal/src/plugins/europeana/edm/Aggregation.js
@@ -95,12 +95,33 @@ export default class Aggregation extends Base {
         }
       }
 
-      const wrs = [...uris].map((uri) => (this.webResources || []).find((wr) => wr.about === uri));
+      const wrs = [...uris].map((uri) => this.findWebResourcePrefFormat(uri));
 
       // Sort by isNextInSequence property if present
       this.#displayableWebResources = sortByIsNextInSequence(wrs);
     }
 
     return this.#displayableWebResources;
+  }
+
+  findWebResourcePrefFormat(uri) {
+    const wr = this.findWebResource(uri);
+
+    // hack to prefer our own gltf file display to an oEmbed
+    // TODO: remove when data regards gltf as displayable
+    if (wr.isOEmbed && wr.dctermsIsFormatOf?.def) {
+      const gltfWebResourceUri = (wr.dctermsIsFormatOf?.def || []).find((dctermsIsFormatOfUri) => {
+        return this.findWebResource(dctermsIsFormatOfUri)?.ebucoreHasMimeType === 'model/gltf-binary';
+      });
+      if (gltfWebResourceUri) {
+        return this.findWebResource(gltfWebResourceUri);
+      }
+    }
+
+    return wr;
+  }
+
+  findWebResource(uri) {
+    return (this.webResources || []).find((wr) => wr.about === uri);
   }
 }


### PR DESCRIPTION
For oEmbed web resources, look to see if they have a dcterms:isFormatOf property linking to a gltf 3D web resource, and if so, prefer that to the oEmbed so that it may be displayed without the 3rd-party embed.