### PR TITLE
chore: api gateway (/fulltext) as default fulltext endpoint

### DIFF
--- a/packages/portal/src/plugins/europeana/fulltext.js
+++ b/packages/portal/src/plugins/europeana/fulltext.js
@@ -2,7 +2,5 @@ import EuropeanaApi from './apis/base.js';
 
 export default class EuropeanaFulltextApi extends EuropeanaApi {
   static ID = 'fulltext';
-  // NOTE: full text does not work via API gateway
-  // static BASE_URL = 'https://api.europeana.eu/fulltext';
-  static BASE_URL = 'https://newspapers.eanadev.org/api/v2';
+  static BASE_URL = 'https://api.europeana.eu/fulltext';
 }

--- a/tests/e2e/docker/nginx/conf.d/default.conf
+++ b/tests/e2e/docker/nginx/conf.d/default.conf
@@ -17,12 +17,6 @@ server {
     proxy_cache apis;
   }
 
-  location ~ ^/api/fulltext/(.*) {
-    proxy_pass https://newspapers.eanadev.org/api/v2/$1$is_args$args;
-    proxy_cache apis;
-    proxy_cache_valid 200 301 302 400 401 403 404 10m;
-  }
-
   location ~ ^/api/(.*) {
     proxy_pass https://api.europeana.eu/$1$is_args$args;
     proxy_cache apis;


### PR DESCRIPTION
Also removes newspapers.eanadev.org support for test env/ci tasks