### PR TITLE
feat(postgresql): add web_element_event_types table

### DIFF
--- a/docker/compose/postgres/model/12-create-web-element-event-types-table.psql
+++ b/docker/compose/postgres/model/12-create-web-element-event-types-table.psql
@@ -1,0 +1,18 @@
+BEGIN;
+
+  SET search_path TO events;
+
+  CREATE TABLE web_element_event_types (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL UNIQUE
+  );
+
+  CREATE INDEX ix_web_element_event_types_name ON events.web_element_event_types(name);
+
+  INSERT INTO web_element_event_types (name) 
+    SELECT DISTINCT activated_by
+    FROM sessions
+    WHERE activated_by IS NOT NULL
+    ORDER BY activated_by ASC;
+
+COMMIT;

--- a/docker/compose/postgres/model/13-add-sessions-activated-by-event-id.psql
+++ b/docker/compose/postgres/model/13-add-sessions-activated-by-event-id.psql
@@ -1,0 +1,23 @@
+BEGIN;
+
+  SET search_path TO events;
+
+  ALTER TABLE sessions
+    ADD COLUMN activated_by_id INT,
+    ADD CONSTRAINT fk_activated_by
+      FOREIGN KEY(activated_by_id)
+      REFERENCES web_element_event_types(id);
+  
+  UPDATE sessions
+    SET activated_by_id=event_type_id
+    FROM
+      (
+        SELECT
+          id event_type_id,
+          name event_type_name
+        FROM
+          web_element_event_types
+      )
+    WHERE activated_by=event_type_name;
+
+COMMIT;

--- a/docker/compose/postgres/model/14-drop-sessions-activated-by.psql
+++ b/docker/compose/postgres/model/14-drop-sessions-activated-by.psql
@@ -1,0 +1,15 @@
+BEGIN;
+
+  SET search_path TO events;
+
+  -- NOTE: dropping a column does not free up the disk space it used,
+  -- it just hides it from operations
+  --
+  -- ref: https://www.postgresql.org/docs/15/sql-altertable.html#SQL-ALTERTABLE-NOTES
+  -- para starting "The DROP COLUMN form"
+  --
+  -- use pg_repack to reclaim the disk space
+  ALTER TABLE sessions
+    DROP COLUMN activated_by;
+
+COMMIT;


### PR DESCRIPTION
referenced by sessions table

after running the three migrations against a portal.js PG db, then run pg_repack on the events.sessions table:
```shell
pg_repack --dbname=${DB} --table=events.sessions
```