### PR TITLE
refactor: fix up ebucore:duration

### DIFF
--- a/packages/portal/src/components/media/MediaAudioVideoPlayer.spec.js
+++ b/packages/portal/src/components/media/MediaAudioVideoPlayer.spec.js
@@ -27,7 +27,8 @@ const factory = ({ propsData } = {}) => mountNuxt(MediaAudioVideoPlayer, {
     $i18n: {
       locale: 'en'
     }
-  }
+  },
+  stubs: ['MediaCardImage']
 });
 
 describe('components/media/MediaAudioVideoPlayer', () => {
@@ -243,61 +244,125 @@ describe('components/media/MediaAudioVideoPlayer', () => {
       });
 
       describe('on loadedmetadata', () => {
-        describe('when media is seekable', () => {
-          const seekable = {
-            length: 1,
-            start: sinon.stub().returns(0),
-            end: sinon.stub().returns(1)
-          };
+        describe('duration initialisation', () => {
+          const ebucoreDuration = 138000;
+          const durationSeconds = 138;
 
-          it('does not disable the control bar progress control', async() => {
-            const wrapper = factory();
-            await wrapper.vm.fetch();
-            await wrapper.vm.initVideojs();
-            await wrapper.vm.$nextTick();
-            wrapper.vm.$refs.avPlayer = {
-              seekable
-            };
+          describe('when media element duration is NaN', () => {
+            const mediaElementDuration = NaN;
 
-            wrapper.vm.player.trigger('loadedmetadata');
+            it('sets duration from the resource ebucore:duration property', async() => {
+              const wrapper = factory({ propsData: { resource: { edm: { ebucoreDuration } } } });
+              await wrapper.vm.fetch();
+              await wrapper.vm.initVideojs();
+              await wrapper.vm.$nextTick();
+              sinon.stub(wrapper.vm.player, 'duration');
+              wrapper.vm.$refs.avPlayer = {
+                duration: mediaElementDuration
+              };
 
-            expect(wrapper.vm.player.controlBar.progressControl.enabled()).toBe(true);
+              wrapper.vm.player.trigger('loadedmetadata');
+
+              expect(wrapper.vm.player.duration.calledWith(durationSeconds)).toBe(true);
+            });
+          });
+
+          describe('when media element duration is Infinity', () => {
+            const mediaElementDuration = Infinity;
+
+            it('sets duration from the resource ebucore:duration property', async() => {
+              const wrapper = factory({ propsData: { resource: { edm: { ebucoreDuration } } } });
+              await wrapper.vm.fetch();
+              await wrapper.vm.initVideojs();
+              await wrapper.vm.$nextTick();
+              sinon.stub(wrapper.vm.player, 'duration');
+              wrapper.vm.$refs.avPlayer = {
+                duration: mediaElementDuration
+              };
+
+              wrapper.vm.player.trigger('loadedmetadata');
+
+              expect(wrapper.vm.player.duration.calledWith(durationSeconds)).toBe(true);
+            });
+          });
+
+          describe('when media element duration is a Number', () => {
+            const mediaElementDuration = ebucoreDuration - 1;
+
+            it('does not set duration from the resource ebucore:duration property', async() => {
+              const wrapper = factory({ propsData: { resource: { edm: { ebucoreDuration } } } });
+              await wrapper.vm.fetch();
+              await wrapper.vm.initVideojs();
+              await wrapper.vm.$nextTick();
+              sinon.stub(wrapper.vm.player, 'duration');
+              wrapper.vm.$refs.avPlayer = {
+                duration: mediaElementDuration
+              };
+
+              wrapper.vm.player.trigger('loadedmetadata');
+
+              expect(wrapper.vm.player.duration.calledWith(durationSeconds)).toBe(false);
+            });
           });
         });
 
-        describe('when media is not seekable', () => {
-          const seekable = {
-            length: 1,
-            start: sinon.stub().returns(0),
-            end: sinon.stub().returns(0)
-          };
-
-          it('disables the control bar progress control', async() => {
-            const wrapper = factory();
-            await wrapper.vm.fetch();
-            await wrapper.vm.initVideojs();
-            await wrapper.vm.$nextTick();
-            wrapper.vm.$refs.avPlayer = {
-              seekable
+        describe('seekable status handling', () => {
+          describe('when media is seekable', () => {
+            const seekable = {
+              length: 1,
+              start: sinon.stub().returns(0),
+              end: sinon.stub().returns(1)
             };
 
-            wrapper.vm.player.trigger('loadedmetadata');
+            it('does not disable the control bar progress control', async() => {
+              const wrapper = factory();
+              await wrapper.vm.fetch();
+              await wrapper.vm.initVideojs();
+              await wrapper.vm.$nextTick();
+              wrapper.vm.$refs.avPlayer = {
+                seekable
+              };
 
-            expect(wrapper.vm.player.controlBar.progressControl.enabled()).toBe(false);
+              wrapper.vm.player.trigger('loadedmetadata');
+
+              expect(wrapper.vm.player.controlBar.progressControl.enabled()).toBe(true);
+            });
           });
 
-          it('emits warn event', async() => {
-            const wrapper = factory();
-            await wrapper.vm.fetch();
-            await wrapper.vm.initVideojs();
-            await wrapper.vm.$nextTick();
-            wrapper.vm.$refs.avPlayer = {
-              seekable
+          describe('when media is not seekable', () => {
+            const seekable = {
+              length: 1,
+              start: sinon.stub().returns(0),
+              end: sinon.stub().returns(0)
             };
 
-            wrapper.vm.player.trigger('loadedmetadata');
-            expect(wrapper.emitted().warn[0][0].name).toBe('MediaAudioVideoPlayerError');
-            expect(wrapper.emitted().warn[0][0].message).toBe('A/V not seekable');
+            it('disables the control bar progress control', async() => {
+              const wrapper = factory();
+              await wrapper.vm.fetch();
+              await wrapper.vm.initVideojs();
+              await wrapper.vm.$nextTick();
+              wrapper.vm.$refs.avPlayer = {
+                seekable
+              };
+
+              wrapper.vm.player.trigger('loadedmetadata');
+
+              expect(wrapper.vm.player.controlBar.progressControl.enabled()).toBe(false);
+            });
+
+            it('emits warn event', async() => {
+              const wrapper = factory();
+              await wrapper.vm.fetch();
+              await wrapper.vm.initVideojs();
+              await wrapper.vm.$nextTick();
+              wrapper.vm.$refs.avPlayer = {
+                seekable
+              };
+
+              wrapper.vm.player.trigger('loadedmetadata');
+              expect(wrapper.emitted().warn[0][0].name).toBe('MediaAudioVideoPlayerError');
+              expect(wrapper.emitted().warn[0][0].message).toBe('A/V not seekable');
+            });
           });
         });
       });

--- a/packages/portal/src/components/media/MediaAudioVideoPlayer.vue
+++ b/packages/portal/src/components/media/MediaAudioVideoPlayer.vue
@@ -226,17 +226,9 @@
         if (![Infinity, NaN].includes(this.$refs.avPlayer.duration)) {
           return;
         }
-        // TODO: mv this to WebResource class?
+
         if (this.resource?.edm?.ebucoreDuration) {
-          let durationSeconds = Number(this.resource.edm.ebucoreDuration) / 1000;
-          // some WRs have duration metadata incorrectly in microseconds instead of
-          // the expected milliseconds. try to handle this by assuming that if the
-          // WR's duration appears to be more than 24 hours, then it is using the
-          // wrong unit
-          if ((durationSeconds / 3600) > 24) {
-            durationSeconds = durationSeconds / 1000;
-          }
-          this.player.duration(durationSeconds);
+          this.player.duration(this.resource.edm.ebucoreDuration / 1000);
         }
       },
 
@@ -257,7 +249,7 @@
       checkSeekable() {
         const seekable = this.$refs.avPlayer.seekable;
 
-        if ((seekable.length === 0) || ((seekable.start(0) === 0) && (seekable.end(0) === 0))) {
+        if ((seekable?.length === 0) || ((seekable?.start(0) === 0) && (seekable?.end(0) === 0))) {
           this.$emit('warn', new MediaAudioVideoPlayerError('A/V not seekable'));
 
           this.disableProgressControl();

--- a/packages/portal/src/plugins/europeana/edm/WebResource.js
+++ b/packages/portal/src/plugins/europeana/edm/WebResource.js
@@ -62,6 +62,19 @@ export default class WebResource extends Base {
     // delete large unused fields
     delete this.htmlAttributionSnippet;
     delete this.textAttributionSnippet;
+
+    if (this.ebucoreDuration) {
+      // ebucoreDuration is stored as a string
+      this.ebucoreDuration = Number(this.ebucoreDuration);
+      // some WRs have duration metadata incorrectly in microseconds instead of
+      // the expected milliseconds. try to handle this by assuming that if the
+      // WR's duration appears to be more than 24 hours, then it is using the
+      // wrong unit
+
+      if ((this.ebucoreDuration / 1000 / 3600) > 24) {
+        this.ebucoreDuration = this.ebucoreDuration / 1000;
+      }
+    }
   }
 
   get id() {

--- a/packages/portal/src/plugins/europeana/edm/WebResource.spec.js
+++ b/packages/portal/src/plugins/europeana/edm/WebResource.spec.js
@@ -2,6 +2,36 @@ import WebResource from '@/plugins/europeana/edm/WebResource';
 
 describe('plugins/europeana/edm/WebResource', () => {
   describe('WebResource', () => {
+    describe('constructor', () => {
+      it('deletes htmlAttributionSnippet', () => {
+        const edm = { htmlAttributionSnippet: 'html' };
+        const wr = new WebResource(edm);
+
+        expect(wr.htmlAttributionSnippet).toBeUndefined();
+      });
+
+      it('deletes textAttributionSnippet', () => {
+        const edm = { textAttributionSnippet: 'text' };
+        const wr = new WebResource(edm);
+
+        expect(wr.textAttributionSnippet).toBeUndefined();
+      });
+
+      it('converts ebucoreDuration to a Number', () => {
+        const edm = { ebucoreDuration: '165912' };
+        const wr = new WebResource(edm);
+
+        expect(wr.ebucoreDuration).toBe(165912);
+      });
+
+      it('divides ebucoreDuration > 24 hours by 1,000', () => {
+        const edm = { ebucoreDuration: '138411000' };
+        const wr = new WebResource(edm);
+
+        expect(wr.ebucoreDuration).toBe(138411);
+      });
+    });
+
     describe('.id', () => {
       it('is an alias for property `about`', () => {
         const edm = { about: '/123/abc' };


### PR DESCRIPTION
1. it is a string instead of a number
2. it may be 1,000 bigger than it should; infer erroneous if duration > 24 hours
3. it is used in the A/V player if duration otherwise unknown