### PR TITLE
refactor: check roles in ItemPinButton

### DIFF
--- a/packages/portal/src/components/item/ItemHero.spec.js
+++ b/packages/portal/src/components/item/ItemHero.spec.js
@@ -26,10 +26,6 @@ const factory = ({ propsData = {}, mocks = {}, provide = {} } = {}) => shallowMo
     $t: (key) => key,
     $i18n: { locale: 'en' },
     $features: { itemEmbedCode: false, transcribathonCta: true },
-    $auth: {
-      loggedIn: true,
-      userHasClientRole: sinon.stub().returns(false)
-    },
     $store: {
       getters: {
         'entity/isPinned': storeIsPinnedGetter,
@@ -193,46 +189,6 @@ describe('components/item/ItemHero', () => {
         const wrapper = factory({ propsData: { linkForContributingAnnotation: 'https://example.org/123', media, entities } });
 
         expect(wrapper.vm.showTranscribathonLink).toBe(false);
-      });
-    });
-  });
-
-  describe('showPins', () => {
-    describe('when the user is an editor', () => {
-      const userHasClientRole = sinon.stub().returns(false)
-        .withArgs('entities', 'editor').returns(true)
-        .withArgs('usersets', 'editor').returns(true);
-      const mocks = {
-        $auth: {
-          loggedIn: true,
-          userHasClientRole
-        }
-      };
-
-      it('is `true`', () => {
-        const wrapper = factory({ propsData: { media, entities }, mocks });
-
-        const showPins = wrapper.vm.showPins;
-
-        expect(showPins).toBe(true);
-      });
-
-      it('is `false` if no entities', () => {
-        const wrapper = factory({ propsData: { media, entities: [] }, mocks });
-
-        const showPins = wrapper.vm.showPins;
-
-        expect(showPins).toBe(false);
-      });
-    });
-
-    describe('when the user is NOT an editor', () => {
-      it('is `false`', () => {
-        const wrapper = factory({ propsData: { media, entities } });
-
-        const showPins = wrapper.vm.showPins;
-
-        expect(showPins).toBe(false);
       });
     });
   });

--- a/packages/portal/src/components/item/ItemHero.spec.js
+++ b/packages/portal/src/components/item/ItemHero.spec.js
@@ -95,8 +95,6 @@ const media = [
   })
 ];
 
-const entities = [{ about: 'http://data.europeana.eu/agent/123', prefLabel: { 'en': ['CARARE'] } }];
-
 describe('components/item/ItemHero', () => {
   describe('selectMedia', () => {
     describe('when a new item is selected', () => {

--- a/packages/portal/src/components/item/ItemHero.vue
+++ b/packages/portal/src/components/item/ItemHero.vue
@@ -43,8 +43,7 @@
               <client-only>
                 <UserButtons
                   :identifier="identifier"
-                  :show-pins="showPins"
-                  :entities="entities"
+                  :show-pins="true"
                   button-variant="secondary"
                 />
               </client-only>
@@ -139,11 +138,6 @@
         type: Object,
         default: () => ({})
       },
-      // Entities related to the item, used for pinning.
-      entities: {
-        type: Array,
-        default: () => []
-      },
       providerUrl: {
         type: String,
         default: null
@@ -181,15 +175,6 @@
           return this.edmRights;
         }
         return '';
-      },
-      showPins() {
-        return this.userIsEntitiesEditor && this.userIsSetsEditor && this.entities.length > 0;
-      },
-      userIsEntitiesEditor() {
-        return this.$auth.userHasClientRole('entities', 'editor');
-      },
-      userIsSetsEditor() {
-        return this.$auth.userHasClientRole('usersets', 'editor');
       },
       showTranscribathonLink() {
         return this.$features.transcribathonCta && this.linkForContributingAnnotation && TRANSCRIBATHON_URL_ROOT.test(this.linkForContributingAnnotation);

--- a/packages/portal/src/components/item/ItemPinButton.spec.js
+++ b/packages/portal/src/components/item/ItemPinButton.spec.js
@@ -10,9 +10,10 @@ const identifier = '/123/abc';
 const storeDispatchSuccess = sinon.spy();
 const storeIsPinnedGetter = sinon.stub();
 
-const factory = ({ storeState = {}, storeDispatch = storeDispatchSuccess } = {}) => shallowMount(ItemPinButton, {
+const factory = ({ mocks = {}, provide = {}, storeState = {}, storeDispatch = storeDispatchSuccess } = {}) => shallowMount(ItemPinButton, {
   localVue,
   propsData: { identifier },
+  provide,
   mocks: {
     $apis: {
       set: {
@@ -24,6 +25,7 @@ const factory = ({ storeState = {}, storeDispatch = storeDispatchSuccess } = {})
         pinItem: sinon.spy()
       }
     },
+    $auth: {},
     $error: (error) => {
       console.error(error);
       throw error;
@@ -41,7 +43,8 @@ const factory = ({ storeState = {}, storeDispatch = storeDispatchSuccess } = {})
       },
       dispatch: storeDispatch
     },
-    $t: (key) => key
+    $t: (key) => key,
+    ...mocks
   }
 });
 
@@ -49,150 +52,188 @@ describe('components/item/ItemPinButton', () => {
   afterEach(sinon.resetHistory);
 
   describe('template', () => {
-    describe('when on an entity page', () => {
-      const storeState = { id: 'http://data.europeana.eu/topic/123' };
+    describe('when not logged-in', () => {
+      const $auth = {
+        loggedIn: false,
+        userHasClientRole: sinon.stub().returns(false)
+      };
 
-      it('is visible', async() => {
-        const wrapper = factory({ storeState });
+      it('is not rendered', () => {
+        const wrapper = factory({ mocks: { $auth } });
 
-        const pinButton = wrapper.find('b-button-stub[data-qa="pin button"]');
+        const buttonWrapper = wrapper.find('.pin-button-wrapper');
 
-        expect(pinButton.isVisible()).toBe(true);
-      });
-
-      it('does not contain text', async() => {
-        const wrapper = factory({ storeState });
-
-        const pinButton = wrapper.find('b-button-stub[data-qa="pin button"]');
-
-        expect(pinButton.text()).toBe('');
-      });
-
-      describe('when button with text', () => {
-        it('contains text', async() => {
-          const wrapper = factory({ storeState });
-          await wrapper.setProps({ buttonText: true });
-
-          const pinButton = wrapper.find('b-button-stub[data-qa="pin button"]');
-
-          expect(pinButton.text()).toBe('actions.pin');
-        });
-      });
-
-      describe('when item is not pinned', () => {
-        beforeEach(() => {
-          storeIsPinnedGetter.returns(false);
-        });
-
-        describe('when pressed', () => {
-          it('ensures the set exists', async() => {
-            const wrapper = factory({ storeState });
-            sinon.spy(wrapper.vm, 'ensureEntityBestItemsSetExists');
-
-            const pinButton = wrapper.find('b-button-stub[data-qa="pin button"]');
-            await pinButton.trigger('click');
-
-            expect(wrapper.vm.ensureEntityBestItemsSetExists.called).toBe(true);
-          });
-
-          it('pins the item', async() => {
-            const wrapper = factory({ storeState });
-            sinon.spy(wrapper.vm, 'pinItemToEntityBestItemsSet');
-
-            const pinButton = wrapper.find('b-button-stub[data-qa="pin button"]');
-            await pinButton.trigger('click');
-
-            expect(wrapper.vm.pinItemToEntityBestItemsSet.called).toBe(true);
-          });
-        });
-      });
-      describe('when item is pinned', () => {
-        beforeEach(() => {
-          storeIsPinnedGetter.returns(true);
-        });
-
-        it('button text is updated', async() => {
-          const wrapper = factory({ storeState });
-          await wrapper.setProps({ buttonText: true });
-
-          const pinButton = wrapper.find('b-button-stub[data-qa="pin button"]');
-          expect(pinButton.text()).toBe('statuses.pinned');
-        });
-
-        describe('when pressed', () => {
-          it('unpins the item', async() => {
-            const wrapper = factory({ storeState });
-            sinon.spy(wrapper.vm, 'unpinItemFromEntityBestItemsSet');
-
-            const pinButton = wrapper.find('b-button-stub[data-qa="pin button"]');
-            await pinButton.trigger('click');
-
-            expect(wrapper.vm.unpinItemFromEntityBestItemsSet.called).toBe(true);
-          });
-        });
+        expect(buttonWrapper.exists()).toBe(false);
       });
     });
 
-    describe('when on an entity-set page', () => {
-      it('is visible', async() => {
-        const wrapper = factory();
-        wrapper.vm.$store.state.entity.bestItemsSetId = 1;
+    describe('when logged-in but not authorised to pin', () => {
+      const $auth = {
+        loggedIn: true,
+        userHasClientRole: sinon.stub().returns(false)
+      };
 
-        const pinButton = wrapper.find('b-button-stub[data-qa="pin button"]');
+      it('is not rendered', () => {
+        const wrapper = factory({ mocks: { $auth } });
 
-        expect(pinButton.isVisible()).toBe(true);
-      });
+        const buttonWrapper = wrapper.find('.pin-button-wrapper');
 
-      it('does not contain text', async() => {
-        const wrapper = factory();
-        wrapper.vm.$store.state.entity.bestItemsSetId = 1;
-
-        const pinButton = wrapper.find('b-button-stub[data-qa="pin button"]');
-
-        expect(pinButton.text()).toBe('');
-      });
-
-      describe('when item is pinned', () => {
-        beforeEach(() => {
-          storeIsPinnedGetter.returns(true);
-        });
-
-        describe('when pressed', () => {
-          it('unpins the item', async() => {
-            const wrapper = factory();
-            wrapper.vm.$store.state.entity.bestItemsSetId = 1;
-            sinon.spy(wrapper.vm, 'unpinItemFromEntityBestItemsSet');
-
-            const pinButton = wrapper.find('b-button-stub[data-qa="pin button"]');
-            await pinButton.trigger('click');
-
-            expect(wrapper.vm.unpinItemFromEntityBestItemsSet.called).toBe(true);
-          });
-        });
+        expect(buttonWrapper.exists()).toBe(false);
       });
     });
 
-    describe('when on an item page', () => {
-      describe('when the item has related entities', () => {
+    describe('when logged-in and authorised to pin', () => {
+      const $auth = {
+        loggedIn: true,
+        userHasClientRole: sinon.stub().returns(false)
+          .withArgs('entities', 'editor').returns(true)
+          .withArgs('usersets', 'editor').returns(true)
+      };
+
+      describe('when on an entity page', () => {
+        const storeState = { id: 'http://data.europeana.eu/topic/123' };
+
         it('is visible', async() => {
-          const wrapper = factory();
-          await wrapper.setProps({ entities: ['http://data.europeana.eu/topic/123'] });
+          const wrapper = factory({ mocks: { $auth }, storeState });
 
           const pinButton = wrapper.find('b-button-stub[data-qa="pin button"]');
 
           expect(pinButton.isVisible()).toBe(true);
         });
 
-        describe('when clicked', () => {
-          it('opens the modal', async() => {
-            const wrapper = factory();
-            await wrapper.setProps({ entities: ['http://data.europeana.eu/topic/123'] });
-            const bvModalShow = sinon.spy(wrapper.vm.$bvModal, 'show');
+        it('does not contain text', async() => {
+          const wrapper = factory({ mocks: { $auth }, storeState });
+
+          const pinButton = wrapper.find('b-button-stub[data-qa="pin button"]');
+
+          expect(pinButton.text()).toBe('');
+        });
+
+        describe('when button with text', () => {
+          it('contains text', async() => {
+            const wrapper = factory({ mocks: { $auth }, storeState });
+            await wrapper.setProps({ buttonText: true });
 
             const pinButton = wrapper.find('b-button-stub[data-qa="pin button"]');
-            await pinButton.trigger('click');
 
-            expect(bvModalShow.calledWith(`pin-modal-${identifier}`)).toBe(true);
+            expect(pinButton.text()).toBe('actions.pin');
+          });
+        });
+
+        describe('when item is not pinned', () => {
+          beforeEach(() => {
+            storeIsPinnedGetter.returns(false);
+          });
+
+          describe('when pressed', () => {
+            it('ensures the set exists', async() => {
+              const wrapper = factory({ mocks: { $auth }, storeState });
+              sinon.spy(wrapper.vm, 'ensureEntityBestItemsSetExists');
+
+              const pinButton = wrapper.find('b-button-stub[data-qa="pin button"]');
+              await pinButton.trigger('click');
+
+              expect(wrapper.vm.ensureEntityBestItemsSetExists.called).toBe(true);
+            });
+
+            it('pins the item', async() => {
+              const wrapper = factory({ mocks: { $auth }, storeState });
+              sinon.spy(wrapper.vm, 'pinItemToEntityBestItemsSet');
+
+              const pinButton = wrapper.find('b-button-stub[data-qa="pin button"]');
+              await pinButton.trigger('click');
+
+              expect(wrapper.vm.pinItemToEntityBestItemsSet.called).toBe(true);
+            });
+          });
+        });
+        describe('when item is pinned', () => {
+          beforeEach(() => {
+            storeIsPinnedGetter.returns(true);
+          });
+
+          it('button text is updated', async() => {
+            const wrapper = factory({ mocks: { $auth }, storeState });
+            await wrapper.setProps({ buttonText: true });
+
+            const pinButton = wrapper.find('b-button-stub[data-qa="pin button"]');
+            expect(pinButton.text()).toBe('statuses.pinned');
+          });
+
+          describe('when pressed', () => {
+            it('unpins the item', async() => {
+              const wrapper = factory({ mocks: { $auth }, storeState });
+              sinon.spy(wrapper.vm, 'unpinItemFromEntityBestItemsSet');
+
+              const pinButton = wrapper.find('b-button-stub[data-qa="pin button"]');
+              await pinButton.trigger('click');
+
+              expect(wrapper.vm.unpinItemFromEntityBestItemsSet.called).toBe(true);
+            });
+          });
+        });
+      });
+
+      describe('when on an entity-set page', () => {
+        const storeState = { bestItemsSetId: 1 };
+
+        it('is visible', () => {
+          const wrapper = factory({ mocks: { $auth }, storeState });
+
+          const pinButton = wrapper.find('b-button-stub[data-qa="pin button"]');
+
+          expect(pinButton.isVisible()).toBe(true);
+        });
+
+        it('does not contain text', () => {
+          const wrapper = factory({ mocks: { $auth }, storeState });
+
+          const pinButton = wrapper.find('b-button-stub[data-qa="pin button"]');
+
+          expect(pinButton.text()).toBe('');
+        });
+
+        describe('when item is pinned', () => {
+          beforeEach(() => {
+            storeIsPinnedGetter.returns(true);
+          });
+
+          describe('when pressed', () => {
+            it('unpins the item', async() => {
+              const wrapper = factory({ mocks: { $auth }, storeState });
+              sinon.spy(wrapper.vm, 'unpinItemFromEntityBestItemsSet');
+
+              const pinButton = wrapper.find('b-button-stub[data-qa="pin button"]');
+              await pinButton.trigger('click');
+
+              expect(wrapper.vm.unpinItemFromEntityBestItemsSet.called).toBe(true);
+            });
+          });
+        });
+      });
+
+      describe('when on an item page', () => {
+        describe('when the item has related entities', () => {
+          const provide = { itemPinning: { entities: ['http://data.europeana.eu/topic/123'] } };
+
+          it('is visible', () => {
+            const wrapper = factory({ mocks: { $auth }, provide });
+
+            const pinButton = wrapper.find('b-button-stub[data-qa="pin button"]');
+
+            expect(pinButton.isVisible()).toBe(true);
+          });
+
+          describe('when clicked', () => {
+            it('opens the modal', async() => {
+              const wrapper = factory({ mocks: { $auth }, provide });
+              const bvModalShow = sinon.spy(wrapper.vm.$bvModal, 'show');
+
+              const pinButton = wrapper.find('b-button-stub[data-qa="pin button"]');
+              await pinButton.trigger('click');
+
+              expect(bvModalShow.calledWith(`pin-modal-${identifier}`)).toBe(true);
+            });
           });
         });
       });

--- a/packages/portal/src/components/item/ItemPinButton.vue
+++ b/packages/portal/src/components/item/ItemPinButton.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="pin-button-wrapper">
+  <div
+    v-if="isPinnable && userMayPin"
+    class="pin-button-wrapper"
+  >
     <b-button
       class="pin-button text-uppercase"
       :class="{ 'button-icon-only': !buttonText }"
@@ -61,6 +64,14 @@
       entityBestItemsSetMixin
     ],
 
+    inject: {
+      itemPinning: {
+        default() {
+          return {};
+        }
+      }
+    },
+
     props: {
       /**
        * Identifier of the item
@@ -68,13 +79,6 @@
       identifier: {
         type: String,
         required: true
-      },
-      /**
-       * Entities related to the item, used on item page.
-       */
-      entities: {
-        type: Array,
-        default: () => []
       },
       /**
        * Button variant to use for styling the buttons
@@ -100,8 +104,23 @@
     },
 
     computed: {
+      entities() {
+        return this.itemPinning.entities || [];
+      },
       entityUris() {
         return this.entities.map((entity) => entity.about);
+      },
+      isPinnable() {
+        return (this.entities.length > 0) || this.entityId || this.setId;
+      },
+      userMayPin() {
+        return this.userIsEntitiesEditor && this.userIsSetsEditor;
+      },
+      userIsEntitiesEditor() {
+        return this.$auth.userHasClientRole('entities', 'editor');
+      },
+      userIsSetsEditor() {
+        return this.$auth.userHasClientRole('usersets', 'editor');
       },
       pinned() {
         return this.$store.getters['entity/isPinned'](this.identifier);

--- a/packages/portal/src/components/user/UserButtons.vue
+++ b/packages/portal/src/components/user/UserButtons.vue
@@ -7,7 +7,6 @@
       v-if="showPins"
       data-qa="item pin button"
       :identifier="identifier"
-      :entities="entities"
       :button-variant="buttonVariant"
       :button-text="buttonText"
     />
@@ -73,11 +72,6 @@
       identifier: {
         type: String,
         required: true
-      },
-      // Entities related to the item, used on item page.
-      entities: {
-        type: Array,
-        default: () => []
       },
       /**
        * If `true`, pin button will be rendered

--- a/packages/portal/src/pages/collections/_type/_.vue
+++ b/packages/portal/src/pages/collections/_type/_.vue
@@ -15,7 +15,7 @@
         v-if="!$fetchState.pending && !redirecting"
         :route="route"
         :show-content-tier-toggle="false"
-        :show-pins="userIsEntitiesEditor && userIsSetsEditor"
+        :show-pins="true"
         :default-params="searchOverrides"
       >
         <template
@@ -232,9 +232,6 @@
       },
       userIsEntitiesEditor() {
         return this.$auth.userHasClientRole('entities', 'editor');
-      },
-      userIsSetsEditor() {
-        return this.$auth.userHasClientRole('usersets', 'editor');
       },
       route() {
         return {

--- a/packages/portal/src/pages/galleries/_.vue
+++ b/packages/portal/src/pages/galleries/_.vue
@@ -130,7 +130,7 @@
         :loading="$fetchState.pending"
         :per-page="perPage"
         :total="set.total"
-        :show-pins="setIsEntityBestItems && userIsEntityEditor"
+        :show-pins="true"
         :user-editable-items="userCanEditSet"
         @endItemDrag="repositionItem"
       >

--- a/packages/portal/src/pages/item/_.vue
+++ b/packages/portal/src/pages/item/_.vue
@@ -28,7 +28,6 @@
           :edm-type="type"
           :attribution-fields="attributionFields"
           :link-for-contributing-annotation="linkForContributingAnnotation"
-          :entities="europeanaEntities"
           :provider-url="isShownAt"
           :iiif-presentation-manifest="iiifPresentationManifest"
         />
@@ -176,6 +175,9 @@
         deBias: computed(() => this.deBias),
         itemIsDeleted: computed(() => this.isDeleted),
         itemLanguage: computed(() => this.metadata.edmLanguage?.def?.[0]),
+        itemPinning: computed(() => ({
+          entities: this.europeanaEntities
+        })),
         metadataLanguage: this.metadataLanguage,
         textTrackAnnotations: computed(() => this.textTrackAnnotations)
       };


### PR DESCRIPTION
so they don't need to be checked in all ancestor views

plus, use provide/inject for pinnable entities from item page