### PR TITLE
chore: pass index per table to set id and sort query

### DIFF
--- a/packages/portal/src/components/entity/EntityTable.spec.js
+++ b/packages/portal/src/components/entity/EntityTable.spec.js
@@ -233,5 +233,17 @@ describe('components/entity/EntityTable', () => {
 
       expect(wrapper.vm.updateRouteQuery.calledWith({ sort: 'prefLabel desc', page: 1 })).toBe(true);
     });
+
+    describe('when an index is set', () => {
+      it('updates the route query per index', async() => {
+        const wrapper = factory({ type: 'organisations', index: '1' });
+        sinon.spy(wrapper.vm, 'updateRouteQuery');
+
+        const recordCountTh = wrapper.find('.table-name-cell');
+        await recordCountTh.trigger('click');
+
+        expect(wrapper.vm.updateRouteQuery.calledWith({ 't1-sort': 'prefLabel desc', page: 1 })).toBe(true);
+      });
+    });
   });
 });

--- a/packages/portal/src/components/entity/EntityTable.spec.js
+++ b/packages/portal/src/components/entity/EntityTable.spec.js
@@ -234,15 +234,15 @@ describe('components/entity/EntityTable', () => {
       expect(wrapper.vm.updateRouteQuery.calledWith({ sort: 'prefLabel desc', page: 1 })).toBe(true);
     });
 
-    describe('when an index is set', () => {
-      it('updates the route query per index', async() => {
-        const wrapper = factory({ type: 'organisations', index: '1' });
+    describe('when a table ID is set', () => {
+      it('updates the route query including it', async() => {
+        const wrapper = factory({ type: 'organisations', tableId: 'aggregators' });
         sinon.spy(wrapper.vm, 'updateRouteQuery');
 
         const recordCountTh = wrapper.find('.table-name-cell');
         await recordCountTh.trigger('click');
 
-        expect(wrapper.vm.updateRouteQuery.calledWith({ 't1-sort': 'prefLabel desc', page: 1 })).toBe(true);
+        expect(wrapper.vm.updateRouteQuery.calledWith({ 'aggregators-sort': 'prefLabel desc', page: 1 })).toBe(true);
       });
     });
   });

--- a/packages/portal/src/components/entity/EntityTable.vue
+++ b/packages/portal/src/components/entity/EntityTable.vue
@@ -235,7 +235,7 @@
 
     computed: {
       id() {
-        return `entity-table${this.index ? `-${this.index}` : ''}`;
+        return this.index ? `entity-table-${this.index}` : 'entity-table';
       },
       currentPage() {
         return Number(this.$route?.query?.page) || 1;

--- a/packages/portal/src/components/entity/EntityTable.vue
+++ b/packages/portal/src/components/entity/EntityTable.vue
@@ -129,13 +129,6 @@
 
     props: {
       /**
-       * index to differentiate multiple tables
-       */
-      index: {
-        type: String,
-        default: null
-      },
-      /**
        * the type of entity, human-friendly, plural
        * @values organisations, topics, times
        */
@@ -147,6 +140,13 @@
        * sub-type of entity, e.g. "aggregators"
        */
       subType: {
+        type: String,
+        default: null
+      },
+      /**
+       * id to differentiate multiple tables
+       */
+      tableId: {
         type: String,
         default: null
       },
@@ -235,10 +235,13 @@
 
     computed: {
       id() {
-        return this.index ? `entity-table-${this.index}` : 'entity-table';
+        return this.tableId ? `entity-table-${this.tableId}` : 'entity-table';
       },
       currentPage() {
         return Number(this.$route?.query?.page) || 1;
+      },
+      sortQuery() {
+        return this.tableId ? `${this.tableId}-sort` : 'sort';
       },
       sortBy: {
         get() {
@@ -259,12 +262,10 @@
       },
       sort: {
         get() {
-          const sortQuery = this.index ? this.$route?.query?.[`t${this.index}-sort`] : this.$route?.query?.sort;
-          return sortQuery?.split(' ') || ['prefLabel', 'asc'];
+          return this.$route?.query?.[this.sortQuery]?.split(' ') || ['prefLabel', 'asc'];
         },
         set({ sortBy, sortDesc }) {
-          const sortQuery = this.index ? `t${this.index}-sort` : 'sort';
-          const newRouteQuery = { [sortQuery]: `${sortBy} ${sortDesc ? 'desc' : 'asc'}` };
+          const newRouteQuery = { [this.sortQuery]: `${sortBy} ${sortDesc ? 'desc' : 'asc'}` };
           if (this.perPage) {
             newRouteQuery.page = 1;
           }

--- a/packages/portal/src/components/entity/EntityTable.vue
+++ b/packages/portal/src/components/entity/EntityTable.vue
@@ -26,7 +26,7 @@
       />
     </b-form>
     <b-table
-      id="entity-table"
+      :id="id"
       :fields="tableFields"
       :items="collections"
       :sort-by.sync="sortBy"
@@ -129,6 +129,13 @@
 
     props: {
       /**
+       * index to differentiate multiple tables
+       */
+      index: {
+        type: String,
+        default: null
+      },
+      /**
        * the type of entity, human-friendly, plural
        * @values organisations, topics, times
        */
@@ -227,6 +234,9 @@
     },
 
     computed: {
+      id() {
+        return `entity-table${this.index ? `-${this.index}` : ''}`;
+      },
       currentPage() {
         return Number(this.$route?.query?.page) || 1;
       },
@@ -249,10 +259,16 @@
       },
       sort: {
         get() {
-          return this.$route?.query?.sort?.split(' ') || ['prefLabel', 'asc'];
+          const sortQuery = this.index ? this.$route?.query?.[`t${this.index}-sort`] : this.$route?.query?.sort;
+          return sortQuery?.split(' ') || ['prefLabel', 'asc'];
         },
         set({ sortBy, sortDesc }) {
-          this.updateRouteQuery({ sort: `${sortBy} ${sortDesc ? 'desc' : 'asc'}`, page: 1 });
+          const sortQuery = this.index ? `t${this.index}-sort` : 'sort';
+          const newRouteQuery = { [sortQuery]: `${sortBy} ${sortDesc ? 'desc' : 'asc'}` };
+          if (this.perPage) {
+            newRouteQuery.page = 1;
+          }
+          this.updateRouteQuery(newRouteQuery);
         }
       },
       aggregatorType() {

--- a/packages/portal/src/components/entity/organisations/EntityOrganisationsPageContent.vue
+++ b/packages/portal/src/components/entity/organisations/EntityOrganisationsPageContent.vue
@@ -38,6 +38,7 @@
             <p>{{ $t(`organisations.${type.key}.description`) }}</p>
           </b-col>
           <EntityTable
+            :index="`${index}`"
             type="organisations"
             sub-type="aggregators"
             :data-qa="`${type.key} entity table`"

--- a/packages/portal/src/components/entity/organisations/EntityOrganisationsPageContent.vue
+++ b/packages/portal/src/components/entity/organisations/EntityOrganisationsPageContent.vue
@@ -25,8 +25,8 @@
       </template>
       <template v-else-if="tab === 'aggregators'">
         <div
-          v-for="type, index in aggregatorTypes"
-          :key="index"
+          v-for="type in aggregatorTypes"
+          :key="type.key"
         >
           <b-col
             cols="12"
@@ -38,7 +38,7 @@
             <p>{{ $t(`organisations.${type.key}.description`) }}</p>
           </b-col>
           <EntityTable
-            :index="`${index}`"
+            :table-id="type.key"
             type="organisations"
             sub-type="aggregators"
             :data-qa="`${type.key} entity table`"


### PR DESCRIPTION
- Sets entity table `id` and `sort` query per table when `tableId` prop is present
- Does not set page URL query when `perPage` is falsy