### PR TITLE
chore: update lokalise key usage

### DIFF
--- a/.github/workflows/lokalise-pull.yml
+++ b/.github/workflows/lokalise-pull.yml
@@ -39,7 +39,6 @@ jobs:
           async_mode: true
           additional_params: |
             add_newline_eof: true
-            directory_prefix: packages/portal/src/i18n/lang
             exclude_tags:
               - "Not ready"
             export_empty_as: skip

--- a/.github/workflows/lokalise-pull.yml
+++ b/.github/workflows/lokalise-pull.yml
@@ -28,7 +28,6 @@ jobs:
           project_id: ${{ secrets.LOKALISE_PROJECT_ID }}
           file_format: react_native
           file_ext: js
-          translations_path: packages/portal/src/i18n/lang
           base_lang: en_GB
           flat_naming: true
           skip_include_tags: true
@@ -40,6 +39,7 @@ jobs:
           async_mode: true
           additional_params: |
             add_newline_eof: true
+            directory_prefix: packages/portal/src/i18n/lang
             exclude_tags:
               - "Not ready"
             export_empty_as: skip

--- a/.github/workflows/lokalise-pull.yml
+++ b/.github/workflows/lokalise-pull.yml
@@ -32,7 +32,6 @@ jobs:
           base_lang: en_GB
           flat_naming: true
           skip_include_tags: true
-          skip_original_filenames: true
           always_pull_base: true
           git_commit_message: "chore: update translations"
           custom_github_token: "${{ secrets.GIT_PAT_LOKALISE }}"
@@ -40,7 +39,6 @@ jobs:
           async_mode: true
           additional_params: |
             add_newline_eof: true
-            directory_prefix: packages/portal/src/i18n/lang
             exclude_tags:
               - "Not ready"
             export_empty_as: skip

--- a/.github/workflows/lokalise-pull.yml
+++ b/.github/workflows/lokalise-pull.yml
@@ -28,6 +28,7 @@ jobs:
           project_id: ${{ secrets.LOKALISE_PROJECT_ID }}
           file_format: react_native
           file_ext: js
+          translations_path: packages/portal/src/i18n/lang
           base_lang: en_GB
           flat_naming: true
           skip_include_tags: true
@@ -39,6 +40,7 @@ jobs:
           async_mode: true
           additional_params: |
             add_newline_eof: true
+            directory_prefix: packages/portal/src/i18n/lang
             exclude_tags:
               - "Not ready"
             export_empty_as: skip

--- a/.github/workflows/lokalise-pull.yml
+++ b/.github/workflows/lokalise-pull.yml
@@ -40,7 +40,6 @@ jobs:
           async_mode: true
           additional_params: |
             add_newline_eof: true
-            directory_prefix: packages/portal/src/i18n/lang
             exclude_tags:
               - "Not ready"
             export_empty_as: skip

--- a/.github/workflows/lokalise-push.yml
+++ b/.github/workflows/lokalise-push.yml
@@ -33,5 +33,3 @@ jobs:
           rambo_mode: ${{ inputs.force }}
           additional_params: |
             cleanup_mode: true
-            distinguish_by_file: false
-            include_path: false

--- a/packages/portal/src/i18n/lang/en.js
+++ b/packages/portal/src/i18n/lang/en.js
@@ -38,7 +38,6 @@ export default {
     }
   },
   "actions": {
-    "testKey": "test value",
     "accept": "Accept",
     "add": "Add",
     "apply": "Apply",

--- a/packages/portal/src/i18n/lang/en.js
+++ b/packages/portal/src/i18n/lang/en.js
@@ -38,6 +38,7 @@ export default {
     }
   },
   "actions": {
+    "testKey": "test value",
     "accept": "Accept",
     "add": "Add",
     "apply": "Apply",


### PR DESCRIPTION
Prevent trying to force files to be directory ambiguous , instead use default key-file associations on both lokalise push and pull github actions.