### PR TITLE
chore: set fulltext API base URL w/o gateway

### DIFF
--- a/packages/portal/src/plugins/europeana/fulltext.js
+++ b/packages/portal/src/plugins/europeana/fulltext.js
@@ -2,5 +2,7 @@ import EuropeanaApi from './apis/base.js';
 
 export default class EuropeanaFulltextApi extends EuropeanaApi {
   static ID = 'fulltext';
-  static BASE_URL = 'https://api.europeana.eu/fulltext';
+  // NOTE: full text does not work via API gateway
+  // static BASE_URL = 'https://api.europeana.eu/fulltext';
+  static BASE_URL = 'https://newspapers.eanadev.org/api/v2';
 }

--- a/tests/e2e/docker/nginx/conf.d/default.conf
+++ b/tests/e2e/docker/nginx/conf.d/default.conf
@@ -17,6 +17,12 @@ server {
     proxy_cache apis;
   }
 
+  location ~ ^/api/fulltext/(.*) {
+    proxy_pass https://newspapers.eanadev.org/api/v2/$1$is_args$args;
+    proxy_cache apis;
+    proxy_cache_valid 200 301 302 400 401 403 404 10m;
+  }
+
   location ~ ^/api/(.*) {
     proxy_pass https://api.europeana.eu/$1$is_args$args;
     proxy_cache apis;


### PR DESCRIPTION
as the API gateway still doesn't work with it