### PR TITLE
refactor: return entity API search response as-is

### DIFF
--- a/packages/portal/src/components/entity/EntityTypeBrowse.vue
+++ b/packages/portal/src/components/entity/EntityTypeBrowse.vue
@@ -71,9 +71,8 @@
 
       try {
         const response = await this.$apis.entity.search(entityIndexParams);
-
-        this.entities = response.entities;
-        this.total = response.total;
+        this.entities = response.items;
+        this.total = response.partOf?.total || null;
       } finally {
         process.client && this.scrollToSelector('#header');
       }

--- a/packages/portal/src/plugins/europeana/entity.js
+++ b/packages/portal/src/plugins/europeana/entity.js
@@ -89,11 +89,7 @@ export default class EuropeanaEntityApi extends EuropeanaApi {
       method: 'get',
       url: '/search',
       params
-    })
-      .then((response) => ({
-        entities: response.items || [],
-        total: response.partOf?.total || null
-      }));
+    });
   }
 
   imageUrl(entity) {

--- a/packages/portal/src/plugins/europeana/entity.spec.js
+++ b/packages/portal/src/plugins/europeana/entity.spec.js
@@ -475,19 +475,9 @@ describe('plugins/europeana/entity', () => {
         scope: 'europeana'
       };
 
-      it('returns a list of concept entities', async() => {
+      it('returns the response data', async() => {
         const response = await (new api).search(eParams, 'topic');
-        expect(response.entities.length).toBe(conceptEntitiesResponse.items.length);
-      });
-
-      it('returns the total number of entities', async() => {
-        const response = await (new api).search(eParams, 'topic');
-        expect(response.total).toBe(conceptEntitiesResponse.partOf.total);
-      });
-
-      it('returns a thumbnail for each entity', async() => {
-        const response = await (new api).search(eParams, 'topic');
-        expect(response.entities[0].isShownBy.thumbnail).toBe(conceptEntitiesResponse.items[0].isShownBy.thumbnail);
+        expect(response).toEqual(conceptEntitiesResponse);
       });
     });
   });


### PR DESCRIPTION
and let consumers pick/modify as they required