### PR TITLE
feat: add BFF to retrieve entities

### DIFF
--- a/packages/i18n/src/langMap.js
+++ b/packages/i18n/src/langMap.js
@@ -230,6 +230,7 @@ export const reduceLangMapsForLocale = (value, locale, options = {}) => {
   if (Array.isArray(value)) {
     return value.map((val) => reduceLangMapsForLocale(val, locale, options));
   } else if (typeof value === 'object') {
+    // TODO: this behaviour is opaque as reduction has failed; improve
     if (Object.isFrozen(value)) {
       return value;
     } else if (isLangMap(value)) {

--- a/packages/portal/src/server-middleware/api/collections/retrieve.js
+++ b/packages/portal/src/server-middleware/api/collections/retrieve.js
@@ -1,0 +1,19 @@
+import EuropeanaEntityApi from '../../../plugins/europeana/entity.js';
+
+export const fetchData = async(ids, context = {}) => {
+  const api = context.$apis?.entity || new EuropeanaEntityApi(context);
+
+  const entities = await api.retrieve(ids);
+
+  return entities;
+};
+
+export default (context = {}) => async(req, res, next) => {
+  try {
+    const data = await fetchData(req.body, context);
+
+    res.json(data);
+  } catch (e) {
+    next(e);
+  }
+};

--- a/packages/portal/src/server-middleware/api/collections/retrieve.js
+++ b/packages/portal/src/server-middleware/api/collections/retrieve.js
@@ -1,4 +1,5 @@
 import EuropeanaEntityApi from '../../../plugins/europeana/entity.js';
+import { reduceLangMapsForLocale } from '@europeana/i18n';
 
 const pickFields = (entity, fields) => {
   return [].concat(fields).reduce((memo, field) => {
@@ -7,13 +8,16 @@ const pickFields = (entity, fields) => {
   }, {});
 };
 
-export const fetchData = async(ids, fields, context = {}) => {
+export const fetchData = async(ids, { fields, lang } = {}, context = {}) => {
   const api = context.$apis?.entity || new EuropeanaEntityApi(context);
 
   let entities = await api.retrieve(ids);
 
   if (fields) {
-    entities = entities.map((entity) => pickFields(entity, fields));
+    entities = entities.map((entity) => pickFields(entity, fields.split(',')));
+  }
+  if (lang) {
+    entities = reduceLangMapsForLocale(entities, lang);
   }
 
   return entities;
@@ -21,7 +25,7 @@ export const fetchData = async(ids, fields, context = {}) => {
 
 export default (context = {}) => async(req, res, next) => {
   try {
-    const data = await fetchData(req.body, req.query?.fl, context);
+    const data = await fetchData(req.body, { fields: req.query.fl, lang: req.query.lang }, context);
 
     res.json(data);
   } catch (e) {

--- a/packages/portal/src/server-middleware/api/collections/retrieve.js
+++ b/packages/portal/src/server-middleware/api/collections/retrieve.js
@@ -14,7 +14,7 @@ export const fetchData = async(ids, { fields, lang } = {}, context = {}) => {
   let entities = await api.retrieve(ids);
 
   if (fields) {
-    entities = entities.map((entity) => pickFields(entity, fields.split(',')));
+    entities = entities.map((entity) => pickFields(entity, fields));
   }
   if (lang) {
     entities = reduceLangMapsForLocale(entities, lang);
@@ -25,7 +25,9 @@ export const fetchData = async(ids, { fields, lang } = {}, context = {}) => {
 
 export default (context = {}) => async(req, res, next) => {
   try {
-    const data = await fetchData(req.body, { fields: req.query.fl, lang: req.query.lang }, context);
+    const data = await fetchData(req.body, {
+      fields: req.query.fl?.split(','), lang: req.query.lang?.split(',')
+    }, context);
 
     res.json(data);
   } catch (e) {

--- a/packages/portal/src/server-middleware/api/collections/retrieve.js
+++ b/packages/portal/src/server-middleware/api/collections/retrieve.js
@@ -1,16 +1,27 @@
 import EuropeanaEntityApi from '../../../plugins/europeana/entity.js';
 
-export const fetchData = async(ids, context = {}) => {
+const pickFields = (entity, fields) => {
+  return [].concat(fields).reduce((memo, field) => {
+    memo[field] = entity[field];
+    return memo;
+  }, {});
+};
+
+export const fetchData = async(ids, fields, context = {}) => {
   const api = context.$apis?.entity || new EuropeanaEntityApi(context);
 
-  const entities = await api.retrieve(ids);
+  let entities = await api.retrieve(ids);
+
+  if (fields) {
+    entities = entities.map((entity) => pickFields(entity, fields));
+  }
 
   return entities;
 };
 
 export default (context = {}) => async(req, res, next) => {
   try {
-    const data = await fetchData(req.body, context);
+    const data = await fetchData(req.body, req.query?.fl, context);
 
     res.json(data);
   } catch (e) {

--- a/packages/portal/src/server-middleware/api/collections/retrieve.spec.js
+++ b/packages/portal/src/server-middleware/api/collections/retrieve.spec.js
@@ -1,0 +1,50 @@
+import sinon from 'sinon';
+
+import serverMiddleware, { fetchData } from './retrieve.js';
+
+describe('server-middleware/api/collections/retrieve.js', () => {
+  const context = { $apis: { entity: { retrieve: sinon.stub().resolves({}) } } };
+  const ids = [
+    'http://data.europeana.eu/organization/1',
+    'http://data.europeana.eu/organization/2'
+  ];
+
+  afterEach(() => {
+    sinon.resetHistory();
+  });
+  afterAll(() => {
+    sinon.restore();
+  });
+
+  describe('default export (middleware)', () => {
+    const req = { body: ids };
+    const resStub = {
+      json: sinon.stub()
+    };
+    const nextStub = sinon.stub().callsFake((err) => {
+      if (err instanceof Error) {
+        throw err;
+      }
+    });
+
+    it('retrieves from the Entity API, with IDs from request body', async() => {
+      await serverMiddleware(context)(req, resStub, nextStub);
+
+      expect(context.$apis.entity.retrieve.calledWith(ids)).toBe(true);
+    });
+
+    it('responds with JSON', async() => {
+      await serverMiddleware(context)(req, resStub, nextStub);
+
+      expect(resStub.json.called).toBe(true);
+    });
+  });
+
+  describe('fetchData', () => {
+    it('retrieves from the Entity API, with IDs from arg', async() => {
+      await fetchData(ids, context);
+
+      expect(context.$apis.entity.retrieve.calledWith(ids)).toBe(true);
+    });
+  });
+});

--- a/packages/portal/src/server-middleware/api/collections/retrieve.spec.js
+++ b/packages/portal/src/server-middleware/api/collections/retrieve.spec.js
@@ -1,5 +1,6 @@
 import nock from 'nock';
 import sinon from 'sinon';
+import cloneDeep from 'lodash/cloneDeep.js';
 
 import serverMiddleware, { fetchData } from './retrieve.js';
 
@@ -7,21 +8,26 @@ describe('server-middleware/api/collections/retrieve.js', () => {
   const entities = [
     {
       id: 'http://data.europeana.eu/organization/1',
-      prefLabel: { en: 'one' }
+      type: 'Aggregator',
+      prefLabel: { en: 'One', nl: 'Een' }
     },
     {
       id: 'http://data.europeana.eu/organization/2',
-      prefLabel: { en: 'two' }
+      type: 'Organization',
+      prefLabel: { en: 'Two', nl: 'Twee' }
     }
   ];
   const ids = [
     'http://data.europeana.eu/organization/1',
     'http://data.europeana.eu/organization/2'
   ];
-  const context = { $apis: { entity: { retrieve: sinon.stub().withArgs(ids).resolves(entities) } } };
+  const context = { $apis: { entity: { retrieve: sinon.stub() } } };
 
   beforeAll(() => {
     nock.disableNetConnect();
+  });
+  beforeEach(() => {
+    context.$apis.entity.retrieve.withArgs(ids).resolves(cloneDeep(entities));
   });
   afterEach(() => {
     sinon.resetHistory();
@@ -32,7 +38,7 @@ describe('server-middleware/api/collections/retrieve.js', () => {
   });
 
   describe('default export (middleware)', () => {
-    const req = { body: ids };
+    const req = { body: ids, query: {} };
     const resStub = {
       json: sinon.stub()
     };
@@ -56,25 +62,64 @@ describe('server-middleware/api/collections/retrieve.js', () => {
   });
 
   describe('fetchData', () => {
-    it('retrieves from the Entity API client, with IDs from 1st arg', async() => {
-      await fetchData(ids, undefined, context);
+    it('retrieves from the Entity API client, with IDs from ids prop', async() => {
+      await fetchData(ids, {}, context);
 
       expect(context.$apis.entity.retrieve.calledWith(ids)).toBe(true);
     });
 
     it('returns the items from the API client', async() => {
-      const response = await fetchData(ids, undefined, context);
+      const response = await fetchData(ids, {}, context);
 
       expect(response).toEqual(entities);
     });
 
-    describe('picking fields to include in 2nd arg', () => {
+    describe('picking fields to include from fields prop', () => {
       it('picks single top-level field', async() => {
         const fields = 'id';
+        const expected = [{ id: entities[0].id }, { id: entities[1].id }];
 
-        const response = await fetchData(ids, fields, context);
+        const response = await fetchData(ids, { fields }, context);
 
-        expect(response).toEqual([{ id: response[0].id }, { id: response[1].id }]);
+        expect(response).toEqual(expected);
+      });
+
+      it('picks multiple top-level fields', async() => {
+        const fields = 'id,prefLabel';
+        const expected = [
+          { id: entities[0].id, prefLabel: entities[0].prefLabel },
+          { id: entities[1].id, prefLabel: entities[1].prefLabel }
+        ];
+
+        const response = await fetchData(ids, { fields }, context);
+
+        expect(response).toEqual(expected);
+      });
+    });
+
+    describe('localising LangMap values from lang prop', () => {
+      it('reduces all LangMap fields to the specified language', async() => {
+        const lang = 'nl';
+        const expected = [
+          { ...entities[0], prefLabel: { nl: entities[0].prefLabel.nl } },
+          { ...entities[1], prefLabel: { nl: entities[1].prefLabel.nl } }
+        ];
+
+        const response = await fetchData(ids, { lang }, context);
+
+        expect(response).toEqual(expected);
+      });
+
+      it('falls back to English default if specified language unavailable', async() => {
+        const lang = 'fr';
+        const expected = [
+          { ...entities[0], prefLabel: { en: entities[0].prefLabel.en } },
+          { ...entities[1], prefLabel: { en: entities[1].prefLabel.en } }
+        ];
+
+        const response = await fetchData(ids, { lang }, context);
+
+        expect(response).toEqual(expected);
       });
     });
   });

--- a/packages/portal/src/server-middleware/api/collections/retrieve.spec.js
+++ b/packages/portal/src/server-middleware/api/collections/retrieve.spec.js
@@ -85,7 +85,7 @@ describe('server-middleware/api/collections/retrieve.js', () => {
       });
 
       it('picks multiple top-level fields', async() => {
-        const fields = 'id,prefLabel';
+        const fields = ['id', 'prefLabel'];
         const expected = [
           { id: entities[0].id, prefLabel: entities[0].prefLabel },
           { id: entities[1].id, prefLabel: entities[1].prefLabel }

--- a/packages/portal/src/server-middleware/api/collections/retrieve.spec.js
+++ b/packages/portal/src/server-middleware/api/collections/retrieve.spec.js
@@ -1,18 +1,33 @@
+import nock from 'nock';
 import sinon from 'sinon';
 
 import serverMiddleware, { fetchData } from './retrieve.js';
 
 describe('server-middleware/api/collections/retrieve.js', () => {
-  const context = { $apis: { entity: { retrieve: sinon.stub().resolves({}) } } };
+  const entities = [
+    {
+      id: 'http://data.europeana.eu/organization/1',
+      prefLabel: { en: 'one' }
+    },
+    {
+      id: 'http://data.europeana.eu/organization/2',
+      prefLabel: { en: 'two' }
+    }
+  ];
   const ids = [
     'http://data.europeana.eu/organization/1',
     'http://data.europeana.eu/organization/2'
   ];
+  const context = { $apis: { entity: { retrieve: sinon.stub().withArgs(ids).resolves(entities) } } };
 
+  beforeAll(() => {
+    nock.disableNetConnect();
+  });
   afterEach(() => {
     sinon.resetHistory();
   });
   afterAll(() => {
+    nock.enableNetConnect();
     sinon.restore();
   });
 
@@ -41,10 +56,26 @@ describe('server-middleware/api/collections/retrieve.js', () => {
   });
 
   describe('fetchData', () => {
-    it('retrieves from the Entity API, with IDs from arg', async() => {
-      await fetchData(ids, context);
+    it('retrieves from the Entity API client, with IDs from 1st arg', async() => {
+      await fetchData(ids, undefined, context);
 
       expect(context.$apis.entity.retrieve.calledWith(ids)).toBe(true);
+    });
+
+    it('returns the items from the API client', async() => {
+      const response = await fetchData(ids, undefined, context);
+
+      expect(response).toEqual(entities);
+    });
+
+    describe('picking fields to include in 2nd arg', () => {
+      it('picks single top-level field', async() => {
+        const fields = 'id';
+
+        const response = await fetchData(ids, fields, context);
+
+        expect(response).toEqual([{ id: response[0].id }, { id: response[1].id }]);
+      });
     });
   });
 });

--- a/packages/portal/src/server-middleware/api/index.js
+++ b/packages/portal/src/server-middleware/api/index.js
@@ -15,6 +15,7 @@ import jiraServiceDeskGalleries from './jira-service-desk/galleries.js';
 import version from './version.js';
 import polls from './polls/index.js';
 import createCollectionsIndexEndpoint from './collections/index.js';
+import createCollectionsRetrieveEndpoint from './collections/retrieve.js';
 
 export const createApiExpressApp = (context = {}, app) => {
   const config = context.$config || {};
@@ -66,6 +67,9 @@ export const createApiExpressApp = (context = {}, app) => {
 
   const collectionsIndexEndpoint = createCollectionsIndexEndpoint(config.redis);
   app.get('/collections/*', collectionsIndexEndpoint);
+
+  const collectionsRetrieveEndpoint = createCollectionsRetrieveEndpoint(context);
+  app.post('/collections/retrieve', collectionsRetrieveEndpoint);
 
   app.all('/*', (req, res) => res.sendStatus(404));
   app.use(errorHandler);


### PR DESCRIPTION
- adds a backend-for-frontend (BFF) for entity retrieval acting as a go-between to the Entity API's retrieval endpoint
- accessible at `POST /_api/collections/retrieve`
- supports specification of the fields to return via `fl` query param e.g. `?fl=id,prefLabel`
- supports localisation of LangMap fields via `lang` query param e.g. `?lang=nl`