### PR TITLE
chore(vue-session): do not activate sessions by scroll event

### DIFF
--- a/packages/vue-session/README.md
+++ b/packages/vue-session/README.md
@@ -58,7 +58,9 @@ Available options:
 {
   monitor: {
     // document events to regard as user activity
-    events: ['drag', 'keydown', 'mousedown', 'mousemove', 'scroll', 'touchstart', 'wheel']
+    // NOTE: default events used to include scroll, but that was primarily triggered
+    //       by automated activity, i.e. bots, so has been removed
+    events: ['drag', 'keydown', 'mousedown', 'mousemove', 'touchstart', 'wheel']
     // number of seconds to pause monitoring after activity is observed, to
     // prevent constantly updating the session timestamp during periods of
     // sustained activity

--- a/packages/vue-session/src/manager.js
+++ b/packages/vue-session/src/manager.js
@@ -13,9 +13,9 @@ export default class Manager {
 
   /**
    * @param {Object} options Session management options
-   * @param {MonitorOptions} options.monitor Session activity monitor options, passed to
+   * @param {MonitorOptions} options.monitor Monitor options
    * @param {SessionOptions} options.session Session options
-   * @param {StorageOptions} options.storage Session storage options
+   * @param {StorageOptions} options.storage Storage options
    */
   constructor(options = {}) {
     this.options = options;

--- a/packages/vue-session/src/monitor.js
+++ b/packages/vue-session/src/monitor.js
@@ -3,14 +3,14 @@
  */
 export default class Monitor {
   static DEFAULTS = {
-    events: ['drag', 'keydown', 'mousedown', 'mousemove', 'scroll', 'touchstart', 'wheel'],
+    events: ['drag', 'keydown', 'mousedown', 'mousemove', 'touchstart', 'wheel'],
     interval: 60 // in seconds
   };
 
   /**
    * @typedef {Object} MonitorOptions
    * @property {string[]} events Document events to listen to for activity.
-   *   Defaults to `['drag', 'keydown', 'mousedown', 'mousemove', 'scroll', 'touchstart', 'wheel']`.
+   *   Defaults to `['drag', 'keydown', 'mousedown', 'mousemove', 'touchstart', 'wheel']`.
    * @property {number} interval Number of seconds to pause event listeners
    *   after activity is detected before resuming them. Defaults to 60 seconds.
    */

--- a/packages/vue-session/src/monitor.spec.js
+++ b/packages/vue-session/src/monitor.spec.js
@@ -27,7 +27,7 @@ describe('Monitor', () => {
         const monitor = new Monitor(callback);
 
         expect(monitor.events).toEqual(
-          ['drag', 'keydown', 'mousedown', 'mousemove', 'scroll', 'touchstart', 'wheel']
+          ['drag', 'keydown', 'mousedown', 'mousemove', 'touchstart', 'wheel']
         );
       });
     });


### PR DESCRIPTION
as it's primarily triggered by automated activity, i.e. bots