### PR TITLE
feat: handle videojs errors

### DIFF
--- a/packages/portal/src/components/iiif/IIIFErrorMessage.vue
+++ b/packages/portal/src/components/iiif/IIIFErrorMessage.vue
@@ -27,6 +27,7 @@
 
 <script>
   export default {
+    // TODO: rename to MediaErrorMessage
     name: 'IIIFErrorMessage',
 
     components: {

--- a/packages/portal/src/components/item/ItemMediaPresentation.vue
+++ b/packages/portal/src/components/item/ItemMediaPresentation.vue
@@ -74,6 +74,7 @@
                 :offset="page - 1"
                 :text-tracks="textTracks"
                 :resource="resource"
+                @error="handleMediaError"
                 @warn="handleMediaWarn"
               />
               <MediaEuropeanaMediaPlayer

--- a/packages/portal/src/components/media/MediaAudioVisualPlayer.spec.js
+++ b/packages/portal/src/components/media/MediaAudioVisualPlayer.spec.js
@@ -210,6 +210,20 @@ describe('components/media/MediaAudioVisualPlayer', () => {
     });
 
     describe('player', () => {
+      describe('on error', () => {
+        it('emits error event', async() => {
+          const message = 'Media playback failed';
+          const wrapper = factory();
+          await wrapper.vm.fetch();
+          await wrapper.vm.initVideojs();
+          await wrapper.vm.$nextTick();
+          sinon.stub(wrapper.vm.player, 'error').returns({ message });
+
+          wrapper.vm.player.trigger('error');
+          expect(wrapper.emitted().error[0][0].message).toBe(message);
+        });
+      });
+
       describe('on loadedmetadata', () => {
         describe('when media is seekable', () => {
           const seekable = {

--- a/packages/portal/src/components/media/MediaAudioVisualPlayer.vue
+++ b/packages/portal/src/components/media/MediaAudioVisualPlayer.vue
@@ -120,6 +120,7 @@
               'fullscreenToggle'
             ]
           },
+          errorDisplay: false,
           language: this.$i18n.locale,
           noUITitleAttributes: true, // do not add title attributes to controls
           textTrackSettings: false // disable captions settings menu
@@ -246,6 +247,10 @@
         this.player.controlBar.progressControl.disable();
       },
 
+      handlePlayerError() {
+        this.$emit('error', this.player.error());
+      },
+
       async initVideojs() {
         this.player?.dispose();
 
@@ -272,6 +277,7 @@
 
         this.player.ready(this.onPlayerReady);
         this.player.on('loadedmetadata', this.checkSeekable);
+        this.player.on('error', this.handlePlayerError);
       }
     }
   };


### PR DESCRIPTION
- suppress the built-in videojs error display
- add a videojs player error event handler which just emits from the component, to be handled by the parent
  - in our case, this will display the generic "unfortunately this media can not be displayed" message and log the specifics to APM