### PR TITLE
fix: init WRs to empty array

### DIFF
--- a/packages/portal/src/pages/item/_.vue
+++ b/packages/portal/src/pages/item/_.vue
@@ -465,7 +465,7 @@
         //       - not iiif: proxy
         //       - iiif, europeana: proxy
         //       - iiif, institution: don't proxy
-        this.proxyableMedia = item.providerAggregation.webResources.map((wr) => wr.about)
+        this.proxyableMedia = (item.providerAggregation.webResources || []).map((wr) => wr.about)
           .filter((wr) => wr.ebucoreMimeType !== 'application/dash+xml');
         this.iiifPresentationManifest = item.iiifPresentationManifest;
         this.isShownAt = item.providerAggregation.edmIsShownAt;


### PR DESCRIPTION
to not break on item tombstone page