### PR TITLE
feat: entity info modal aggregates from badges

### DIFF
--- a/packages/portal/src/components/entity/EntityBadges.vue
+++ b/packages/portal/src/components/entity/EntityBadges.vue
@@ -4,7 +4,10 @@
     data-qa="related collections"
     class="related-collections"
   >
-    <h2 class="related-heading text-uppercase">
+    <h2
+      v-if="showTitle"
+      class="related-heading text-uppercase"
+    >
       {{ title || $t('related.collections.title') }}
     </h2>
     <component
@@ -99,6 +102,13 @@
       limit: {
         type: Number,
         default: null
+      },
+      /**
+       * Show or hide title
+       */
+      showTitle: {
+        type: Boolean,
+        default: true
       }
     },
 

--- a/packages/portal/src/components/entity/EntityHeader.spec.js
+++ b/packages/portal/src/components/entity/EntityHeader.spec.js
@@ -1,5 +1,6 @@
 import { createLocalVue, shallowMount } from '@vue/test-utils';
 import BootstrapVue from 'bootstrap-vue';
+import sinon from 'sinon';
 
 import EntityHeader from '@/components/entity/EntityHeader.vue';
 
@@ -11,6 +12,14 @@ const factory = (propsData = {}) => shallowMount(EntityHeader, {
   localVue,
   propsData,
   mocks: {
+    $apis: {
+      entity: {
+        imageUrl: sinon.spy()
+      }
+    },
+    $i18n: {
+      locale: 'en'
+    },
     $store: {
       state: {
         search: {
@@ -20,19 +29,32 @@ const factory = (propsData = {}) => shallowMount(EntityHeader, {
     },
     $t: (val) => val,
     $redrawVueMasonry: () => true
-  }
+  },
+  stubs: ['EntityInformationModal', 'EntityUpdateModal']
 });
 
 const entityProps = {
-  id: 'http://data.europeana.eu/concept/6',
   title: { values: ['Book'], code: 'en' },
   description: { values: ['Architecture is both the process and the product of planning, designing, and constructing buildings and other physical structures.'], code: 'en' },
-  logo: 'https://www.example.eu/logo.svg',
-  email: 'email@example.org',
-  image: 'https://www.example.eu/image.jpg',
   editable: false,
-  externalLink: 'https://www.example.eu/',
-  moreInfo: []
+  entity: {
+    id: 'http://data.europeana.eu/concept/6',
+    prefLabel: { en: 'Book' }
+  }
+};
+
+const organisationEntityProps = {
+  title: { values: ['Bibliotheek'], code: 'nl' },
+  description: { values: ['Architecture is both the process and the product of planning, designing, and constructing buildings and other physical structures.'], code: 'en' },
+  editable: false,
+  entity: {
+    id: 'http://data.europeana.eu/organization/1',
+    logo: { id: 'https://www.example.eu/logo.svg' },
+    homepage: 'https://www.example.eu/',
+    mbox: 'email@example.org',
+    prefLabel: { en: 'Library',  nl: 'Bibliotheek' },
+    type: 'Organization'
+  }
 };
 
 describe('components/entity/EntityHeaders', () => {
@@ -41,7 +63,6 @@ describe('components/entity/EntityHeaders', () => {
       const wrapper = factory(entityProps);
 
       expect(wrapper.find('[data-qa="entity title"]').text()).toBe('Book');
-      expect(wrapper.find('[data-qa="entity title"]').attributes('lang')).toBe('en');
       expect(wrapper.find('[data-qa="entity description"]').text()).toBe(entityProps.description.values[0]);
     });
 
@@ -67,43 +88,6 @@ describe('components/entity/EntityHeaders', () => {
       });
     });
 
-    it('shows a logo', () => {
-      const wrapper = factory(entityProps);
-
-      const logo = wrapper.find('[data-qa="entity logo"]');
-      const resizedLogo = wrapper.vm.resizedLogo;
-
-      expect(logo.exists()).toBe(true);
-      expect(logo.attributes('style')).toBe(`background-image: url(${resizedLogo});`);
-    });
-
-    it('shows a contact button', () => {
-      const wrapper = factory(entityProps);
-
-      const contactButton = wrapper.find('[data-qa="entity contact button"]');
-
-      expect(contactButton.exists()).toBe(true);
-      expect(contactButton.attributes('href')).toBe('mailto:email@example.org');
-    });
-
-    it('shows a learn more button', () => {
-      // This test doesn't confirm that the button opens the modal.
-      const wrapper = factory(entityProps);
-
-      const learnMoreButton = wrapper.find('[data-qa="entity details button"]');
-
-      expect(learnMoreButton.exists()).toBe(true);
-    });
-
-    it('has a more info modal', () => {
-      // This test doesn't confirm that the modal works, just that it exists.
-      const wrapper = factory(entityProps);
-
-      const moreInfoModal = wrapper.find('#entityInformationModal');
-
-      expect(moreInfoModal.exists()).toBe(true);
-    });
-
     describe('editing when it is enabled', () => {
       it('shows an edit button', () => {
         // This test doesn't confirm that the button opens the modal.
@@ -118,9 +102,94 @@ describe('components/entity/EntityHeaders', () => {
         // This test doesn't confirm that the modal works, just that it exists.
         const wrapper = factory({ ...entityProps, editable: true });
 
-        const editModal = wrapper.find('#entityUpdateModal');
+        const editModal = wrapper.find('entityupdatemodal-stub');
 
         expect(editModal.exists()).toBe(true);
+      });
+    });
+
+    describe('when type is organisation', () => {
+      it('shows a logo', () => {
+        const wrapper = factory(organisationEntityProps);
+
+        const logo = wrapper.find('[data-qa="entity logo"]');
+        const resizedLogo = wrapper.vm.resizedLogo;
+
+        expect(logo.exists()).toBe(true);
+        expect(logo.attributes('style')).toBe(`background-image: url(${resizedLogo});`);
+      });
+
+      it('shows a contact button', () => {
+        const wrapper = factory(organisationEntityProps);
+
+        const contactButton = wrapper.find('[data-qa="entity contact button"]');
+
+        expect(contactButton.exists()).toBe(true);
+        expect(contactButton.attributes('href')).toBe('mailto:email@example.org');
+      });
+
+      it('shows a learn more button', () => {
+      // This test doesn't confirm that the button opens the modal.
+        const wrapper = factory(organisationEntityProps);
+
+        const learnMoreButton = wrapper.find('[data-qa="entity details button"]');
+
+        expect(learnMoreButton.exists()).toBe(true);
+      });
+
+      it('has a more info modal', () => {
+      // This test doesn't confirm that the modal works, just that it exists.
+        const wrapper = factory(organisationEntityProps);
+
+        const moreInfoModal = wrapper.find('entityinformationmodal-stub');
+
+        expect(moreInfoModal.exists()).toBe(true);
+      });
+    });
+  });
+
+  describe('computed', () => {
+    describe('thumbnail', () => {
+      it('returns a thumbnail when available', () => {
+        const wrapper = factory(entityProps);
+
+        wrapper.vm.thumbnail;
+        expect(wrapper.vm.$apis.entity.imageUrl.called).toBe(true);
+      });
+    });
+    describe('when type is organisation', () => {
+      describe('email', () => {
+        it('returns the email on organisation pages', () => {
+          const wrapper = factory(organisationEntityProps);
+
+          const email = wrapper.vm.email;
+          expect(email).toBe(organisationEntityProps.entity.mbox);
+        });
+      });
+      describe('subTitle', () => {
+        it('uses the English prefLabel for an organisation, if non-native', () => {
+          const wrapper = factory(organisationEntityProps);
+
+          const subTitle = wrapper.vm.subTitle.values[0];
+
+          expect(subTitle).toBe(organisationEntityProps.entity.prefLabel.en);
+        });
+      });
+      describe('homepage', () => {
+        it('returns a homepage on organisation pages', () => {
+          const wrapper = factory(organisationEntityProps);
+
+          const homepage = wrapper.vm.homepage;
+          expect(homepage).toBe(organisationEntityProps.entity.homepage);
+        });
+      });
+      describe('logo', () => {
+        it('returns a logo', () => {
+          const wrapper = factory(organisationEntityProps);
+
+          const logo = wrapper.vm.logo;
+          expect(logo).toBe(organisationEntityProps.entity.logo.id);
+        });
       });
     });
   });

--- a/packages/portal/src/components/entity/EntityHeader.vue
+++ b/packages/portal/src/components/entity/EntityHeader.vue
@@ -44,7 +44,7 @@
       </b-button>
     </b-card-text>
     <template
-      v-if="moreInfo"
+      v-if="isOrganisationType"
     >
       <b-button
         class="d-inline-flex align-items-center"
@@ -56,7 +56,9 @@
       </b-button>
       <EntityInformationModal
         :title="title"
-        :entity-info="moreInfo"
+        :sub-title="subTitle"
+        :entity="entity"
+        :english-name="organisationNonNativeEnglishName"
       />
     </template>
     <b-button
@@ -69,16 +71,16 @@
       {{ $t('actions.contact') }}
     </b-button>
     <b-button
-      v-if="externalLink"
+      v-if="homepage"
       class="d-inline-flex align-items-center"
-      :href="externalLink"
+      :href="homepage"
       target="_blank"
     >
       <span class="icon-link pr-1" />
       {{ $t('website') }}
     </b-button>
     <ShareButton />
-    <ShareSocialModal :media-url="image ? image : logo" />
+    <ShareSocialModal :media-url="thumbnail ? thumbnail : logo" />
     <client-only>
       <template
         v-if="editable"
@@ -92,7 +94,7 @@
           {{ $t('actions.edit') }}
         </b-button>
         <EntityUpdateModal
-          :id="id"
+          :id="entity.id"
           :description="description && description.values[0] || null"
           @updated="$emit('updated')"
         />
@@ -108,6 +110,8 @@
   import { getWikimediaThumbnailUrl } from '@/plugins/europeana/entity';
   import ShareButton from '@/components/share/ShareButton';
   import ShareSocialModal from '@/components/share/ShareSocialModal';
+  import { langMapValueForLocale, uriRegex } from  '@europeana/i18n';
+  import { organizationEntityNonNativeEnglishName } from '@/utils/europeana/entities/organizations.js';
 
   export default {
     name: 'EntityHeader',
@@ -126,25 +130,18 @@
 
     props: {
       /**
+       * Entity
+       */
+      entity: {
+        type: Object,
+        required: true
+      },
+      /**
        * Title of the entity
        */
       title: {
         type: Object,
         required: true
-      },
-      /**
-       * URI of the entity
-       */
-      id: {
-        type: String,
-        required: true
-      },
-      /**
-       * Sub-title of the entity
-       */
-      subTitle: {
-        type: Object,
-        default: null
       },
       /**
        * Description of the entity as object with 'values' (array of strings) and 'code' two letter language code
@@ -154,46 +151,11 @@
         default: null
       },
       /**
-       * Logo image file path (currently only used for organisation entity)
-       */
-      logo: {
-        type: String,
-        default: null
-      },
-      /**
-       * Email, used for organisation entity contact button
-       */
-      email: {
-        type: String,
-        default: null
-      },
-      /**
-       * Image file path for social media sharing
-       */
-      image: {
-        type: String,
-        default: null
-      },
-      /**
        * If 'true' enables the edit button and modal
        */
       editable: {
         type: Boolean,
         default: false
-      },
-      /**
-       * Website link (currently only used for organisation entity)
-       */
-      externalLink: {
-        type: String,
-        default: null
-      },
-      /**
-       * More entity data to show in modal (currently only used for organisation entity)
-       */
-      moreInfo: {
-        type: Array,
-        default: null
       }
     },
     data() {
@@ -204,6 +166,14 @@
     },
 
     computed: {
+      organisationNonNativeEnglishName() {
+        return this.organizationEntityNonNativeEnglishName(this.entity);
+      },
+      subTitle() {
+        return this.organisationNonNativeEnglishName ?
+          langMapValueForLocale(this.organisationNonNativeEnglishName, this.$i18n.locale) :
+          null;
+      },
       truncatedDescription() {
         return truncate(this.fullDescription, this.limitCharacters);
       },
@@ -213,11 +183,38 @@
       fullDescription() {
         return this.hasDescription ? this.description.values[0] : '';
       },
+      isOrganisationType() {
+        return this.entity.type === 'Organization';
+      },
+      logo() {
+        if (this.isOrganisationType && this.entity?.logo) {
+          return this.entity.logo.id;
+        }
+        return null;
+      },
       resizedLogo() {
         return getWikimediaThumbnailUrl(this.logo, 120);
+      },
+      email() {
+        if (this.isOrganisationType) {
+          return this.entity?.mbox;
+        }
+        return null;
+      },
+      thumbnail() {
+        return this.$apis.entity.imageUrl(this.entity);
+      },
+      homepage() {
+        if (this.isOrganisationType &&
+          this.entity?.homepage &&
+          uriRegex.test(this.entity.homepage)) {
+          return this.entity.homepage;
+        }
+        return null;
       }
     },
     methods: {
+      organizationEntityNonNativeEnglishName,
       toggleMoreDescription() {
         this.showAll = !this.showAll;
         this.$nextTick(() => {
@@ -300,7 +297,6 @@
   ```jsx
     <div style="background-color: #ededed; margin: -16px; padding: 16px;">
       <EntityHeader
-        id="http://data.europeana.eu/concept/190"
         :description="{ values: [
           'Discover inspiring art, artists and stories in the digitised collections of European museums, galleries,\
            libraries and archives. Explore paintings, drawings, engravings and sculpture from cultural heritage institutions\
@@ -309,14 +305,46 @@
            across Europe.'
         ] }"
         :title="{ values: ['Title'] }"
-        logo="https://cdn.jsdelivr.net/npm/@europeana/portal@1.62.2/.nuxt/dist/client/img/logo.e9d9080.svg"
+        :entity="{
+          id: 'http://data.europeana.eu/concept/190',
+          logo: { id: 'https://cdn.jsdelivr.net/npm/@europeana/portal@1.62.2/.nuxt/dist/client/img/logo.e9d9080.svg' },
+          homepage: 'https://www.europeana.eu'
+        }"
+      />
+    </div>
+  ```
+  Aggregator entity header
+  ```jsx
+    <div style="background-color: #ededed; margin: -16px; padding: 16px;">
+      <EntityHeader
+        :description="{ values: [
+          'Discover inspiring art, artists and stories in the digitised collections of European museums, galleries,\
+           libraries and archives. Explore paintings, drawings, engravings and sculpture from cultural heritage institutions\
+           across Europe. Discover inspiring art, artists and stories in the digitised collections of European museums, galleries,\
+           libraries and archives. Explore paintings, drawings, engravings and sculpture from cultural heritage institutions\
+           across Europe.'
+        ] }"
+        :title="{ values: ['Aggregator titel oorspronkelijke taal'] }"
+        :entity="{
+          id: 'http://data.europeana.eu/organization/190',
+          logo: { id: 'https://cdn.jsdelivr.net/npm/@europeana/portal@1.62.2/.nuxt/dist/client/img/logo.e9d9080.svg' },
+          homepage: 'https://www.europeana.eu',
+          mbox: 'info@aggregator.eu',
+          prefLabel: { en: 'Aggregator title in English', nl: 'Aggregator titel oorspronkelijke taal' },
+          type: 'Organization',
+          acronym: ['ABC'],
+          hasAddress: { countryName: 'The Netherlands', locality: 'The Hague' },
+          homepage: 'https://www.example.eu',
+          heritageDomain: 'Scientific heritage',
+          providesSupportForMediaType: ['Image', 'Video'],
+          geographicScope: 'International',
+          providesSupportForDataActivity: ['Copyright support','Content storage'],
+          providesCapacityBuildingActivity: ['One-to-one support', 'Webinars / workshops'],
+          providesAudienceEngagementActivity: ['Social media engagement', 'Digital curation'],
+          isAggregatedBy: { recordCount: 20000 },
+          aggregatesFrom: ['http://data.europeana.eu/organization/100', 'http://data.europeana.eu/organization/101',]
+        }"
         :editable="true"
-        externalLink="https://www.europeana.eu"
-        :moreInfo="[{ label: 'website', value: 'https://www.europeana.eu' },
-          { label: 'Country', value: 'The Netherlands' },
-          { label: 'Acronym', value: 'EF' },
-          { label: 'city', value: 'The Hague' }
-        ]"
       />
     </div>
   ```

--- a/packages/portal/src/components/entity/EntityInformationModal.spec.js
+++ b/packages/portal/src/components/entity/EntityInformationModal.spec.js
@@ -10,45 +10,87 @@ const factory = (propsData = {}) => mount(EntityInformationModal, {
   localVue,
   propsData,
   mocks: {
+    $i18n: { locale: 'en' },
     $n: (val) => val,
-    $t: (val) => val
+    $t: (val) => val,
+    $features: { aggregatorsTab: true }
   }
 });
 
-const info = [
-  { label: 'Website', value: 'https://www.deutsche-digitale-bibliothek.de' },
-  { label: 'Country', value: 'Germany' },
-  { label: 'Name acronym', value: 'DDB', lang: 'de' },
-  { label: 'City', value: 'Frankfurt am Main' }
+const englishName = { values: ['Library of Europe'], code: 'en' };
+const homepage = 'https://www.deutsche-digitale-bibliothek.de';
+const country = 'Germany';
+const city = 'Frankfurt am Main';
+const acronym = { en: 'ABC' };
+const heritageDomain = 'Scientific heritage';
+const providesSupportForMediaType = ['Image', 'Video'];
+const geographicScope = 'International';
+const providesSupportForDataActivity = ['Copyright support', 'Content storage'];
+const providesCapacityBuildingActivity = ['One-to-one support', 'Webinars / workshops'];
+const providesAudienceEngagementActivity = ['Social media engagement', 'Digital curation'];
+const isAggregatedBy = { recordCount: 20000 };
+const aggregatesFrom = ['http://data.europeana.eu/organization/100', 'http://data.europeana.eu/organization/101'];
+
+const expectedInfo = [
+  { label: 'website', value: homepage },
+  { label: 'organisation.country', value: country },
+  { label: 'organisation.nameAcronym', value: Object.values(acronym)[0], lang: Object.keys(acronym)[0] },
+  { label: 'organisation.city', value: city },
+  { label: 'organisation.heritageDomain', value: heritageDomain },
+  { label: 'organisation.providesSupportForMediaType', value: providesSupportForMediaType.join('; ') },
+  { label: 'organisation.geographicScope', value: geographicScope },
+  { label: 'organisation.providesSupportForDataActivity', value: providesSupportForDataActivity.join('; ') },
+  { label: 'organisation.providesCapacityBuildingActivity', value: providesCapacityBuildingActivity.join('; ') },
+  { label: 'organisation.providesAudienceEngagementActivity', value: providesAudienceEngagementActivity.join('; ') },
+  { label: 'organisation.recordCount', value: isAggregatedBy.recordCount.toString() },
+  { label: 'organisation.providingInstitutionsCount', value: aggregatesFrom.length.toString() }
+
 ];
+
+const entity = {
+  homepage,
+  hasAddress: {
+    countryName: country,
+    locality: city
+  },
+  acronym,
+  heritageDomain,
+  providesSupportForMediaType,
+  geographicScope,
+  providesSupportForDataActivity,
+  providesCapacityBuildingActivity,
+  providesAudienceEngagementActivity,
+  isAggregatedBy,
+  aggregatesFrom
+};
 
 const entityProps = {
   modalStatic: true,
-  title: { values: ['Europeana'], code: 'en' },
-  entityInfo: info
+  title: englishName,
+  entity,
+  englishName
 };
 
 describe('components/entity/EntityInformationModal', () => {
   it('shows a title', () => {
     const wrapper = factory(entityProps);
 
-    expect(wrapper.find('h5.modal-title').text()).toBe('Europeana');
-    expect(wrapper.find('h5.modal-title span').attributes('lang')).toBe('en');
+    expect(wrapper.find('h5.modal-title').text()).toBe(englishName.values[0]);
   });
 
   it('shows each info field with the corresponding label', () => {
     const wrapper = factory(entityProps);
-    Object.keys(info).forEach((key) => {
-      const infoField = wrapper.find(`ul li[data-qa="${info[key].label} field"]`);
-      expect(infoField.text()).toContain(info[key].label);
-      expect(infoField.text()).toContain(info[key].value);
+    Object.keys(expectedInfo).forEach((key) => {
+      const infoField = wrapper.find(`ul li[data-qa="${expectedInfo[key].label} field"]`);
+      expect(infoField.text()).toContain(expectedInfo[key].label);
+      expect(infoField.text()).toContain(expectedInfo[key].value);
     });
   });
 
   it('links to the organisation URL for the website', () => {
     const wrapper = factory(entityProps);
 
-    const websiteLink = wrapper.find('ul li[data-qa="Website field"] a');
-    expect(websiteLink.attributes().href).toEqual('https://www.deutsche-digitale-bibliothek.de');
+    const websiteLink = wrapper.find('ul li[data-qa="website field"] a');
+    expect(websiteLink.attributes().href).toEqual(homepage);
   });
 });

--- a/packages/portal/src/components/entity/EntityInformationModal.spec.js
+++ b/packages/portal/src/components/entity/EntityInformationModal.spec.js
@@ -14,9 +14,11 @@ const factory = (propsData = {}) => mount(EntityInformationModal, {
     $n: (val) => val,
     $t: (val) => val,
     $features: { aggregatorsTab: true }
-  }
+  },
+  stubs: ['EntityBadges']
 });
 
+const id = 'http://data.europeana.eu/organization/190';
 const englishName = { values: ['Library of Europe'], code: 'en' };
 const homepage = 'https://www.deutsche-digitale-bibliothek.de';
 const country = 'Germany';
@@ -48,6 +50,7 @@ const expectedInfo = [
 ];
 
 const entity = {
+  id,
   homepage,
   hasAddress: {
     countryName: country,
@@ -92,5 +95,16 @@ describe('components/entity/EntityInformationModal', () => {
 
     const websiteLink = wrapper.find('ul li[data-qa="website field"] a');
     expect(websiteLink.attributes().href).toEqual(homepage);
+  });
+
+  describe('when entity aggregates from', () => {
+    it('shows 4 entity badges and a view all link', () => {
+      const wrapper = factory(entityProps);
+
+      const viewAllLink = wrapper.find('.view-all-button');
+      expect(wrapper.find('entitybadges-stub').exists()).toBe(true);
+      expect(viewAllLink.text()).toEqual('actions.viewAll');
+      expect(viewAllLink.attributes().href).toEqual('/collections/organisations#aggregators-190');
+    });
   });
 });

--- a/packages/portal/src/components/entity/EntityInformationModal.vue
+++ b/packages/portal/src/components/entity/EntityInformationModal.vue
@@ -41,16 +41,24 @@
             {{ info.value }}
           </template>
         </span>
-        <b-button
-          v-if="info.moreLink"
-          :href="info.moreLink.link"
-          variant="link"
-          class="view-all-button w-100 text-left"
-        >
-          {{ info.moreLink.text }}
-        </b-button>
       </li>
     </ul>
+    <div
+      v-if="$features.aggregatorsTab && aggregatesFrom"
+      class="mb-4 ml-sm-3"
+    >
+      <EntityBadges
+        :entity-uris="aggregatesFromForDisplay"
+        :show-title="false"
+      />
+      <b-button
+        :href="aggregatorPageLink.link"
+        variant="link"
+        class="view-all-button p-0"
+      >
+        {{ aggregatorPageLink.text }}
+      </b-button>
+    </div>
     <b-button
       variant="outline-primary"
       @click="$bvModal.hide('entityInformationModal')"
@@ -66,6 +74,10 @@
 
   export default {
     name: 'EntityInformationModal',
+
+    components: {
+      EntityBadges: () => import('./EntityBadges')
+    },
 
     mixins: [langAttributeMixin],
 
@@ -125,17 +137,29 @@
           labelledMoreInfo.push({ label: this.$t('organisation.recordCount'), value: this.entity.isAggregatedBy.recordCount });
         }
 
-        if (this.$features.aggregatorsTab && this.entity?.aggregatesFrom)  {
-          const aggregatesFromCount = this.entity.aggregatesFrom.length;
-          const moreLink = {
-            link: '/collections/organisations#aggregators', // TODO: needs to link to the specific aggregator expanded
-            text: this.$t('actions.viewAll', { count: aggregatesFromCount })
-          };
-          labelledMoreInfo.push({ label: this.$t('organisation.providingInstitutionsCount'), value: aggregatesFromCount, moreLink });
+        if (this.$features.aggregatorsTab && this.aggregatesFrom)  {
+          labelledMoreInfo.push({ label: this.$t('organisation.providingInstitutionsCount'), value: this.aggregatesFromCount });
         }
-        // TODO: Pass 4 institutions, but consider passing via distinct prop
 
         return labelledMoreInfo;
+      },
+      aggregatesFrom() {
+        return this.entity.aggregatesFrom;
+      },
+      aggregatesFromForDisplay() {
+        return this.entity.aggregatesFrom.slice(0, 4);
+      },
+      aggregatesFromCount() {
+        return this.aggregatesFrom?.length;
+      },
+      entityId() {
+        return this.entity.id.toString().split('/').pop();
+      },
+      aggregatorPageLink() {
+        return {
+          link: `/collections/organisations#aggregators-${this.entityId}`,
+          text: this.$t('actions.viewAll', { count: this.aggregatesFromCount })
+        };
       }
     },
 
@@ -162,5 +186,9 @@
     .semibold {
       font-weight: 600;
     }
+  }
+
+  .view-all-button.btn-link:hover {
+    text-decoration: none;
   }
 </style>

--- a/packages/portal/src/components/entity/EntityInformationModal.vue
+++ b/packages/portal/src/components/entity/EntityInformationModal.vue
@@ -31,12 +31,6 @@
           >
             {{ info.value }}
           </b-link>
-          <template v-else-if="Array.isArray(info.value)">
-            {{ info.value.join('; ') }}
-          </template>
-          <template v-else-if="typeof info.value === 'number'">
-            {{ $n(info.value) }}
-          </template>
           <template v-else>
             {{ info.value }}
           </template>
@@ -70,7 +64,7 @@
 
 <script>
   import langAttributeMixin from '@/mixins/langAttribute';
-  import { langMapValueForLocale } from '@europeana/i18n';
+  import { isLangMap, langMapValueForLocale } from '@europeana/i18n';
 
   export default {
     name: 'EntityInformationModal',
@@ -92,8 +86,9 @@
       },
       entity: {
         type: Object,
-        default: null
+        required: true
       },
+      // TODO: should this be derived instead of passed in?
       englishName: {
         type: Object,
         default: null
@@ -102,46 +97,41 @@
 
     computed: {
       entityInfo() {
-        const labelledMoreInfo = [];
+        const fieldData = {
+          'organisation.englishName': this.englishName,
+          'organisation.nameAcronym': this.entity.acronym,
+          // TODO: Update to use API country field?
+          'organisation.country': this.entity.hasAddress?.countryName,
+          'organisation.city': this.entity.hasAddress.locality,
+          'website': this.entity.homepage,
+          'organisation.heritageDomain': this.entity.heritageDomain,
+          'organisation.providesSupportForMediaType': this.entity.providesSupportForMediaType,
+          'organisation.geographicScope': this.entity.geographicScope,
+          'organisation.providesSupportForDataActivity': this.entity.providesSupportForDataActivity,
+          'organisation.providesCapacityBuildingActivity': this.entity.providesCapacityBuildingActivity,
+          'organisation.providesAudienceEngagementActivity': this.entity.providesAudienceEngagementActivity,
+          'organisation.recordCount': this.entity.isAggregatedBy?.recordCount,
+          'organisation.providingInstitutionsCount': this.$features.aggregatorsTab ? this.aggregatesFromCount : undefined
+        };
 
-        if (this.englishName) {
-          labelledMoreInfo.push({
-            label: this.$t('organisation.englishName'),
-            value: Object.values(this.englishName)[0],
-            lang: Object.keys(this.englishName)[0]
+        return Object.keys(fieldData)
+          .map((key) => ({ label: this.$t(key), value: fieldData[key] }))
+          .filter((info) => info.value)
+          .map((info) => {
+            if (isLangMap(info.value)) {
+              const langMapValue = langMapValueForLocale(info.value, this.$i18n.locale);
+              info.value = langMapValue.values[0];
+              info.lang = langMapValue.code;
+            }
+
+            if (Array.isArray(info.value)) {
+              info.value = info.value.join('; ');
+            } else if (typeof info.value === 'number') {
+              info.value = this.$n(info.value);
+            }
+
+            return info;
           });
-        }
-        if (this.entity?.acronym)  {
-          const langMapValue = langMapValueForLocale(this.entity.acronym, this.$i18n.locale);
-          labelledMoreInfo.push({ label: this.$t('organisation.nameAcronym'), value: langMapValue.values[0], lang: langMapValue.code });
-        }
-        // TODO: Update to use API country field?
-        if (this.entity?.hasAddress?.countryName)  {
-          labelledMoreInfo.push({ label: this.$t('organisation.country'), value: this.entity.hasAddress.countryName });
-        }
-        if (this.entity?.hasAddress?.locality)  {
-          labelledMoreInfo.push({ label: this.$t('organisation.city'), value: this.entity.hasAddress.locality });
-        }
-        if (this.entity.homepage)  {
-          labelledMoreInfo.push({ label: this.$t('website'), value: this.entity.homepage });
-        }
-
-        const aggregationInfoFields = ['heritageDomain', 'providesSupportForMediaType', 'geographicScope', 'providesSupportForDataActivity', 'providesCapacityBuildingActivity', 'providesAudienceEngagementActivity'];
-        for (const field of aggregationInfoFields) {
-          if (this.entity?.[field])  {
-            labelledMoreInfo.push({ label: this.$t(`organisation.${field}`), value: this.entity[field] });
-          }
-        }
-
-        if (this.entity?.isAggregatedBy?.recordCount) {
-          labelledMoreInfo.push({ label: this.$t('organisation.recordCount'), value: this.entity.isAggregatedBy.recordCount });
-        }
-
-        if (this.$features.aggregatorsTab && this.aggregatesFrom)  {
-          labelledMoreInfo.push({ label: this.$t('organisation.providingInstitutionsCount'), value: this.aggregatesFromCount });
-        }
-
-        return labelledMoreInfo;
       },
       aggregatesFrom() {
         return this.entity.aggregatesFrom;

--- a/packages/portal/src/components/entity/EntityInformationModal.vue
+++ b/packages/portal/src/components/entity/EntityInformationModal.vue
@@ -62,6 +62,7 @@
 
 <script>
   import langAttributeMixin from '@/mixins/langAttribute';
+  import { langMapValueForLocale } from '@europeana/i18n';
 
   export default {
     name: 'EntityInformationModal',
@@ -77,9 +78,64 @@
         type: Object,
         default: null
       },
-      entityInfo: {
-        type: Array,
+      entity: {
+        type: Object,
         default: null
+      },
+      englishName: {
+        type: Object,
+        default: null
+      }
+    },
+
+    computed: {
+      entityInfo() {
+        const labelledMoreInfo = [];
+
+        if (this.englishName) {
+          labelledMoreInfo.push({
+            label: this.$t('organisation.englishName'),
+            value: Object.values(this.englishName)[0],
+            lang: Object.keys(this.englishName)[0]
+          });
+        }
+        if (this.entity?.acronym)  {
+          const langMapValue = langMapValueForLocale(this.entity.acronym, this.$i18n.locale);
+          labelledMoreInfo.push({ label: this.$t('organisation.nameAcronym'), value: langMapValue.values[0], lang: langMapValue.code });
+        }
+        // TODO: Update to use API country field?
+        if (this.entity?.hasAddress?.countryName)  {
+          labelledMoreInfo.push({ label: this.$t('organisation.country'), value: this.entity.hasAddress.countryName });
+        }
+        if (this.entity?.hasAddress?.locality)  {
+          labelledMoreInfo.push({ label: this.$t('organisation.city'), value: this.entity.hasAddress.locality });
+        }
+        if (this.entity.homepage)  {
+          labelledMoreInfo.push({ label: this.$t('website'), value: this.entity.homepage });
+        }
+
+        const aggregationInfoFields = ['heritageDomain', 'providesSupportForMediaType', 'geographicScope', 'providesSupportForDataActivity', 'providesCapacityBuildingActivity', 'providesAudienceEngagementActivity'];
+        for (const field of aggregationInfoFields) {
+          if (this.entity?.[field])  {
+            labelledMoreInfo.push({ label: this.$t(`organisation.${field}`), value: this.entity[field] });
+          }
+        }
+
+        if (this.entity?.isAggregatedBy?.recordCount) {
+          labelledMoreInfo.push({ label: this.$t('organisation.recordCount'), value: this.entity.isAggregatedBy.recordCount });
+        }
+
+        if (this.$features.aggregatorsTab && this.entity?.aggregatesFrom)  {
+          const aggregatesFromCount = this.entity.aggregatesFrom.length;
+          const moreLink = {
+            link: '/collections/organisations#aggregators', // TODO: needs to link to the specific aggregator expanded
+            text: this.$t('actions.viewAll', { count: aggregatesFromCount })
+          };
+          labelledMoreInfo.push({ label: this.$t('organisation.providingInstitutionsCount'), value: aggregatesFromCount, moreLink });
+        }
+        // TODO: Pass 4 institutions, but consider passing via distinct prop
+
+        return labelledMoreInfo;
       }
     },
 

--- a/packages/portal/src/pages/collections/_type/_.spec.js
+++ b/packages/portal/src/pages/collections/_type/_.spec.js
@@ -14,18 +14,8 @@ const redirectSpy = sinon.spy();
 const organisationEntity = {
   entity: {
     id: 'http://data.europeana.eu/organization/01234567890',
-    logo: { id: 'http://commons.wikimedia.org/wiki/Special:FilePath/Albertina%20Logo.svg' },
-    mbox: 'email@example.org',
     prefLabel: { en: 'English name', nl: 'Dutch name' },
-    homepage: 'https://www.example-organisation.eu',
-    hasAddress: {
-      countryName: 'The Netherlands',
-      locality: 'The Hague'
-    },
-    geographicScope: 'National',
-    description: { en: ['example of an organisation description'] },
-    acronym: { en: 'ABC' },
-    type: 'Organization'
+    description: { en: ['example of an organisation description'] }
   },
   type: 'organisation',
   pathMatch: '01234567890-organisation'
@@ -62,7 +52,6 @@ const factory = (options = {}) => shallowMountNuxt(collection, {
       userHasClientRole: options.userHasClientRoleStub || sinon.stub().returns(false)
     },
     $fetchState: {},
-    $features: {},
     $t: (key, args) => args ? `${key} ${args}` : key,
     $route: {
       query: options.query || '',
@@ -71,8 +60,7 @@ const factory = (options = {}) => shallowMountNuxt(collection, {
     $apis: {
       entity: {
         get: options.get || sinon.stub().resolves({}),
-        facets: sinon.stub().resolves([]),
-        imageUrl: sinon.spy()
+        facets: sinon.stub().resolves([])
       },
       entityManagement: {
         get: sinon.stub().resolves({})
@@ -304,39 +292,12 @@ describe('pages/collections/_type/_', () => {
       });
     });
 
-    describe('contextLabel', () => {
-      it('returns the label for an organisation', () => {
-        const wrapper = factory(organisationEntity);
-
-        const contextLabel = wrapper.vm.contextLabel;
-        expect(contextLabel).toBe('cardLabels.organisation');
-      });
-    });
-
     describe('collectionType', () => {
       it('returns the collection type', () => {
         const wrapper = factory(organisationEntity);
 
         const collectionType = wrapper.vm.collectionType;
         expect(collectionType).toBe('organisation');
-      });
-    });
-
-    describe('logo', () => {
-      it('returns a logo on organisation pages', () => {
-        const wrapper = factory(organisationEntity);
-
-        const logo = wrapper.vm.logo;
-        expect(logo).toBe(organisationEntity.entity.logo.id);
-      });
-    });
-
-    describe('mbox', () => {
-      it('returns the email on organisation pages', () => {
-        const wrapper = factory(organisationEntity);
-
-        const mbox = wrapper.vm.mbox;
-        expect(mbox).toBe(organisationEntity.entity.mbox);
       });
     });
 
@@ -366,16 +327,6 @@ describe('pages/collections/_type/_', () => {
       });
     });
 
-    describe('subTitle', () => {
-      it('uses the English prefLabel for an organisation, if non-native', () => {
-        const wrapper = factory(organisationEntity);
-
-        const subTitle = wrapper.vm.subTitle.values[0];
-
-        expect(subTitle).toBe(organisationEntity.entity.prefLabel.en);
-      });
-    });
-
     describe('description', () => {
       it('uses the entity note, if present', () => {
         const wrapper = factory(topicEntity);
@@ -391,37 +342,6 @@ describe('pages/collections/_type/_', () => {
         const description = wrapper.vm.description.values;
 
         expect(description).toEqual(organisationEntity.entity.description.en);
-      });
-    });
-
-    describe('homepage', () => {
-      it('returns a homepage on organisation pages', () => {
-        const wrapper = factory(organisationEntity);
-
-        const homepage = wrapper.vm.homepage;
-        expect(homepage).toBe(organisationEntity.entity.homepage);
-      });
-    });
-
-    describe('thumbnail', () => {
-      it('returns a thumbnail when available', () => {
-        const wrapper = factory(topicEntity);
-
-        wrapper.vm.thumbnail;
-        expect(wrapper.vm.$apis.entity.imageUrl.called).toBe(true);
-      });
-    });
-    describe('moreInfo', () => {
-      it('returns an array with more entity data on organisation pages', () => {
-        const wrapper = factory(organisationEntity);
-
-        const moreInfo = wrapper.vm.moreInfo;
-        expect(moreInfo[0].value).toBe(organisationEntity.entity.prefLabel.en);
-        expect(moreInfo[1].value).toBe(organisationEntity.entity.acronym.en);
-        expect(moreInfo[2].value).toBe(organisationEntity.entity.hasAddress.countryName);
-        expect(moreInfo[3].value).toBe(organisationEntity.entity.hasAddress.locality);
-        expect(moreInfo[4].value).toBe(organisationEntity.entity.homepage);
-        expect(moreInfo[5].value).toBe(organisationEntity.entity.geographicScope);
       });
     });
   });

--- a/packages/portal/src/pages/collections/_type/_.vue
+++ b/packages/portal/src/pages/collections/_type/_.vue
@@ -24,16 +24,10 @@
         >
           <EntityHeader
             v-show="!hasUserQuery"
-            :id="entity && entity.id"
             :description="description"
             :title="title"
-            :sub-title="subTitle"
-            :logo="logo"
-            :email="mbox"
-            :image="thumbnail"
             :editable="editable"
-            :external-link="homepage"
-            :more-info="moreInfo"
+            :entity="entity"
             @updated="handleUpdated"
           />
         </template>
@@ -75,7 +69,7 @@
   import ClientOnly from 'vue-client-only';
 
   import SearchInterface from '@/components/search/SearchInterface';
-  import { organizationEntityNativeName, organizationEntityNonNativeEnglishName } from '@/utils/europeana/entities/organizations.js';
+  import { organizationEntityNativeName } from '@/utils/europeana/entities/organizations.js';
   import pageMetaMixin from '@/mixins/pageMeta';
   import entityBestItemsSetMixin from '@/mixins/europeana/entities/entityBestItemsSet';
   import { redirectToPrefPath } from '@/utils/redirect/redirectToPrefPath.js';
@@ -83,7 +77,7 @@
   import {
     getEntityTypeApi, getEntityUri, getEntityQuery, normalizeEntityId
   } from '@/plugins/europeana/entity';
-  import { langMapValueForLocale, uriRegex } from  '@europeana/i18n';
+  import { langMapValueForLocale } from  '@europeana/i18n';
 
   const FIELDS = [
     'id',
@@ -218,23 +212,8 @@
       entityId() {
         return normalizeEntityId(this.$route.params.pathMatch);
       },
-      contextLabel() {
-        return this.$t(`cardLabels.${this.collectionType}`);
-      },
       collectionType() {
         return this.$route.params.type;
-      },
-      logo() {
-        if (this.collectionType === 'organisation' && this.entity?.logo) {
-          return this.entity.logo.id;
-        }
-        return null;
-      },
-      mbox() {
-        if (this.collectionType === 'organisation') {
-          return this.entity?.mbox;
-        }
-        return null;
       },
       description() {
         let description = null;
@@ -249,14 +228,6 @@
       },
       descriptionText() {
         return ((this.description?.values?.length || 0) >= 1) ? this.description.values[0] : null;
-      },
-      homepage() {
-        if (this.collectionType === 'organisation' &&
-          this.entity?.homepage &&
-          uriRegex.test(this.entity.homepage)) {
-          return this.entity.homepage;
-        }
-        return null;
       },
       editable() {
         return this.entity &&
@@ -288,83 +259,16 @@
 
         return title;
       },
-      subTitle() {
-        return this.organisationNonNativeEnglishName ?
-          langMapValueForLocale(this.organisationNonNativeEnglishName, this.$i18n.locale) :
-          null;
-      },
       hasUserQuery() {
         return this.$route.query.query &&  this.$route.query.query !== '';
       },
-      thumbnail() {
-        return this.$apis.entity.imageUrl(this.entity);
-      },
       organisationNativeName() {
         return this.organizationEntityNativeName(this.entity);
-      },
-      organisationNonNativeEnglishName() {
-        return this.organizationEntityNonNativeEnglishName(this.entity);
-      },
-      // TODO: there is way too much logic here, which is done on behalf
-      //       of the EntityInformationModal component, which should
-      //       handle this itself. consider passing the whole entity down,
-      //       or provide/inject it, then move this logic there
-      moreInfo() {
-        if (!this.entity || this.collectionType !== 'organisation') {
-          return null;
-        }
-
-        const labelledMoreInfo = [];
-
-        if (this.organisationNonNativeEnglishName) {
-          labelledMoreInfo.push({
-            label: this.$t('organisation.englishName'),
-            value: Object.values(this.organisationNonNativeEnglishName)[0],
-            lang: Object.keys(this.organisationNonNativeEnglishName)[0]
-          });
-        }
-        if (this.entity?.acronym)  {
-          const langMapValue = langMapValueForLocale(this.entity.acronym, this.$i18n.locale);
-          labelledMoreInfo.push({ label: this.$t('organisation.nameAcronym'), value: langMapValue.values[0], lang: langMapValue.code });
-        }
-        // TODO: Update to use API country field?
-        if (this.entity?.hasAddress?.countryName)  {
-          labelledMoreInfo.push({ label: this.$t('organisation.country'), value: this.entity.hasAddress.countryName });
-        }
-        if (this.entity?.hasAddress?.locality)  {
-          labelledMoreInfo.push({ label: this.$t('organisation.city'), value: this.entity.hasAddress.locality });
-        }
-        if (this.homepage)  {
-          labelledMoreInfo.push({ label: this.$t('website'), value: this.homepage });
-        }
-
-        const aggregationInfoFields = ['heritageDomain', 'providesSupportForMediaType', 'geographicScope', 'providesSupportForDataActivity', 'providesCapacityBuildingActivity', 'providesAudienceEngagementActivity'];
-        for (const field of aggregationInfoFields) {
-          if (this.entity?.[field])  {
-            labelledMoreInfo.push({ label: this.$t(`organisation.${field}`), value: this.entity[field] });
-          }
-        }
-
-        if (this.entity?.isAggregatedBy?.recordCount) {
-          labelledMoreInfo.push({ label: this.$t('organisation.recordCount'), value: this.entity.isAggregatedBy.recordCount });
-        }
-
-        if (this.$features.aggregatorsTab && this.entity?.aggregatesFrom)  {
-          const aggregatesFromCount = this.entity.aggregatesFrom.length;
-          const moreLink = {
-            link: '/collections/organisations#aggregators', // needs to link to the specific aggregator expanded
-            text: this.$t('actions.viewAll', { count: aggregatesFromCount })
-          };
-          labelledMoreInfo.push({ label: this.$t('organisation.providingInstitutionsCount'), value: aggregatesFromCount, moreLink });
-        }
-        // TODO: Pass 4 institutions, but consider passing via distinct prop
-
-        return labelledMoreInfo;
       }
     },
+
     methods: {
       organizationEntityNativeName,
-      organizationEntityNonNativeEnglishName,
       handleEntityRelatedCollectionsFetched(relatedCollections) {
         this.relatedCollections = relatedCollections;
       },


### PR DESCRIPTION
- refactors the collections type page, EntityHeader and EntityInformationModal so the full entity is passed down from the page level and the child components handle the needed logic and data manipulation
- adds EntityBadges component to the EntityInformationModal
- refactors EntityBadges to handle conditional display of the title