### PR TITLE
feat: add item preview to EntityOrganisationsMapPinPopover

### DIFF
--- a/packages/portal/src/components/entity/organisations/EntityOrganisationsMapPinPopover.spec.js
+++ b/packages/portal/src/components/entity/organisations/EntityOrganisationsMapPinPopover.spec.js
@@ -97,12 +97,26 @@ describe('components/entity/organisations/EntityOrganisationsMapPinPopover', () 
       });
     });
   });
+
   describe('when id is changed', () => {
     it('fetches the entity', async() => {
       const wrapper = factory();
       await wrapper.setProps({ id });
 
       expect(fetchEntityStub.calledWith('organisation', '6')).toBe(true);
+    });
+
+    it('fetches the items', async() => {
+      const wrapper = factory();
+      await wrapper.setProps({ id });
+
+      expect(searchRecordStub.calledWith(
+        {
+          qf: ['foaf_organization:"http://data.europeana.eu/organization/6"'],
+          query: 'foaf_organization:"http://data.europeana.eu/organization/6"',
+          rows: 5
+        }
+      )).toBe(true);
     });
   });
 });

--- a/packages/portal/src/components/entity/organisations/EntityOrganisationsMapPinPopover.spec.js
+++ b/packages/portal/src/components/entity/organisations/EntityOrganisationsMapPinPopover.spec.js
@@ -18,7 +18,18 @@ const entity = {
   hasAddress: { locality: 'Amsterdam', countryName: 'The Netherlands' }
 };
 
+const itemResults = {
+  items: [
+    { id: '/123/abc', edmPreview: ['https://www.example.org/images/123/abc.jpeg'] },
+    { id: '/123/def', edmPreview: ['https://www.example.org/images/123/def.jpeg'] },
+    { id: '/123/ghi', edmPreview: ['https://www.example.org/images/123/ghi.jpeg'] },
+    { id: '/123/jkl', edmPreview: ['https://www.example.org/images/123/jkl.jpeg'] },
+    { id: '/123/mno', edmPreview: ['https://www.example.org/images/123/mno.jpeg'] }
+  ]
+};
+
 const fetchEntityStub = sinon.stub().resolves(entity);
+const searchRecordStub = sinon.stub().resolves(itemResults);
 const factory = (propsData = {}) => shallowMountNuxt(EntityOrganisationsMapPinPopover, {
   localVue,
   propsData,
@@ -26,6 +37,12 @@ const factory = (propsData = {}) => shallowMountNuxt(EntityOrganisationsMapPinPo
     $apis: {
       entity: {
         get: fetchEntityStub
+      },
+      record: {
+        search: searchRecordStub
+      },
+      thumbnail: {
+        edmPreview: (url) => url
       }
     },
     $i18n: {
@@ -67,6 +84,17 @@ describe('components/entity/organisations/EntityOrganisationsMapPinPopover', () 
       await wrapper.vm.fetch();
 
       expect(wrapper.find('.organisation-location').text()).toBe('Amsterdam, The Netherlands');
+    });
+
+    it('shows an image for each of the 5 items', async() => {
+      const wrapper = factory({ id });
+      await wrapper.vm.fetch();
+
+      const images = wrapper.findAll('b-img-stub');
+
+      images.wrappers.forEach((image, index) => {
+        expect(image.attributes('src')).toBe(itemResults.items[index].edmPreview[0]);
+      });
     });
   });
   describe('when id is changed', () => {

--- a/packages/portal/src/components/entity/organisations/EntityOrganisationsMapPinPopover.vue
+++ b/packages/portal/src/components/entity/organisations/EntityOrganisationsMapPinPopover.vue
@@ -50,29 +50,32 @@
         <span class="icon-location" />
         {{ location }}
       </b-card-text>
-      <b-card-footer
+      <div
         v-if="items.length > 0"
         key="items"
       >
-        <SmartLink
-          v-for="item in items"
-          :key="item.id"
-          :destination="{
-            name: 'item-all',
-            params: { pathMatch: item.id.slice(1) }
-          }"
-        >
-          <b-img
-            :src="$apis.thumbnail.edmPreview(item.edmPreview?.[0], { size: 200 })"
-            alt=""
-            sizes="(max-width 1920px) 28w,
+        <!-- TODO: add heading -->
+        <div class="d-flex mx-n2">
+          <SmartLink
+            v-for="item in items"
+            :key="item.id"
+            :destination="{
+              name: 'item-all',
+              params: { pathMatch: item.id.slice(1) }
+            }"
+            class="preview-item-link mx-2"
+          >
+            <b-img
+              :src="$apis.thumbnail.edmPreview(item.edmPreview?.[0], { size: 200 })"
+              alt=""
+              sizes="(max-width 1920px) 28w,
             (max-width 2560) 45w,
             (min-width 2561) 67w"
-            rounded="circle"
-            class="mr-2"
-          />
-        </SmartLink>
-      </b-card-footer>
+              rounded="circle"
+            />
+          </SmartLink>
+        </div>
+      </div>
     </TransitionGroup>
   </b-card>
 </template>
@@ -248,5 +251,11 @@
 
 .fade-leave-active {
   transition: none;
+}
+
+.preview-item-link img {
+  width: 3rem;
+  height: 3rem;
+  object-fit: cover;
 }
 </style>

--- a/packages/portal/src/components/entity/organisations/EntityOrganisationsMapPinPopover.vue
+++ b/packages/portal/src/components/entity/organisations/EntityOrganisationsMapPinPopover.vue
@@ -67,6 +67,7 @@
             }"
             class="preview-item-link mx-2"
           >
+            <!-- TODO: add SR text - links should contain text -->
             <b-img
               :src="$apis.thumbnail.edmPreview(item.edmPreview?.[0], { size: 200 })"
               alt=""

--- a/packages/portal/src/components/entity/organisations/EntityOrganisationsMapPinPopover.vue
+++ b/packages/portal/src/components/entity/organisations/EntityOrganisationsMapPinPopover.vue
@@ -127,17 +127,20 @@
 
     async fetch() {
       if (this.id) {
-        const entity = await this.$apis.entity.get('organisation', this.id.split('/').pop());
-        this.entity = pick(entity, FIELDS);
+        const entityQuery = getEntityQuery(this.id);
 
-        // TODO: duplicates what's in CollectionPage; extract to a util fn
-        const entityQuery = getEntityQuery(this.entity.id);
-        const results = await this.$apis.record.search({
-          qf: [entityQuery],
-          query: entityQuery, // Triggering best bets.
-          rows: 5
-        });
-        this.items = results.items || [];
+        const [entity, itemResults] = await Promise.all([
+          this.$apis.entity.get('organisation', this.id.split('/').pop()),
+          // TODO: duplicates what's in CollectionPage; extract to a util fn
+          this.$apis.record.search({
+            qf: [entityQuery],
+            query: entityQuery, // Triggering best bets.
+            rows: 5
+          })
+        ]);
+
+        this.entity = pick(entity, FIELDS);
+        this.items = itemResults.items || [];
       }
     },
 
@@ -168,6 +171,7 @@
     watch: {
       id() {
         this.entity = null;
+        this.items = [];
         this.$fetch();
       }
     },

--- a/packages/portal/src/components/entity/organisations/EntityOrganisationsMapPinPopover.vue
+++ b/packages/portal/src/components/entity/organisations/EntityOrganisationsMapPinPopover.vue
@@ -16,12 +16,12 @@
     >
       <div
         v-if="resizedLogo"
-        key="0"
+        key="logo"
         class="organisation-logo mb-2"
         :style="`background-image: url('${resizedLogo}')`"
       />
       <SmartLink
-        key="1"
+        key="title"
         :destination="entityRoute"
       >
         <b-card-title
@@ -42,7 +42,7 @@
       </SmartLink>
       <b-card-text
         v-if="location"
-        key="2"
+        key="location"
         text-tag="div"
         class="organisation-location d-flex align-items-center mt-3 mb-2"
         lang="en"
@@ -50,6 +50,29 @@
         <span class="icon-location" />
         {{ location }}
       </b-card-text>
+      <b-card-footer
+        v-if="items.length > 0"
+        key="items"
+      >
+        <SmartLink
+          v-for="item in items"
+          :key="item.id"
+          :destination="{
+            name: 'item-all',
+            params: { pathMatch: item.id.slice(1) }
+          }"
+        >
+          <b-img
+            :src="$apis.thumbnail.edmPreview(item.edmPreview?.[0], { size: 200 })"
+            alt=""
+            sizes="(max-width 1920px) 28w,
+            (max-width 2560) 45w,
+            (min-width 2561) 67w"
+            rounded="circle"
+            class="mr-2"
+          />
+        </SmartLink>
+      </b-card-footer>
     </TransitionGroup>
   </b-card>
 </template>
@@ -59,8 +82,9 @@
   import langAttributeMixin from '@/mixins/langAttribute';
   import { langMapValueForLocale } from  '@europeana/i18n';
   import { organizationEntityNativeName, organizationEntityNonNativeEnglishName } from '@/utils/europeana/entities/organizations.js';
-  import { getWikimediaThumbnailUrl } from '@/plugins/europeana/entity';
+  import { getEntityQuery, getWikimediaThumbnailUrl } from '@/plugins/europeana/entity.js';
   import { getLabelledSlug } from '@/plugins/europeana/utils.js';
+
   import SmartLink from '@/components/generic/SmartLink';
 
   const FIELDS = [
@@ -90,15 +114,24 @@
 
     data() {
       return {
-        entity: null
+        entity: null,
+        items: []
       };
     },
 
     async fetch() {
       if (this.id) {
         const entity = await this.$apis.entity.get('organisation', this.id.split('/').pop());
-
         this.entity = pick(entity, FIELDS);
+
+        // TODO: duplicates what's in CollectionPage; extract to a util fn
+        const entityQuery = getEntityQuery(this.entity.id);
+        const results = await this.$apis.record.search({
+          qf: [entityQuery],
+          query: entityQuery, // Triggering best bets.
+          rows: 5
+        });
+        this.items = results.items || [];
       }
     },
 

--- a/packages/portal/src/components/entity/organisations/EntityOrganisationsMapPinPopover.vue
+++ b/packages/portal/src/components/entity/organisations/EntityOrganisationsMapPinPopover.vue
@@ -54,7 +54,9 @@
         v-if="items.length > 0"
         key="items"
       >
-        <!-- TODO: add heading -->
+        <h4 class="context-label mt-3 mb-1">
+          {{ $t('related.collection.preview') }}
+        </h4>
         <div class="d-flex mx-n2">
           <SmartLink
             v-for="item in items"

--- a/packages/portal/src/components/search/SearchInterface.vue
+++ b/packages/portal/src/components/search/SearchInterface.vue
@@ -33,7 +33,6 @@
         />
         <b-row v-else>
           <ItemPreviewInterface
-            data-qa="liked items"
             :items="results"
             :hits="hits"
             :loading="$fetchState.pending"

--- a/packages/portal/src/i18n/lang/en.js
+++ b/packages/portal/src/i18n/lang/en.js
@@ -1299,6 +1299,9 @@ export default {
     "categoryTags": {
       "title": "Discover related stories"
     },
+    "collection": {
+      "preview": "Collection preview"
+    },
     "collections": {
       "name": "Related collections",
       "title": "Discover related collections"


### PR DESCRIPTION
In the entity organisation map pin popover, display previews of the top 5 items for the organisation as returned by the Record API.