### PR TITLE
fix: display metadata sidebar for isFormatOf

### DIFF
--- a/packages/portal/src/components/item/ItemMediaPresentation.vue
+++ b/packages/portal/src/components/item/ItemMediaPresentation.vue
@@ -335,7 +335,8 @@
       },
 
       hasWebResourceMetadataToDisplay() {
-        return WEB_RESOURCE_METADATA_DISPLAY_FIELDS.some((field) => !!this.resource?.edm?.[field]);
+        const wrs = [this.resource?.edm].concat(this.resource?.edm?.dctermsIsFormatOf?.def).filter(Boolean);
+        return WEB_RESOURCE_METADATA_DISPLAY_FIELDS.some((field) => wrs.some((wr) => wr[field] !== undefined));
       },
 
       sidebarHasContent() {


### PR DESCRIPTION
even if no metadata to show for displayed web resource