### PR TITLE
refactor: abstract backend fetch (SSR/CSR) to util fn

### DIFF
--- a/packages/portal/src/components/browse/BrowseAutomatedCardGroup.spec.js
+++ b/packages/portal/src/components/browse/BrowseAutomatedCardGroup.spec.js
@@ -1,10 +1,11 @@
 import { createLocalVue } from '@vue/test-utils';
-import axios from 'axios';
 import { shallowMountNuxt } from '@test/utils.js';
+import nock from 'nock';
 import sinon from 'sinon';
 import BootstrapVue from 'bootstrap-vue';
 
 import BrowseAutomatedCardGroup from '@/components/browse/BrowseAutomatedCardGroup.vue';
+import * as backendFetchModule from '@/utils/backendFetch.js';
 
 const localVue = createLocalVue();
 localVue.use(BootstrapVue);
@@ -52,8 +53,8 @@ const factory = (propsData = { sectionType: FEATURED_TOPICS })  => shallowMountN
     },
     localePath: () => 'mocked path',
     $i18n: { locale: 'en', t: (key) => key, n: (num) => `${num}`, localeProperties: { iso: 'en-GB' } },
+    $nuxt: { context: { $config: { redis: {} } } },
     $route: { query: {} },
-    $config: { app: { internalLinkDomain: 'https://europeana.eu' } },
     $t: (key) => key
   }
 });
@@ -152,28 +153,34 @@ const entries = {
 };
 
 describe('components/browse/BrowseAutomatedCardGroup', () => {
-  beforeEach(() => {
-    sinon.stub(axios, 'get');
+  const backendFetch = sinon.stub(backendFetchModule, 'backendFetch').resolves({ 'en/collections/topics/featured': entries.featuredTopics });
+
+  beforeAll(() => {
+    nock.disableNetConnect();
   });
-  afterEach(sinon.restore);
-  afterEach(sinon.resetHistory);
+  afterEach(() => {
+    sinon.resetHistory();
+  });
+  afterAll(() => {
+    nock.enableNetConnect();
+    sinon.restore();
+  });
 
   describe('fetch()', () => {
     describe('when section is cached', () => {
       const propsData = { sectionType: FEATURED_TOPICS };
-      beforeEach(() => {
-        axios.get.withArgs('/_api/cache/en/collections/topics/featured').resolves(
-          { data: { 'en/collections/topics/featured': entries.featuredTopics } }
-        );
-      });
-      afterEach(() => {
-        axios.get.reset();
-      });
+
       describe('when rendering on the client', () => {
-        it('gets the data from the cache API endpoint', async() => {
+        it('fetches cached data from the backend', async() => {
           const wrapper = factory(propsData);
+
           await wrapper.vm.fetch();
-          expect(axios.get.calledWith('/_api/cache/en/collections/topics/featured')).toBe(true);
+
+          expect(backendFetch.calledWith(
+            'cache',
+            ['en/collections/topics/featured'],
+            wrapper.vm.$nuxt.context
+          )).toBe(true);
           expect(wrapper.vm.entries).toEqual(entries.featuredTopics);
         });
       });

--- a/packages/portal/src/components/browse/BrowseAutomatedCardGroup.vue
+++ b/packages/portal/src/components/browse/BrowseAutomatedCardGroup.vue
@@ -192,18 +192,7 @@
 
     methods: {
       fetchCachedData() {
-        return backendFetch(process.server ? {
-          module: {
-            import: () => import('@/server-middleware/api/cache/index.js'),
-            fn: 'cached',
-            args: [this.key, this.$config.redis]
-          }
-        } : {
-          http: {
-            method: 'get',
-            url: `/_api/cache/${this.key}`
-          }
-        }, this.$nuxt.context)
+        return backendFetch('cache', [this.key], this.$nuxt.context)
           .then((response) => response[this.key]);
       },
       async fetchContentfulData() {

--- a/packages/portal/src/components/browse/BrowseAutomatedCardGroup.vue
+++ b/packages/portal/src/components/browse/BrowseAutomatedCardGroup.vue
@@ -18,14 +18,13 @@
 </template>
 
 <script>
-  import axios from 'axios';
-
   import ContentCardSection from '../content/ContentCardSection';
   import ItemTrendingItems from '@/components/item/ItemTrendingItems';
   import BrowseInfoCardSection from './BrowseInfoCardSection';
   import themesGraphql from '@/graphql/queries/themes.graphql';
   import { getLabelledSlug } from '@/plugins/europeana/utils.js';
   import { daily } from '@/plugins/europeana/utils';
+  import { backendFetch } from '@/utils/backendFetch.js';
 
   const FEATURED_ORGANISATIONS = 'Featured organisations';
   const FEATURED_PLACES = 'Featured places';
@@ -193,16 +192,19 @@
 
     methods: {
       fetchCachedData() {
-        if (process.server) {
-          return import('@/server-middleware/api/cache/index.js')
-            .then((module) => {
-              return module.cached(this.key, this.$config.redis)
-                .then((response) => response[this.key]);
-            });
-        } else {
-          return axios.get(`/_api/cache/${this.key}`, { baseURL: window.location.origin })
-            .then((response) => response.data[this.key]);
-        }
+        return backendFetch(process.server ? {
+          module: {
+            import: () => import('@/server-middleware/api/cache/index.js'),
+            fn: 'cached',
+            args: [this.key, this.$config.redis]
+          }
+        } : {
+          http: {
+            method: 'get',
+            url: `/_api/cache/${this.key}`
+          }
+        }, this.$nuxt.context)
+          .then((response) => response[this.key]);
       },
       async fetchContentfulData() {
         const variables = {

--- a/packages/portal/src/components/entity/EntityTable.spec.js
+++ b/packages/portal/src/components/entity/EntityTable.spec.js
@@ -1,11 +1,11 @@
 import { createLocalVue } from '@vue/test-utils';
-import axios from 'axios';
 import { mountNuxt } from '@test/utils.js';
 import sinon from 'sinon';
 import nock from 'nock';
 import BootstrapVue from 'bootstrap-vue';
 
 import EntityTable from '@/components/entity/EntityTable.vue';
+import * as backendFetchModule from '@/utils/backendFetch.js';
 
 const localVue = createLocalVue();
 localVue.use(BootstrapVue);
@@ -15,12 +15,8 @@ const factory = (propsData = { type: 'organisations' }) => mountNuxt(EntityTable
   localVue,
   propsData,
   mocks: {
-    $config: {
-      app: {
-        baseUrl: 'https://example.org'
-      }
-    },
     $n: (num) => num,
+    $nuxt: { context: { $config: { redis: {} } } },
     $t: (key) => key,
     $i18n: { locale: 'en' },
     $route: { query: { page: 1, query: null, sort: null } },
@@ -69,36 +65,40 @@ const organisations = [
 ];
 
 describe('components/entity/EntityTable', () => {
+  const backendFetch = sinon.stub(backendFetchModule, 'backendFetch')
+    .resolves({ items: collections, total: collections.length });
+
   beforeAll(() => {
     nock.disableNetConnect();
   });
+  afterEach(() => {
+    sinon.resetHistory();
+  });
   afterAll(() => {
     nock.enableNetConnect();
+    sinon.restore();
   });
-  beforeEach(() => {
-    sinon.stub(axios, 'request');
-    axios.request.resolves({ data: { items: collections, total: collections.length } });
-  });
-  afterEach(sinon.restore);
 
   describe('fetch()', () => {
-    it('sends a get request to the collections server middleware', async() => {
+    it('fetches collections data from the backend', async() => {
       const wrapper = factory();
 
       await wrapper.vm.fetch();
 
-      expect(axios.request.calledWith({
-        method: 'get',
-        baseURL: 'https://example.org',
-        url: '/_api/collections/organisations',
-        params: {
-          lang: 'en',
-          page: 1,
-          pageSize: 40,
-          query: null,
-          sort: 'prefLabel asc'
-        }
-      })).toBe(true);
+      expect(backendFetch.calledWith(
+        'collections',
+        [
+          'organisations',
+          {
+            lang: 'en',
+            page: 1,
+            pageSize: 40,
+            query: null,
+            sort: 'prefLabel asc'
+          }
+        ],
+        wrapper.vm.$nuxt.context
+      )).toBe(true);
     });
 
     it('stores collections from response body on component collections property', async() => {

--- a/packages/portal/src/components/entity/EntityTable.vue
+++ b/packages/portal/src/components/entity/EntityTable.vue
@@ -290,19 +290,7 @@
           sort: this.sort.join(' ')
         };
 
-        return backendFetch(process.server ? {
-          module: {
-            import: () => import('@/server-middleware/api/collections/index.js'),
-            fn: 'fetchData',
-            args: [fetchType, params, this.$config.redis]
-          }
-        } : {
-          http: {
-            method: 'get',
-            url: `/_api/collections/${fetchType}`,
-            params
-          }
-        }, this.$nuxt.context);
+        return backendFetch('collections', [fetchType, params], this.$nuxt.context);
       },
       organisationData(org) {
         const nativeName = Object.values(org.prefLabel)[0];

--- a/packages/portal/src/components/entity/EntityTable.vue
+++ b/packages/portal/src/components/entity/EntityTable.vue
@@ -104,13 +104,13 @@
 </template>
 
 <script>
-  import axios from 'axios';
   import { BTable } from 'bootstrap-vue';
 
   import LoadingSpinner from '../generic/LoadingSpinner';
   import PaginationNavInput from '@/components/generic/PaginationNavInput';
   import SmartLink from '../generic/SmartLink';
   import langAttributeMixin from '@/mixins/langAttribute';
+  import { backendFetch } from '@/utils/backendFetch.js';
 
   export default {
     name: 'EntityTable',
@@ -290,20 +290,19 @@
           sort: this.sort.join(' ')
         };
 
-        // TODO: similar code exists in multiple components now, e.g. also BrowseAutomatedCardGroup;
-        //       abstract out into a helper fn
-        if (process.server) {
-          return import('@/server-middleware/api/collections/index.js')
-            .then((module) => module.fetchData(fetchType, params, this.$config.redis));
-        } else  {
-          return axios.request({
+        return backendFetch(process.server ? {
+          module: {
+            import: () => import('@/server-middleware/api/collections/index.js'),
+            fn: 'fetchData',
+            args: [fetchType, params, this.$config.redis]
+          }
+        } : {
+          http: {
             method: 'get',
-            baseURL: this.$config.app.baseUrl,
             url: `/_api/collections/${fetchType}`,
             params
-          })
-            .then((response) => response.data);
-        }
+          }
+        }, this.$nuxt.context);
       },
       organisationData(org) {
         const nativeName = Object.values(org.prefLabel)[0];

--- a/packages/portal/src/components/landing/LandingAutomatedCardGroup.spec.js
+++ b/packages/portal/src/components/landing/LandingAutomatedCardGroup.spec.js
@@ -1,7 +1,8 @@
-import { createLocalVue } from '@vue/test-utils';
-import axios from 'axios';
-import { shallowMountNuxt } from '@test/utils.js';
+import nock from 'nock';
 import sinon from 'sinon';
+import { createLocalVue } from '@vue/test-utils';
+import { shallowMountNuxt } from '@test/utils.js';
+import * as backendFetchModule from '@/utils/backendFetch.js';
 
 import LandingAutomatedCardGroup from '@/components/landing/LandingAutomatedCardGroup.vue';
 
@@ -13,34 +14,47 @@ const factory = (propsData) => shallowMountNuxt(LandingAutomatedCardGroup, {
   localVue,
   propsData,
   mocks: {
-    $config: { redis: {} },
     $i18n: { n: (num) => `${num}` },
+    $nuxt: { context: { $config: { redis: {} } } },
     $t: key => key
   },
   stubs: ['b-container', 'b-col']
 });
 
 describe('components/landing/LandingAutomatedCardGroup', () => {
-  beforeEach(() => {
-    sinon.stub(axios, 'get');
+  const backendFetch = sinon.stub(backendFetchModule, 'backendFetch').resolves({});
+
+  beforeAll(() => {
+    nock.disableNetConnect();
   });
-  afterEach(sinon.restore);
+  afterEach(() => {
+    sinon.resetHistory();
+  });
+  afterAll(() => {
+    nock.enableNetConnect();
+    sinon.restore();
+  });
 
   describe('fetch()', () => {
     describe('when rendering on the client', () => {
       describe('for Europeana numbers', () => {
         const propsData = { genre: EUROPEANA_NUMBERS };
-        const axiosArgs = '/_api/cache?id=matomo/visits&id=items/type-counts&id=collections/organisations/count';
-        beforeEach(() => {
-          axios.get.withArgs(axiosArgs).resolves({ data: 2000 });
-        });
-        afterEach(() => {
-          axios.get.reset();
-        });
-        it('gets the data from the cache API endpoint', async() => {
+
+        it('fetches cached data from the backend', async() => {
           const wrapper = factory(propsData);
           await wrapper.vm.fetch();
-          expect(axios.get.calledWith(axiosArgs)).toBe(true);
+
+          expect(backendFetch.calledWith(
+            'cache',
+            [
+              [
+                'matomo/visits',
+                'items/type-counts',
+                'collections/organisations/count'
+              ]
+            ],
+            wrapper.vm.$nuxt.context
+          )).toBe(true);
         });
       });
     });

--- a/packages/portal/src/components/landing/LandingAutomatedCardGroup.vue
+++ b/packages/portal/src/components/landing/LandingAutomatedCardGroup.vue
@@ -105,21 +105,7 @@
     },
     methods: {
       fetchCachedData() {
-        return backendFetch(process.server ? {
-          module: {
-            import: () => import('@/server-middleware/api/cache/index.js'),
-            fn: 'cached',
-            args: [this.keys, this.$config.redis]
-          }
-        } : {
-          http: {
-            method: 'get',
-            url: '/_api/cache',
-            params: {
-              id: this.keys
-            }
-          }
-        }, this.$nuxt.context);
+        return backendFetch('cache', [this.keys], this.$nuxt.context);
       },
       roundedNumber(number) {
         const precision = 2;

--- a/packages/portal/src/components/landing/LandingAutomatedCardGroup.vue
+++ b/packages/portal/src/components/landing/LandingAutomatedCardGroup.vue
@@ -26,10 +26,10 @@
 </template>
 
 <script>
-  import axios from 'axios';
   import camelCase from 'lodash/camelCase.js';
 
   import InfoCard from '@/components/generic/InfoCard';
+  import { backendFetch } from '@/utils/backendFetch.js';
 
   const EUROPEANA_NUMBERS = 'Europeana numbers';
 
@@ -105,18 +105,21 @@
     },
     methods: {
       fetchCachedData() {
-        if (process.server) {
-          return import('@/server-middleware/api/cache/index.js')
-            .then(module => {
-              return module.cached(this.keys, this.$config.redis)
-                .then((response) => response);
-            });
-        } else {
-          const queryIds = `?id=${this.keys.join('&id=')}`;
-
-          return axios.get(`/_api/cache${queryIds}`, { baseURL: window.location.origin })
-            .then((response) => response.data);
-        }
+        return backendFetch(process.server ? {
+          module: {
+            import: () => import('@/server-middleware/api/cache/index.js'),
+            fn: 'cached',
+            args: [this.keys, this.$config.redis]
+          }
+        } : {
+          http: {
+            method: 'get',
+            url: '/_api/cache',
+            params: {
+              id: this.keys
+            }
+          }
+        }, this.$nuxt.context);
       },
       roundedNumber(number) {
         const precision = 2;

--- a/packages/portal/src/server-middleware/api/cache/index.js
+++ b/packages/portal/src/server-middleware/api/cache/index.js
@@ -11,7 +11,6 @@ const createRedisClient = (config = {}) => {
 };
 
 export const cached = async(ids, config = {}) => {
-  console.log('cached', ids, config);
   if (!config.url) {
     return Promise.reject(new Error('No cache configured.'));
   }

--- a/packages/portal/src/server-middleware/api/cache/index.js
+++ b/packages/portal/src/server-middleware/api/cache/index.js
@@ -11,6 +11,7 @@ const createRedisClient = (config = {}) => {
 };
 
 export const cached = async(ids, config = {}) => {
+  console.log('cached', ids, config);
   if (!config.url) {
     return Promise.reject(new Error('No cache configured.'));
   }

--- a/packages/portal/src/utils/backendFetch.js
+++ b/packages/portal/src/utils/backendFetch.js
@@ -1,31 +1,32 @@
 import axios from 'axios';
+import qs from 'qs';
 
 let backends;
 
 if (process.server) {
   backends = {
-    collections: {
-      import: () => import('@/server-middleware/api/collections/index.js'),
-      fn: 'fetchData',
-      args: (args = [], context = {}) => [...args, context.$config?.redis]
-    },
     cache: {
       import: () => import('@/server-middleware/api/cache/index.js'),
       fn: 'cached',
+      args: (args = [], context = {}) => [...args, context.$config?.redis]
+    },
+    collections: {
+      import: () => import('@/server-middleware/api/collections/index.js'),
+      fn: 'fetchData',
       args: (args = [], context = {}) => [...args, context.$config?.redis]
     }
   };
 } else {
   backends = {
-    collections: {
-      method: 'get',
-      url: (args) => `/_api/collections/${args[0]}`,
-      params: (args) => args[1]
-    },
     cache: {
       method: 'get',
       url: '/_api/cache',
       params: (args) => ({ id: args[0] })
+    },
+    collections: {
+      method: 'get',
+      url: (args) => `/_api/collections/${args[0]}`,
+      params: (args) => args[1]
     }
   };
 }
@@ -41,7 +42,10 @@ export const backendFetch = (id, args, context = {}) => {
       baseURL: context.$config.app.baseUrl,
       method: backend.method,
       url: typeof backend.url === 'function' ? backend.url(args) : backend.url,
-      params: backend.params(args)
+      params: backend.params(args),
+      paramsSerializer(params) {
+        return qs.stringify(params, { arrayFormat: 'repeat' });
+      }
     })
       .then((response) => response.data);
   }

--- a/packages/portal/src/utils/backendFetch.js
+++ b/packages/portal/src/utils/backendFetch.js
@@ -1,38 +1,38 @@
 import axios from 'axios';
 import qs from 'qs';
 
-let backends;
-
-if (process.server) {
-  backends = {
-    cache: {
-      import: () => import('@/server-middleware/api/cache/index.js'),
-      fn: 'cached',
-      args: (args = [], context = {}) => [...args, context.$config?.redis]
-    },
-    collections: {
-      import: () => import('@/server-middleware/api/collections/index.js'),
-      fn: 'fetchData',
-      args: (args = [], context = {}) => [...args, context.$config?.redis]
-    }
-  };
-} else {
-  backends = {
-    cache: {
-      method: 'get',
-      url: '/_api/cache',
-      params: (args) => ({ id: args[0] })
-    },
-    collections: {
-      method: 'get',
-      url: (args) => `/_api/collections/${args[0]}`,
-      params: (args) => args[1]
-    }
-  };
-}
+const backends = () => {
+  if (process.server) {
+    return {
+      cache: {
+        import: () => import('@/server-middleware/api/cache/index.js'),
+        fn: 'cached',
+        args: (args = [], context = {}) => [...args, context.$config?.redis]
+      },
+      collections: {
+        import: () => import('@/server-middleware/api/collections/index.js'),
+        fn: 'fetchData',
+        args: (args = [], context = {}) => [...args, context.$config?.redis]
+      }
+    };
+  } else {
+    return {
+      cache: {
+        method: 'get',
+        url: '/_api/cache',
+        params: (args) => ({ id: args[0] })
+      },
+      collections: {
+        method: 'get',
+        url: (args) => `/_api/collections/${args[0]}`,
+        params: (args) => args[1]
+      }
+    };
+  }
+};
 
 export const backendFetch = (id, args, context = {}) => {
-  const backend = backends[id];
+  const backend = backends()[id];
 
   if (process.server) {
     return backend.import()

--- a/packages/portal/src/utils/backendFetch.js
+++ b/packages/portal/src/utils/backendFetch.js
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+export const backendFetch = ({ http, module } = {}, context = {}) => {
+  console.log('backendFetch', http, module);
+  if (process.server) {
+    return module.import()
+      .then((importedModule) => importedModule[module.fn].apply(null, module.args));
+  } else  {
+    return axios.request({
+      baseURL: context.$config.app.baseUrl,
+      ...http
+    })
+      .then((response) => response.data);
+  }
+};

--- a/packages/portal/src/utils/backendFetch.js
+++ b/packages/portal/src/utils/backendFetch.js
@@ -1,14 +1,47 @@
 import axios from 'axios';
 
-export const backendFetch = ({ http, module } = {}, context = {}) => {
-  console.log('backendFetch', http, module);
+let backends;
+
+if (process.server) {
+  backends = {
+    collections: {
+      import: () => import('@/server-middleware/api/collections/index.js'),
+      fn: 'fetchData',
+      args: (args = [], context = {}) => [...args, context.$config?.redis]
+    },
+    cache: {
+      import: () => import('@/server-middleware/api/cache/index.js'),
+      fn: 'cached',
+      args: (args = [], context = {}) => [...args, context.$config?.redis]
+    }
+  };
+} else {
+  backends = {
+    collections: {
+      method: 'get',
+      url: (args) => `/_api/collections/${args[0]}`,
+      params: (args) => args[1]
+    },
+    cache: {
+      method: 'get',
+      url: '/_api/cache',
+      params: (args) => ({ id: args[0] })
+    }
+  };
+}
+
+export const backendFetch = (id, args, context = {}) => {
+  const backend = backends[id];
+
   if (process.server) {
-    return module.import()
-      .then((importedModule) => importedModule[module.fn].apply(null, module.args));
+    return backend.import()
+      .then((module) => module[backend.fn].apply(null, backend.args(args, context)));
   } else  {
     return axios.request({
       baseURL: context.$config.app.baseUrl,
-      ...http
+      method: backend.method,
+      url: typeof backend.url === 'function' ? backend.url(args) : backend.url,
+      params: backend.params(args)
     })
       .then((response) => response.data);
   }

--- a/packages/portal/src/utils/backendFetch.spec.js
+++ b/packages/portal/src/utils/backendFetch.spec.js
@@ -1,0 +1,88 @@
+import isEqual from 'lodash/isEqual.js';
+import nock from 'nock';
+import sinon from 'sinon';
+
+import { backendFetch } from './backendFetch.js';
+
+describe('@/utils/backendFetch.js', () => {
+  const clientSide = () => {
+    process.client = true;
+    process.server = false;
+  };
+  // TODO: spec server-side module imports
+  // const serverSide = () => {
+  //   process.client = false;
+  //   process.server = true;
+  // };
+
+  const baseUrl = 'https://example.org';
+
+  beforeAll(() => {
+    nock.disableNetConnect();
+  });
+  afterEach(() => {
+    sinon.resetHistory();
+    delete process.client;
+    delete process.server;
+  });
+  afterAll(() => {
+    nock.enableNetConnect();
+    sinon.restore();
+  });
+
+  describe('backendFetch', () => {
+    describe('backend: cache', () => {
+      const id = 'cache';
+
+      describe('client-side', () => {
+        beforeEach(() => {
+          clientSide();
+        });
+
+        it('fetches cached content for supplied keys from /_api/cache', async() => {
+          const context = { $config: { app: { baseUrl } } };
+          const keys = ['items/featured', 'matomo/visits'];
+          const response = { 'items/featured': ['/123/abc'], 'matomo/visits': 4000 };
+          nock(baseUrl)
+            .get('/_api/cache')
+            .query((query) => isEqual(query.id, keys))
+            .reply(200, response);
+
+          const fetched = await backendFetch(id, [keys], context);
+
+          expect(nock.isDone()).toBe(true);
+          expect(fetched).toEqual(response);
+        });
+      });
+    });
+
+    describe('backend: collections', () => {
+      const id = 'collections';
+
+      describe('client-side', () => {
+        beforeEach(() => {
+          clientSide();
+        });
+
+        it('fetches collections content for supplied type and params from /_api/collections/${type}', async() => {
+          const context = { $config: { app: { baseUrl } } };
+          const type = 'organisations/aggregators';
+          const params = {
+            page: '2',
+            query: 'museum'
+          };
+          const response = { items: [{ id: 'http://data.example.org/organization/1' }] };
+          nock(baseUrl)
+            .get('/_api/collections/organisations/aggregators')
+            .query((query) => isEqual(query, params))
+            .reply(200, response);
+
+          const fetched = await backendFetch(id, [type, params], context);
+
+          expect(nock.isDone()).toBe(true);
+          expect(fetched).toEqual(response);
+        });
+      });
+    });
+  });
+});

--- a/packages/portal/src/utils/backendFetch.spec.js
+++ b/packages/portal/src/utils/backendFetch.spec.js
@@ -4,16 +4,18 @@ import sinon from 'sinon';
 
 import { backendFetch } from './backendFetch.js';
 
+import * as cacheBackendServerMiddlewareModule from '@/server-middleware/api/cache/index.js';
+import * as collectionsBackendServerMiddlewareModule from '@/server-middleware/api/collections/index.js';
+
 describe('@/utils/backendFetch.js', () => {
   const clientSide = () => {
     process.client = true;
     process.server = false;
   };
-  // TODO: spec server-side module imports
-  // const serverSide = () => {
-  //   process.client = false;
-  //   process.server = true;
-  // };
+  const serverSide = () => {
+    process.client = false;
+    process.server = true;
+  };
 
   const baseUrl = 'https://example.org';
 
@@ -33,6 +35,24 @@ describe('@/utils/backendFetch.js', () => {
   describe('backendFetch', () => {
     describe('backend: cache', () => {
       const id = 'cache';
+      const keys = ['items/featured', 'matomo/visits'];
+      const response = { 'items/featured': ['/123/abc'], 'matomo/visits': 4000 };
+
+      describe('server-side', () => {
+        beforeEach(() => {
+          serverSide();
+        });
+
+        it('fetches cached content for supplied keys from server middleware module fn', async() => {
+          const context = { $config: { redis: {} } };
+          const fn = sinon.stub(cacheBackendServerMiddlewareModule, 'cached').resolves(response);
+
+          const fetched = await backendFetch(id, [keys], context);
+
+          expect(fn.calledWith(['items/featured', 'matomo/visits'], {})).toBe(true);
+          expect(fetched).toEqual(response);
+        });
+      });
 
       describe('client-side', () => {
         beforeEach(() => {
@@ -41,8 +61,7 @@ describe('@/utils/backendFetch.js', () => {
 
         it('fetches cached content for supplied keys from /_api/cache', async() => {
           const context = { $config: { app: { baseUrl } } };
-          const keys = ['items/featured', 'matomo/visits'];
-          const response = { 'items/featured': ['/123/abc'], 'matomo/visits': 4000 };
+
           nock(baseUrl)
             .get('/_api/cache')
             .query((query) => isEqual(query.id, keys))
@@ -58,6 +77,28 @@ describe('@/utils/backendFetch.js', () => {
 
     describe('backend: collections', () => {
       const id = 'collections';
+      const type = 'organisations/aggregators';
+      const params = {
+        page: '2',
+        query: 'museum'
+      };
+      const response = { items: [{ id: 'http://data.example.org/organization/1' }] };
+
+      describe('server-side', () => {
+        beforeEach(() => {
+          serverSide();
+        });
+
+        it('fetches cached content for supplied keys from server middleware module fn', async() => {
+          const context = { $config: { redis: {} } };
+          const fn = sinon.stub(collectionsBackendServerMiddlewareModule, 'fetchData').resolves(response);
+
+          const fetched = await backendFetch(id, [type, params], context);
+
+          expect(fn.calledWith('organisations/aggregators', { page: '2', query: 'museum' }, {})).toBe(true);
+          expect(fetched).toEqual(response);
+        });
+      });
 
       describe('client-side', () => {
         beforeEach(() => {
@@ -66,12 +107,6 @@ describe('@/utils/backendFetch.js', () => {
 
         it('fetches collections content for supplied type and params from /_api/collections/${type}', async() => {
           const context = { $config: { app: { baseUrl } } };
-          const type = 'organisations/aggregators';
-          const params = {
-            page: '2',
-            query: 'museum'
-          };
-          const response = { items: [{ id: 'http://data.example.org/organization/1' }] };
           nock(baseUrl)
             .get('/_api/collections/organisations/aggregators')
             .query((query) => isEqual(query, params))


### PR DESCRIPTION
- create a `backendFetch` utility fn
  - has a registry of backends mapping IDs to server middleware modules to import server-side, or HTTP requests to make client-side
  - supports cache/index and collections/index API server middlewares
- update components implementing their own version of this logic to use the `backendFetch` utility instead